### PR TITLE
fix(asset): resolve version stack name and status fallback in toAssetInfo

### DIFF
--- a/src/services/asset/asset.test.ts
+++ b/src/services/asset/asset.test.ts
@@ -402,6 +402,43 @@ describe('AssetService', () => {
     })
   })
 
+  it('reparent file onto another file - creates version stack and keeps it visible', async () => {
+    const { user, assets } = await setupBasicAssets()
+
+    // Initially fileA1 is processed, fileA2 is processed
+    await prisma.asset.update({
+      where: { id: assets.fileA1.id },
+      data: { status: 'processed' },
+    })
+    await prisma.asset.update({
+      where: { id: assets.fileA2.id },
+      data: { status: 'processed' },
+    })
+
+    // Reparent fileA1 onto fileA2
+    await assetService.reparentAssets({
+      assetIds: [assets.fileA1.id],
+      newParentId: assets.fileA2.id,
+      creatorId: user.id,
+    })
+
+    // Get children of folderA (where fileA2 originally was)
+    const children = await assetService.listChildren({
+      assetId: assets.folderA.id,
+      assetType: 'file',
+      first: 10,
+    })
+
+    // There should be exactly 1 child in folderA, which is the version stack
+    expect(children.data.length).toBe(1)
+    const stackInfo = children.data[0]
+    expect(stackInfo.type).toBe(AssetType.version_stack)
+    // The name of the stack should be fileA1 (since it is the latest version / source asset)
+    expect(stackInfo.name).toBe('fileA1')
+    // The status of the stack should be 'processed' (inherited from the latest version)
+    expect(stackInfo.status).toBe('processed')
+  })
+
   it('handles soft deleting and restoring assets recursively', async () => {
     const { assets } = await setupBasicAssets()
 

--- a/src/services/asset/asset.ts
+++ b/src/services/asset/asset.ts
@@ -1010,12 +1010,12 @@ export class AssetService {
 
     return {
       id: a.id,
-      name: a.name,
+      name: a.type === AssetType.version_stack ? a.name || latestVersion.name : a.name,
       sizeByte: latestVersion.sizeByte,
       fileCount: latestVersion.fileCount,
       type: a.type,
       targetType: a.type === AssetType.symlink ? a.target?.type : null,
-      status: a.status,
+      status: a.type === AssetType.version_stack ? latestVersion.status : a.status,
       mediaType: latestVersion.mediaType,
       latestChildren,
       preview,


### PR DESCRIPTION
## Summary

This PR resolves a bug where files disappear from the UI after reparenting one file onto another (which forms a version stack). The newly created version stack was returned with an empty string as its name and an 'uploaded' status instead of inheriting its name and status dynamically from the latest version of the file, causing it to render as an invisible placeholder/skeleton in the list view.

## Changes

- Updated `toAssetInfo` inside `src/services/asset/asset.ts` so that `version_stack` type assets dynamically inherit the `name` (falling back if not explicitly set) and `status` from their `latestVersion` (active version).
- Created a comprehensive integration test case under `src/services/asset/asset.test.ts` to reproduce the bug and verify that reparented files remain visible and show their latest version's name and status.

## Verification

- Created and ran the test suite:
  ```bash
  bun run test src/services/asset/asset.test.ts
  ```
  Result: all 19 tests passed successfully (including the new integration test).
- Ran all required validation checks:
  - `bun run lint` (passed with 0 warnings/errors)
  - `bun run format` (passed)
  - `bun run typecheck` (passed)
  - `bun run test` (all 333 tests passed)

## Notes

None.