### PR TITLE
feat(video): add timestamp support to comments

### DIFF
--- a/src/api/file.test.ts
+++ b/src/api/file.test.ts
@@ -157,10 +157,11 @@ describe('file api', () => {
   it('POST /files/:fileId/comments', async () => {
     vi.mocked(assetService.createComment).mockResolvedValue({
       id: 'comment-id',
-      assetId: 'test-id',
+      assetId: 'file-id',
       message: 'hello',
       annotations: null,
-      creator: { id: 'user1', name: 'user-name' },
+      second: null,
+      creator: { id: 'user-id', name: 'Test User' },
       replies: [],
       attachments: [],
       mentions: [],
@@ -207,10 +208,11 @@ describe('file api', () => {
       data: [
         {
           id: 'comment-id',
-          assetId: 'test-id',
+          assetId: 'file-id',
           message: 'hello',
           annotations: null,
-          creator: { id: 'user1', name: 'user-name' },
+          second: null,
+          creator: { id: 'user-id', name: 'Test User' },
           replies: [],
           attachments: [],
           mentions: [],

--- a/src/dtos/asset.ts
+++ b/src/dtos/asset.ts
@@ -189,6 +189,7 @@ export type CommentInfo = {
   message: string | null
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   annotations: any
+  second: number | null
   creator: UserInfo
   replies: CommentInfo[]
   attachments: AttachmentInfo[]
@@ -204,6 +205,7 @@ export const commentInfoSchema: z.ZodType<CommentInfo> = z.object({
   message: z.string().nullable(),
 
   annotations: z.any(),
+  second: z.number().nullable(),
   creator: userInfoSchema,
   replies: z.array(z.lazy(() => commentInfoSchema)),
   attachments: z.array(attachmentInfoSchema),

--- a/src/services/asset/asset.test.ts
+++ b/src/services/asset/asset.test.ts
@@ -664,6 +664,28 @@ describe('AssetService', () => {
     expect(list.data[0].replies.length).toBe(1)
   })
 
+  it('can create and retrieve comments with video timestamp', async () => {
+    const { user, assets } = await setupBasicAssets()
+
+    const comment = await assetService.createComment({
+      assetId: assets.fileA1.id,
+      userId: user.id,
+      message: 'Interesting point at 5.5s',
+      second: 5.5,
+      attachmentIds: [],
+    })
+
+    expect(comment.second).toBe(5.5)
+
+    const retrieved = await assetService.getComment(comment.id)
+    expect(retrieved.second).toBe(5.5)
+
+    const list = await assetService.listComments(assets.fileA1.id, {
+      first: 10,
+    })
+    expect(list.data[0].second).toBe(5.5)
+  })
+
   it('correctly handles AI comments with agent identity', async () => {
     const { assets, project } = await setupBasicAssets()
 

--- a/src/services/asset/asset.ts
+++ b/src/services/asset/asset.ts
@@ -1690,6 +1690,7 @@ export class AssetService {
       assetId: c.assetId,
       message: c.message,
       annotations: c.annotation,
+      second: c.second,
       creator,
       replies,
       attachments,

--- a/src/ui/components/chat/message-card.tsx
+++ b/src/ui/components/chat/message-card.tsx
@@ -3,16 +3,16 @@ import type { UserInfo } from '@/dtos/team'
 import { client } from '@/ui/api/client'
 import { Button } from '@/ui/components/ui/button'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
 } from '@/ui/components/ui/dialog'
 import { Separator } from '@/ui/components/ui/separator'
 import { formatTimeAgo } from '@/ui/lib/time'
 import { useQuery } from '@tanstack/react-query'
-import { Clock, Download, File, Terminal } from 'lucide-react'
+import { Download, File, Terminal } from 'lucide-react'
 import React from 'react'
 import Markdown from 'react-markdown'
 import { Avatar, AvatarFallback } from '../ui/avatar'
@@ -177,8 +177,7 @@ export const MessageCard: React.FC<MessageCardProps> = ({
 
         <div className="flow-root mt-1">
           {message.second !== null && message.second !== undefined && frameRate && (
-            <div className="float-left select-none bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-2.5 py-0.5 mt-0.5 mr-2 rounded-sm text-xs font-mono font-bold flex items-center gap-1 border border-blue-200 dark:border-blue-800 shadow-sm">
-              <Clock className="w-3 h-3" />
+            <div className="float-left select-none bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-2.5 py-1 mt-[2px] mr-2 rounded-sm text-xs leading-none font-mono font-bold flex items-center gap-1">
               {formatTimestamp(message.second, frameRate)}
             </div>
           )}

--- a/src/ui/components/chat/message-card.tsx
+++ b/src/ui/components/chat/message-card.tsx
@@ -3,17 +3,17 @@ import type { UserInfo } from '@/dtos/team'
 import { client } from '@/ui/api/client'
 import { Button } from '@/ui/components/ui/button'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
 } from '@/ui/components/ui/dialog'
 import { Separator } from '@/ui/components/ui/separator'
-import { useQuery } from '@tanstack/react-query'
-import { Download, File, Terminal, Clock } from 'lucide-react'
-import React from 'react'
 import { formatTimeAgo } from '@/ui/lib/time'
+import { useQuery } from '@tanstack/react-query'
+import { Download, File, Terminal } from 'lucide-react'
+import React from 'react'
 import Markdown from 'react-markdown'
 import { Avatar, AvatarFallback } from '../ui/avatar'
 import { Skeleton } from '../ui/skeleton'
@@ -138,9 +138,11 @@ export const MessageCard: React.FC<MessageCardProps> = ({
   }
 
   return (
-    <div className={`relative flex gap-4 ${isReply ? 'mt-4' : 'mt-6'} group`}>
+    <div
+      className={`relative flex gap-4 ${isReply ? 'mt-0' : 'mt-2'} group p-3 py-4 bg-foreground/2 dark:bg-foreground/10 hover:bg-foreground/4 dark:hover:bg-foreground/15 rounded`}
+    >
       {hasReplies && !isReply && (
-        <div className="absolute left-[1rem] top-[2rem] bottom-[-1.5rem] w-0.5 bg-foreground/10 -translate-x-1/2 z-0" />
+        <div className="absolute left-[1.7rem] top-[2rem] bottom-[-1.8rem] w-0.5 bg-foreground/10 -translate-x-1/2 z-0" />
       )}
 
       {isReply && !isLastReply && (
@@ -158,18 +160,6 @@ export const MessageCard: React.FC<MessageCardProps> = ({
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-1">
           <span className="font-semibold text-sm">{creator?.name || 'Unknown'}</span>
-          {message.second !== null && message.second !== undefined && frameRate && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation()
-                onTimestampClick?.(message.second!)
-              }}
-              className="bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-2 py-0.5 rounded-full text-[10px] font-mono font-bold flex items-center gap-1 border border-blue-200 dark:border-blue-800 shadow-sm hover:bg-blue-200 dark:hover:bg-blue-900/60 transition-colors"
-            >
-              <Clock className="w-2.5 h-2.5" />
-              {formatTimestamp(message.second, frameRate)}
-            </button>
-          )}
           <span className="text-xs text-gray-400">
             {new Date(message.createdAt!).toLocaleTimeString([], {
               hour: '2-digit',
@@ -178,21 +168,35 @@ export const MessageCard: React.FC<MessageCardProps> = ({
           </span>
         </div>
 
-        {showSkeleton ? (
-          <div className="space-y-2">
-            <Skeleton className="h-4 w-3/4" />
-            <Skeleton className="h-4 w-1/2" />
-            <span className="text-xs text-muted-foreground animate-pulse">{loadingText}</span>
-          </div>
-        ) : message.sessionId ? (
-          <div className="text-sm leading-relaxed prose prose-sm dark:prose-invert max-w-none break-words">
-            <Markdown>{preprocessMarkdown(message.message!)}</Markdown>
-          </div>
-        ) : (
-          <div className="text-sm leading-relaxed whitespace-pre-wrap break-words text-wrap break-all">
-            {renderFormattedMessage(message.message!)}
-          </div>
-        )}
+        <div className="flow-root mt-1">
+          {message.second !== null && message.second !== undefined && frameRate && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onTimestampClick?.(message.second!)
+              }}
+              className="float-left select-none bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-2.5 py-0.5 mt-0.5 mr-2 rounded-sm text-xs font-mono font-bold flex items-center gap-1 transition-colors"
+            >
+              {formatTimestamp(message.second, frameRate)}
+            </button>
+          )}
+
+          {showSkeleton ? (
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-4 w-1/2" />
+              <span className="text-xs text-muted-foreground animate-pulse">{loadingText}</span>
+            </div>
+          ) : message.sessionId ? (
+            <div className="text-sm leading-relaxed prose prose-sm dark:prose-invert max-w-none break-words">
+              <Markdown>{preprocessMarkdown(message.message!)}</Markdown>
+            </div>
+          ) : (
+            <div className="text-sm leading-relaxed whitespace-pre-wrap break-words text-wrap break-all">
+              {renderFormattedMessage(message.message!)}
+            </div>
+          )}
+        </div>
 
         {/* Attachments */}
         {message.attachments && message.attachments.length > 0 && (

--- a/src/ui/components/chat/message-card.tsx
+++ b/src/ui/components/chat/message-card.tsx
@@ -11,12 +11,13 @@ import {
 } from '@/ui/components/ui/dialog'
 import { Separator } from '@/ui/components/ui/separator'
 import { useQuery } from '@tanstack/react-query'
-import { Download, File, Terminal } from 'lucide-react'
+import { Download, File, Terminal, Clock } from 'lucide-react'
 import React from 'react'
 import { formatTimeAgo } from '@/ui/lib/time'
 import Markdown from 'react-markdown'
 import { Avatar, AvatarFallback } from '../ui/avatar'
 import { Skeleton } from '../ui/skeleton'
+import { formatTimestamp } from '../viewers/utils'
 
 interface MessageCardProps {
   teamId?: string
@@ -27,6 +28,8 @@ interface MessageCardProps {
   getUser: (id: string) => UserInfo
   onReply: (message: CommentInfo) => void
   onViewAttachment: (attachment: AttachmentInfo) => void
+  onTimestampClick?: (seconds: number) => void
+  frameRate?: number
   rootParentId?: string
 }
 
@@ -48,6 +51,8 @@ export const MessageCard: React.FC<MessageCardProps> = ({
   getUser,
   onReply,
   onViewAttachment,
+  onTimestampClick,
+  frameRate,
 }) => {
   const isRunning =
     !!initialMessage.sessionId &&
@@ -153,6 +158,18 @@ export const MessageCard: React.FC<MessageCardProps> = ({
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-1">
           <span className="font-semibold text-sm">{creator?.name || 'Unknown'}</span>
+          {message.second !== null && message.second !== undefined && frameRate && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onTimestampClick?.(message.second!)
+              }}
+              className="bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-2 py-0.5 rounded-full text-[10px] font-mono font-bold flex items-center gap-1 border border-blue-200 dark:border-blue-800 shadow-sm hover:bg-blue-200 dark:hover:bg-blue-900/60 transition-colors"
+            >
+              <Clock className="w-2.5 h-2.5" />
+              {formatTimestamp(message.second, frameRate)}
+            </button>
+          )}
           <span className="text-xs text-gray-400">
             {new Date(message.createdAt!).toLocaleTimeString([], {
               hour: '2-digit',

--- a/src/ui/components/chat/message-card.tsx
+++ b/src/ui/components/chat/message-card.tsx
@@ -3,11 +3,11 @@ import type { UserInfo } from '@/dtos/team'
 import { client } from '@/ui/api/client'
 import { Button } from '@/ui/components/ui/button'
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogHeader,
-    DialogTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
 } from '@/ui/components/ui/dialog'
 import { Separator } from '@/ui/components/ui/separator'
 import { formatTimeAgo } from '@/ui/lib/time'

--- a/src/ui/components/chat/message-card.tsx
+++ b/src/ui/components/chat/message-card.tsx
@@ -12,7 +12,7 @@ import {
 import { Separator } from '@/ui/components/ui/separator'
 import { formatTimeAgo } from '@/ui/lib/time'
 import { useQuery } from '@tanstack/react-query'
-import { Download, File, Terminal } from 'lucide-react'
+import { Clock, Download, File, Terminal } from 'lucide-react'
 import React from 'react'
 import Markdown from 'react-markdown'
 import { Avatar, AvatarFallback } from '../ui/avatar'
@@ -28,7 +28,8 @@ interface MessageCardProps {
   getUser: (id: string) => UserInfo
   onReply: (message: CommentInfo) => void
   onViewAttachment: (attachment: AttachmentInfo) => void
-  onTimestampClick?: (seconds: number) => void
+  isSelected?: boolean
+  onSelect?: () => void
   frameRate?: number
   rootParentId?: string
 }
@@ -51,7 +52,8 @@ export const MessageCard: React.FC<MessageCardProps> = ({
   getUser,
   onReply,
   onViewAttachment,
-  onTimestampClick,
+  isSelected,
+  onSelect,
   frameRate,
 }) => {
   const isRunning =
@@ -139,7 +141,12 @@ export const MessageCard: React.FC<MessageCardProps> = ({
 
   return (
     <div
-      className={`relative flex gap-4 ${isReply ? 'mt-0' : 'mt-2'} group p-3 py-4 bg-foreground/2 dark:bg-foreground/10 hover:bg-foreground/4 dark:hover:bg-foreground/15 rounded`}
+      onClick={onSelect}
+      className={`relative flex gap-4 ${isReply ? 'mt-2' : 'mt-3'} mr-3 group p-3 py-4 border transition-all duration-200 cursor-pointer rounded-xl ${
+        isSelected
+          ? 'border-blue-500/40 dark:border-blue-400/40 bg-blue-500/10 dark:bg-blue-400/10 shadow-sm'
+          : 'border-transparent bg-foreground/2 dark:bg-foreground/10 hover:bg-foreground/4 dark:hover:bg-foreground/15'
+      }`}
     >
       {hasReplies && !isReply && (
         <div className="absolute left-[1.7rem] top-[2rem] bottom-[-1.8rem] w-0.5 bg-foreground/10 -translate-x-1/2 z-0" />
@@ -170,15 +177,10 @@ export const MessageCard: React.FC<MessageCardProps> = ({
 
         <div className="flow-root mt-1">
           {message.second !== null && message.second !== undefined && frameRate && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation()
-                onTimestampClick?.(message.second!)
-              }}
-              className="float-left select-none bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-2.5 py-0.5 mt-0.5 mr-2 rounded-sm text-xs font-mono font-bold flex items-center gap-1 transition-colors"
-            >
+            <div className="float-left select-none bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-2.5 py-0.5 mt-0.5 mr-2 rounded-sm text-xs font-mono font-bold flex items-center gap-1 border border-blue-200 dark:border-blue-800 shadow-sm">
+              <Clock className="w-3 h-3" />
               {formatTimestamp(message.second, frameRate)}
-            </button>
+            </div>
           )}
 
           {showSkeleton ? (

--- a/src/ui/components/chat/message-input.tsx
+++ b/src/ui/components/chat/message-input.tsx
@@ -8,6 +8,7 @@ import {
   ArrowUp,
   Brush,
   ChevronDown,
+  Clock,
   FileIcon,
   Minus,
   Paperclip,
@@ -24,6 +25,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
 import { useAnnotationStore } from '@/ui/stores/annotation-store'
 import type { Annotation } from '@/ui/types'
 import { useMutation } from '@tanstack/react-query'
+import { formatTimestamp } from '../viewers/utils'
 
 type UploadingFile = {
   id: string // A unique ID for the file, e.g., timestamp + name
@@ -40,6 +42,7 @@ interface ChatInputProps {
     attachmentIds: string[],
     annotations?: Annotation[],
     replyToId?: string | null,
+    second?: number | null,
   ) => void
   replyingTo?: CommentInfo | null
   onCancelReply?: () => void
@@ -48,6 +51,8 @@ interface ChatInputProps {
   initialText?: string
   hideAnnotationControl?: boolean
   disableMentions?: boolean
+  currentTime?: number
+  frameRate?: number
 }
 
 const PREDEFINED_COLORS = [
@@ -76,11 +81,14 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
       initialText = '',
       hideAnnotationControl = false,
       disableMentions = false,
+      currentTime,
+      frameRate,
     },
     ref,
   ) => {
     const [uploadingFiles, setUploadingFiles] = useState<UploadingFile[]>([])
     const [viewingFile, setViewingFile] = useState<File | null>(null)
+    const [isTimestampEnabled, setIsTimestampEnabled] = useState(true)
 
     // Annotation Store
     const {
@@ -395,7 +403,13 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
       // Allow sending if annotations exist, even if text is empty
       if (!processedText && successfulAttachmentIds.length === 0 && annotations.length === 0) return
 
-      onSendMessage(processedText, successfulAttachmentIds, annotations, replyingTo?.id)
+      onSendMessage(
+        processedText,
+        successfulAttachmentIds,
+        annotations,
+        replyingTo?.id,
+        isTimestampEnabled ? currentTime : undefined,
+      )
 
       // Reset editor
       editorRef.current.innerHTML = ''
@@ -566,6 +580,15 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
           </div>
         )}
 
+        {isTimestampEnabled && currentTime !== undefined && frameRate !== undefined && (
+          <div className="px-4 pt-3 flex">
+            <div className="bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-3 py-1 rounded-full text-xs font-mono font-bold flex items-center gap-1.5 border border-blue-200 dark:border-blue-800 shadow-sm animate-in fade-in zoom-in duration-200">
+              <Clock className="w-3 h-3" />
+              {formatTimestamp(currentTime, frameRate)}
+            </div>
+          </div>
+        )}
+
         <div className="w-full px-4 pt-1 pb-1">
           <div
             ref={editorRef}
@@ -679,6 +702,15 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
                 multiple
                 onChange={handleFileSelect}
               />
+              <Button
+                onClick={() => setIsTimestampEnabled(!isTimestampEnabled)}
+                variant={isTimestampEnabled ? 'secondary' : 'ghost'}
+                size="icon"
+                className={`p-2 rounded-full cursor-pointer ${isTimestampEnabled ? 'text-blue-600 bg-blue-50 dark:bg-blue-900/20' : ''}`}
+                title={isTimestampEnabled ? 'Disable Timestamp' : 'Enable Timestamp'}
+              >
+                <Clock className="w-4 h-4" />
+              </Button>
               <Button
                 onClick={() => fileInputRef.current?.click()}
                 className="p-2 rounded-full cursor-pointer"

--- a/src/ui/components/chat/message-input.tsx
+++ b/src/ui/components/chat/message-input.tsx
@@ -709,15 +709,17 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
                 multiple
                 onChange={handleFileSelect}
               />
-              <Button
-                onClick={() => setIsTimestampEnabled(!isTimestampEnabled)}
-                variant={isTimestampEnabled ? 'secondary' : 'ghost'}
-                size="icon"
-                className={`p-2 rounded-full cursor-pointer ${isTimestampEnabled ? 'text-blue-600 bg-blue-50 dark:bg-blue-900/20' : ''}`}
-                title={isTimestampEnabled ? 'Disable Timestamp' : 'Enable Timestamp'}
-              >
-                <Clock className="w-4 h-4" />
-              </Button>
+              {currentTime !== undefined && frameRate !== undefined && (
+                <Button
+                  onClick={() => setIsTimestampEnabled(!isTimestampEnabled)}
+                  variant={isTimestampEnabled ? 'secondary' : 'ghost'}
+                  size="icon"
+                  className={`p-2 rounded-full cursor-pointer ${isTimestampEnabled ? 'text-blue-600 bg-blue-50 dark:bg-blue-900/20' : ''}`}
+                  title={isTimestampEnabled ? 'Disable Timestamp' : 'Enable Timestamp'}
+                >
+                  <Clock className="w-4 h-4" />
+                </Button>
+              )}
               <Button
                 onClick={() => fileInputRef.current?.click()}
                 className="p-2 rounded-full cursor-pointer"

--- a/src/ui/components/chat/message-input.tsx
+++ b/src/ui/components/chat/message-input.tsx
@@ -1,8 +1,10 @@
-import { client } from '@/ui/api/client'
-import type { CommentInfo } from '@/dtos/asset'
-import type { UserInfo } from '@/dtos/team'
+import type { CommentInfo, PostAttachmentRequest, PostAttachmentResponse } from '@/dtos/asset'
 import type { BotInfo } from '@/dtos/project'
-import type { PostAttachmentRequest, PostAttachmentResponse } from '@/dtos/asset'
+import type { UserInfo } from '@/dtos/team'
+import { client } from '@/ui/api/client'
+import { useAnnotationStore } from '@/ui/stores/annotation-store'
+import type { Annotation } from '@/ui/types'
+import { useMutation } from '@tanstack/react-query'
 import {
   ArrowLeft,
   ArrowUp,
@@ -20,11 +22,8 @@ import {
 import React, { useCallback, useEffect, useRef, useState, type ChangeEvent } from 'react'
 import { Button } from '../ui/button'
 import { DrawAnnotation } from '../ui/icons'
-import { ProgressCircle } from '../ui/progress-circle'
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
-import { useAnnotationStore } from '@/ui/stores/annotation-store'
-import type { Annotation } from '@/ui/types'
-import { useMutation } from '@tanstack/react-query'
+import { ProgressCircle } from '../ui/progress-circle'
 import { formatTimestamp } from '../viewers/utils'
 
 type UploadingFile = {
@@ -53,6 +52,7 @@ interface ChatInputProps {
   disableMentions?: boolean
   currentTime?: number
   frameRate?: number
+  onTyping?: () => void
 }
 
 const PREDEFINED_COLORS = [
@@ -83,6 +83,7 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
       disableMentions = false,
       currentTime,
       frameRate,
+      onTyping,
     },
     ref,
   ) => {
@@ -198,6 +199,7 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
     const handleInput = () => {
       if (!editorRef.current) return
       setHasContent(!!editorRef.current.innerText.trim())
+      onTyping?.()
 
       if (disableMentions) {
         setShowMentionList(false)
@@ -580,16 +582,21 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
           </div>
         )}
 
-        {isTimestampEnabled && currentTime !== undefined && frameRate !== undefined && (
-          <div className="px-4 pt-3 flex">
-            <div className="bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-3 py-1 rounded-full text-xs font-mono font-bold flex items-center gap-1.5 border border-blue-200 dark:border-blue-800 shadow-sm animate-in fade-in zoom-in duration-200">
-              <Clock className="w-3 h-3" />
+        <div
+          onClick={() => editorRef.current?.focus()}
+          className="w-full px-4 pt-1 pb-1 cursor-text flow-root max-h-60 overflow-y-auto"
+        >
+          {isTimestampEnabled && currentTime !== undefined && frameRate !== undefined && (
+            <div
+              onClick={(e) => {
+                e.stopPropagation()
+                editorRef.current?.focus()
+              }}
+              className="float-left select-none bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-2.5 py-0.5 mt-3 mr-2 rounded-sm text-xs font-mono font-bold flex items-center gap-1 cursor-text"
+            >
               {formatTimestamp(currentTime, frameRate)}
             </div>
-          </div>
-        )}
-
-        <div className="w-full px-4 pt-1 pb-1">
+          )}
           <div
             ref={editorRef}
             contentEditable={!isDrawing}
@@ -599,7 +606,7 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
             data-placeholder={
               isDrawing ? 'Drawing active...' : replyingTo ? 'Reply...' : 'Message...'
             }
-            className="w-full bg-transparent border-none focus:ring-0 resize-none max-h-60 min-h-[40px] leading-relaxed py-2 focus:outline-none overflow-y-auto"
+            className={`bg-transparent border-none focus:ring-0 resize-none min-h-[40px] leading-relaxed py-2 focus:outline-none block ${isTimestampEnabled && currentTime !== undefined && frameRate !== undefined && !hasContent ? 'pl-[120px]' : ''}`}
           />
         </div>
 

--- a/src/ui/components/file-viewer-right-sidebar.tsx
+++ b/src/ui/components/file-viewer-right-sidebar.tsx
@@ -331,7 +331,7 @@ export function FileViewerRightSidebar({
           </div>
         </div>
       )}
-      <Tabs defaultValue="comments" className="p-4 flex-1 flex flex-col px-2 min-h-0">
+      <Tabs defaultValue="comments" className="p-1 flex-1 flex flex-col px-2 min-h-0">
         <TabsList className="w-full shrink-0">
           <TabsTrigger value="comments" className="flex-1">
             Comments
@@ -352,7 +352,11 @@ export function FileViewerRightSidebar({
                     onReply={setReplyingTo}
                     onViewAttachment={setViewingAttachment}
                     hasReplies={!!comment.replies?.length}
-                    frameRate={file?.media?.metadata?.frameRate || 30}
+                    frameRate={
+                      file?.mediaType?.startsWith('video/')
+                        ? file?.media?.metadata?.frameRate || 30
+                        : undefined
+                    }
                     isSelected={selectedCommentId === comment.id}
                     onSelect={() => {
                       onCommentSelect?.(comment)
@@ -369,7 +373,11 @@ export function FileViewerRightSidebar({
                         onViewAttachment={setViewingAttachment}
                         hasReplies={false}
                         isLastReply={index === (comment.replies?.length ?? 0) - 1}
-                        frameRate={file?.media?.metadata?.frameRate || 30}
+                        frameRate={
+                          file?.mediaType?.startsWith('video/')
+                            ? file?.media?.metadata?.frameRate || 30
+                            : undefined
+                        }
                         isSelected={selectedCommentId === reply.id}
                         onSelect={() => {
                           onCommentSelect?.(reply)
@@ -398,8 +406,12 @@ export function FileViewerRightSidebar({
                   bots={enabledBots}
                   hideAnnotationControl={hideAnnotationControl}
                   disableMentions={isPublic}
-                  currentTime={currentTime}
-                  frameRate={file?.media?.metadata?.frameRate || 30}
+                  currentTime={file?.mediaType?.startsWith('video/') ? currentTime : undefined}
+                  frameRate={
+                    file?.mediaType?.startsWith('video/')
+                      ? file?.media?.metadata?.frameRate || 30
+                      : undefined
+                  }
                   onTyping={onTyping}
                 />
               </GuestIdentityPopup>

--- a/src/ui/components/file-viewer-right-sidebar.tsx
+++ b/src/ui/components/file-viewer-right-sidebar.tsx
@@ -29,6 +29,7 @@ interface FileViewerRightSidebarProps {
   shareId?: string
   currentTime?: number
   onTyping?: () => void
+  selectedCommentId?: string | null
 }
 
 export function FileViewerRightSidebar({
@@ -45,6 +46,7 @@ export function FileViewerRightSidebar({
   shareId,
   currentTime,
   onTyping,
+  selectedCommentId,
 }: FileViewerRightSidebarProps) {
   const { fields, setFields } = useFieldStore()
   const queryClient = useQueryClient()
@@ -52,7 +54,6 @@ export function FileViewerRightSidebar({
   const [replyingTo, setReplyingTo] = useState<CommentInfo | null>(null)
   const [viewingAttachment, setViewingAttachment] = useState<AttachmentInfo | null>(null)
   const [isGuestPopupOpen, setIsGuestPopupOpen] = useState(false)
-  const [selectedCommentId, setSelectedCommentId] = useState<string | null>(null)
   const [pendingComment, setPendingComment] = useState<{
     text: string
     attachmentIds: string[]
@@ -354,7 +355,6 @@ export function FileViewerRightSidebar({
                     frameRate={file?.media?.metadata?.frameRate || 30}
                     isSelected={selectedCommentId === comment.id}
                     onSelect={() => {
-                      setSelectedCommentId(comment.id!)
                       onCommentSelect?.(comment)
                     }}
                   />
@@ -372,7 +372,6 @@ export function FileViewerRightSidebar({
                         frameRate={file?.media?.metadata?.frameRate || 30}
                         isSelected={selectedCommentId === reply.id}
                         onSelect={() => {
-                          setSelectedCommentId(reply.id!)
                           onCommentSelect?.(reply)
                         }}
                       />

--- a/src/ui/components/file-viewer-right-sidebar.tsx
+++ b/src/ui/components/file-viewer-right-sidebar.tsx
@@ -28,6 +28,7 @@ interface FileViewerRightSidebarProps {
   isPublic?: boolean
   shareId?: string
   currentTime?: number
+  onTyping?: () => void
 }
 
 export function FileViewerRightSidebar({
@@ -43,6 +44,7 @@ export function FileViewerRightSidebar({
   isPublic = false,
   shareId,
   currentTime,
+  onTyping,
 }: FileViewerRightSidebarProps) {
   const { fields, setFields } = useFieldStore()
   const queryClient = useQueryClient()
@@ -389,6 +391,7 @@ export function FileViewerRightSidebar({
                   disableMentions={isPublic}
                   currentTime={currentTime}
                   frameRate={file?.media?.metadata?.frameRate || 30}
+                  onTyping={onTyping}
                 />
               </GuestIdentityPopup>
             </div>

--- a/src/ui/components/file-viewer-right-sidebar.tsx
+++ b/src/ui/components/file-viewer-right-sidebar.tsx
@@ -1,19 +1,19 @@
-import { type FieldInfo as MetadataFieldInfo } from '@/dtos/metadata'
-import { client } from '@/ui/api/client'
 import type { AssetInfo, AttachmentInfo, CommentInfo, FieldValueInfo } from '@/dtos/asset'
+import { type FieldInfo as MetadataFieldInfo } from '@/dtos/metadata'
 import type { UserInfo } from '@/dtos/team'
+import { client } from '@/ui/api/client'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/components/ui/tabs'
 import { useFieldStore } from '@/ui/stores/fields'
-import { useInfiniteQuery, useQueryClient, useQuery, useMutation } from '@tanstack/react-query'
+import type { Annotation } from '@/ui/types'
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { XIcon } from 'lucide-react'
 import React, { useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { MessageCard } from './chat/message-card'
 import { ChatInput } from './chat/message-input'
 import FieldRenderer from './field-renderer'
-import { ScrollArea } from './ui/scroll-area'
-import type { Annotation } from '@/ui/types'
 import { GuestIdentityPopup } from './guest-identity-popup'
+import { ScrollArea } from './ui/scroll-area'
 
 interface FileViewerRightSidebarProps {
   teamId: string
@@ -338,9 +338,9 @@ export function FileViewerRightSidebar({
             Fields
           </TabsTrigger>
         </TabsList>
-        <TabsContent value="comments" className="flex-1 flex flex-col overflow-hidden min-h-0 mt-4">
-          <ScrollArea className="flex-1 px-4">
-            <div className="space-y-4">
+        <TabsContent value="comments" className="flex-1 flex flex-col overflow-hidden min-h-0 mt-0">
+          <ScrollArea className="flex-1">
+            <div className="space-y-2">
               {comments.map((comment) => (
                 <div key={comment.id} onClick={() => onCommentSelect?.(comment)}>
                   <MessageCard

--- a/src/ui/components/file-viewer-right-sidebar.tsx
+++ b/src/ui/components/file-viewer-right-sidebar.tsx
@@ -52,6 +52,7 @@ export function FileViewerRightSidebar({
   const [replyingTo, setReplyingTo] = useState<CommentInfo | null>(null)
   const [viewingAttachment, setViewingAttachment] = useState<AttachmentInfo | null>(null)
   const [isGuestPopupOpen, setIsGuestPopupOpen] = useState(false)
+  const [selectedCommentId, setSelectedCommentId] = useState<string | null>(null)
   const [pendingComment, setPendingComment] = useState<{
     text: string
     attachmentIds: string[]
@@ -340,9 +341,9 @@ export function FileViewerRightSidebar({
         </TabsList>
         <TabsContent value="comments" className="flex-1 flex flex-col overflow-hidden min-h-0 mt-0">
           <ScrollArea className="flex-1">
-            <div className="space-y-2">
+            <div className="space-y-4">
               {comments.map((comment) => (
-                <div key={comment.id} onClick={() => onCommentSelect?.(comment)}>
+                <div key={comment.id}>
                   <MessageCard
                     teamId={teamId}
                     message={comment}
@@ -351,22 +352,31 @@ export function FileViewerRightSidebar({
                     onViewAttachment={setViewingAttachment}
                     hasReplies={!!comment.replies?.length}
                     frameRate={file?.media?.metadata?.frameRate || 30}
-                    onTimestampClick={(sec) => onCommentSelect?.({ ...comment, second: sec })}
+                    isSelected={selectedCommentId === comment.id}
+                    onSelect={() => {
+                      setSelectedCommentId(comment.id!)
+                      onCommentSelect?.(comment)
+                    }}
                   />
                   {comment.replies?.map((reply, index) => (
-                    <MessageCard
-                      teamId={teamId}
-                      isReply={true}
-                      key={reply.id}
-                      message={reply}
-                      getUser={getUser}
-                      onReply={setReplyingTo}
-                      onViewAttachment={setViewingAttachment}
-                      hasReplies={false}
-                      isLastReply={index === (comment.replies?.length ?? 0) - 1}
-                      frameRate={file?.media?.metadata?.frameRate || 30}
-                      onTimestampClick={(sec) => onCommentSelect?.({ ...reply, second: sec })}
-                    />
+                    <div key={reply.id}>
+                      <MessageCard
+                        teamId={teamId}
+                        isReply={true}
+                        message={reply}
+                        getUser={getUser}
+                        onReply={setReplyingTo}
+                        onViewAttachment={setViewingAttachment}
+                        hasReplies={false}
+                        isLastReply={index === (comment.replies?.length ?? 0) - 1}
+                        frameRate={file?.media?.metadata?.frameRate || 30}
+                        isSelected={selectedCommentId === reply.id}
+                        onSelect={() => {
+                          setSelectedCommentId(reply.id!)
+                          onCommentSelect?.(reply)
+                        }}
+                      />
+                    </div>
                   ))}
                 </div>
               ))}

--- a/src/ui/components/file-viewer-right-sidebar.tsx
+++ b/src/ui/components/file-viewer-right-sidebar.tsx
@@ -27,6 +27,7 @@ interface FileViewerRightSidebarProps {
   publicFields?: MetadataFieldInfo[]
   isPublic?: boolean
   shareId?: string
+  currentTime?: number
 }
 
 export function FileViewerRightSidebar({
@@ -41,6 +42,7 @@ export function FileViewerRightSidebar({
   publicFields,
   isPublic = false,
   shareId,
+  currentTime,
 }: FileViewerRightSidebarProps) {
   const { fields, setFields } = useFieldStore()
   const queryClient = useQueryClient()
@@ -53,6 +55,7 @@ export function FileViewerRightSidebar({
     attachmentIds: string[]
     annotations?: Annotation[]
     replyToId?: string | null
+    second?: number | null
   } | null>(null)
 
   const { data: apiFields } = useQuery({
@@ -139,12 +142,14 @@ export function FileViewerRightSidebar({
       annotations,
       replyToId,
       guestUserId,
+      second,
     }: {
       text: string
       attachmentIds: string[]
       annotations?: Annotation[]
       replyToId?: string | null
       guestUserId?: string
+      second?: number | null
     }) => {
       if (isPublic) {
         const password = localStorage.getItem(`share_pwd_${shareId}`) || ''
@@ -156,6 +161,7 @@ export function FileViewerRightSidebar({
               attachmentIds: attachmentIds,
               replyToId: replyToId ?? undefined,
               annotations: annotations,
+              second: second ?? undefined,
             },
           },
           {
@@ -175,6 +181,7 @@ export function FileViewerRightSidebar({
             attachmentIds: attachmentIds,
             replyToId: replyToId ?? undefined,
             annotations: annotations,
+            second: second ?? undefined,
           },
         })
         if (!res.ok) throw new Error('Failed to create comment')
@@ -225,6 +232,7 @@ export function FileViewerRightSidebar({
     attachmentIds: string[],
     annotations?: Annotation[],
     replyToId?: string | null,
+    second?: number | null,
   ) => {
     if (!file?.id) return
 
@@ -240,16 +248,16 @@ export function FileViewerRightSidebar({
         console.log('[handleSendMessage] guestUserId from storage:', guestUserId)
         if (!guestUserId) {
           console.log('[handleSendMessage] no guest ID, opening popup')
-          setPendingComment({ text, attachmentIds, annotations, replyToId })
+          setPendingComment({ text, attachmentIds, annotations, replyToId, second })
           setIsGuestPopupOpen(true)
           return
         }
-        createComment({ text, attachmentIds, annotations, replyToId, guestUserId })
+        createComment({ text, attachmentIds, annotations, replyToId, guestUserId, second })
       } else {
-        createComment({ text, attachmentIds, annotations, replyToId })
+        createComment({ text, attachmentIds, annotations, replyToId, second })
       }
     } else {
-      createComment({ text, attachmentIds, annotations, replyToId })
+      createComment({ text, attachmentIds, annotations, replyToId, second })
     }
     setReplyingTo(null)
   }
@@ -340,6 +348,8 @@ export function FileViewerRightSidebar({
                     onReply={setReplyingTo}
                     onViewAttachment={setViewingAttachment}
                     hasReplies={!!comment.replies?.length}
+                    frameRate={file?.media?.metadata?.frameRate || 30}
+                    onTimestampClick={(sec) => onCommentSelect?.({ ...comment, second: sec })}
                   />
                   {comment.replies?.map((reply, index) => (
                     <MessageCard
@@ -352,6 +362,8 @@ export function FileViewerRightSidebar({
                       onViewAttachment={setViewingAttachment}
                       hasReplies={false}
                       isLastReply={index === (comment.replies?.length ?? 0) - 1}
+                      frameRate={file?.media?.metadata?.frameRate || 30}
+                      onTimestampClick={(sec) => onCommentSelect?.({ ...reply, second: sec })}
                     />
                   ))}
                 </div>
@@ -375,6 +387,8 @@ export function FileViewerRightSidebar({
                   bots={enabledBots}
                   hideAnnotationControl={hideAnnotationControl}
                   disableMentions={isPublic}
+                  currentTime={currentTime}
+                  frameRate={file?.media?.metadata?.frameRate || 30}
                 />
               </GuestIdentityPopup>
             </div>

--- a/src/ui/components/file-viewer.tsx
+++ b/src/ui/components/file-viewer.tsx
@@ -16,10 +16,18 @@ type FileViewerProps = {
   videoRef?: RefObject<Player | null>
   onPlay?: () => void
   onPause?: () => void
+  onTimeUpdate?: (time: number) => void
   annotations?: Annotation[]
 }
 
-export function FileViewer({ file, videoRef, onPlay, onPause, annotations }: FileViewerProps) {
+export function FileViewer({
+  file,
+  videoRef,
+  onPlay,
+  onPause,
+  onTimeUpdate,
+  annotations,
+}: FileViewerProps) {
   const { width: screenWidth } = useScreenSize()
   const isImage = file.mediaType?.startsWith('image/')
   const isVideo = file.mediaType?.startsWith('video/')
@@ -186,6 +194,7 @@ export function FileViewer({ file, videoRef, onPlay, onPause, annotations }: Fil
           playerRef={videoRef}
           onPlay={onPlay}
           onPause={onPause}
+          onTimeUpdate={onTimeUpdate}
           annotations={displayAnnotations}
         />
       )}

--- a/src/ui/components/public-share-manager.tsx
+++ b/src/ui/components/public-share-manager.tsx
@@ -89,6 +89,7 @@ export function PublicShareManager({
   const [isRightSidebarCollapsed] = useState(false)
   const videoRef = useRef<Player | null>(null)
   const [annotations, setAnnotations] = useState<Annotation[]>([])
+  const [currentTime, setCurrentTime] = useState(0)
 
   const {
     data: foldersData,
@@ -257,11 +258,19 @@ export function PublicShareManager({
     const newAnnotations = comment.annotations as Annotation[]
     if (newAnnotations && newAnnotations.length > 0) {
       setAnnotations(newAnnotations)
+    } else {
+      setAnnotations([])
+    }
+
+    if (comment.second !== null && comment.second !== undefined) {
+      if (videoRef.current) {
+        videoRef.current.currentTime(comment.second)
+        videoRef.current.pause()
+      }
+    } else if (newAnnotations && newAnnotations.length > 0) {
       if (videoRef.current) {
         videoRef.current.pause()
       }
-    } else {
-      setAnnotations([])
     }
   }
 
@@ -373,6 +382,7 @@ export function PublicShareManager({
                 file={viewingFileData}
                 videoRef={videoRef}
                 onPlay={handlePlay}
+                onTimeUpdate={setCurrentTime}
                 annotations={annotations}
               />
             )}
@@ -430,6 +440,7 @@ export function PublicShareManager({
                 onCommentSelect={handleCommentSelect}
                 isPublic={true}
                 shareId={shareInfo.id}
+                currentTime={currentTime}
               />
             </div>
           </>

--- a/src/ui/components/public-share-manager.tsx
+++ b/src/ui/components/public-share-manager.tsx
@@ -441,6 +441,11 @@ export function PublicShareManager({
                 isPublic={true}
                 shareId={shareInfo.id}
                 currentTime={currentTime}
+                onTyping={() => {
+                  if (videoRef.current) {
+                    videoRef.current.pause()
+                  }
+                }}
               />
             </div>
           </>

--- a/src/ui/components/public-share-manager.tsx
+++ b/src/ui/components/public-share-manager.tsx
@@ -90,6 +90,7 @@ export function PublicShareManager({
   const videoRef = useRef<Player | null>(null)
   const [annotations, setAnnotations] = useState<Annotation[]>([])
   const [currentTime, setCurrentTime] = useState(0)
+  const [selectedCommentId, setSelectedCommentId] = useState<string | null>(null)
 
   const {
     data: foldersData,
@@ -255,6 +256,7 @@ export function PublicShareManager({
   }
 
   const handleCommentSelect = (comment: CommentInfo) => {
+    setSelectedCommentId(comment.id || null)
     const newAnnotations = comment.annotations as Annotation[]
     if (newAnnotations && newAnnotations.length > 0) {
       setAnnotations(newAnnotations)
@@ -276,6 +278,7 @@ export function PublicShareManager({
 
   const handlePlay = () => {
     setAnnotations([])
+    setSelectedCommentId(null)
   }
 
   const { setProjectState, clearProjectState } = useTopNavStore()
@@ -446,6 +449,7 @@ export function PublicShareManager({
                     videoRef.current.pause()
                   }
                 }}
+                selectedCommentId={selectedCommentId}
               />
             </div>
           </>

--- a/src/ui/components/viewers/utils.ts
+++ b/src/ui/components/viewers/utils.ts
@@ -10,6 +10,16 @@ export const formatTime = (seconds: number): string => {
   return `${mm}:${ss}`
 }
 
+export const formatTimestamp = (seconds: number, fps: number): string => {
+  if (isNaN(seconds)) return '00:00:00:00'
+  const hh = Math.floor(seconds / 3600)
+  const mm = Math.floor((seconds % 3600) / 60)
+  const ss = Math.floor(seconds % 60)
+  const ff = Math.floor((seconds % 1) * fps)
+
+  return `${hh.toString().padStart(2, '0')}:${mm.toString().padStart(2, '0')}:${ss.toString().padStart(2, '0')}:${ff.toString().padStart(2, '0')}`
+}
+
 export const formatFrame = (seconds: number, fps: number): number => {
   if (isNaN(seconds) || !fps) return 0
   return Math.floor(seconds * fps)

--- a/src/ui/components/viewers/video-player.tsx
+++ b/src/ui/components/viewers/video-player.tsx
@@ -51,6 +51,7 @@ interface VideoPlayerProps {
   playerRef?: React.RefObject<Player | null>
   onPlay?: () => void
   onPause?: () => void
+  onTimeUpdate?: (time: number) => void
   annotations?: Annotation[]
 }
 
@@ -299,6 +300,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   playerRef: passedPlayerRef,
   onPlay,
   onPause,
+  onTimeUpdate,
   annotations,
 }) => {
   const localPlayerRef = useRef<Player | null>(null)
@@ -494,6 +496,10 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         duration: duration || prev.duration,
         progress: duration > 0 ? (current / duration) * 100 : 0,
       }))
+
+      if (onTimeUpdate) {
+        onTimeUpdate(current)
+      }
     })
 
     player.on('volumechange', () => {

--- a/src/ui/routes/__root.tsx
+++ b/src/ui/routes/__root.tsx
@@ -8,10 +8,10 @@ import { useAuthStore } from '@/ui/stores/auth'
 import { useTeamContextStore } from '@/ui/stores/team-context'
 import { useUploadStore } from '@/ui/stores/upload'
 import {
-    createRootRouteWithContext,
-    Outlet,
-    useNavigate,
-    useRouterState,
+  createRootRouteWithContext,
+  Outlet,
+  useNavigate,
+  useRouterState,
 } from '@tanstack/react-router'
 import { useEffect } from 'react'
 

--- a/src/ui/routes/projects/$projectId/files/$fileId.tsx
+++ b/src/ui/routes/projects/$projectId/files/$fileId.tsx
@@ -35,6 +35,7 @@ function FileViewPage() {
   const [rightSidebarWidth, setRightSidebarWidth] = useState(360)
   const [annotations, setAnnotations] = useState<Annotation[]>([])
   const [currentTime, setCurrentTime] = useState(0)
+  const [selectedCommentId, setSelectedCommentId] = useState<string | null>(null)
   const $patchMetadata = client.api.files[':fileId'].metadata.$patch
   const { mutate: patchMetadata } = useMutation<
     InferResponseType<typeof $patchMetadata>,
@@ -195,6 +196,7 @@ function FileViewPage() {
   }
 
   const handleCommentSelect = (comment: CommentInfo) => {
+    setSelectedCommentId(comment.id || null)
     const newAnnotations = comment.annotations as Annotation[]
     if (newAnnotations && newAnnotations.length > 0) {
       setAnnotations(newAnnotations)
@@ -216,6 +218,7 @@ function FileViewPage() {
 
   const handlePlay = () => {
     setAnnotations([])
+    setSelectedCommentId(null)
   }
 
   return (
@@ -279,6 +282,7 @@ function FileViewPage() {
                     videoRef.current.pause()
                   }
                 }}
+                selectedCommentId={selectedCommentId}
               />
             </div>
           </>

--- a/src/ui/routes/projects/$projectId/files/$fileId.tsx
+++ b/src/ui/routes/projects/$projectId/files/$fileId.tsx
@@ -256,8 +256,8 @@ function FileViewPage() {
             onTimeUpdate={setCurrentTime}
             annotations={annotations}
           />
-          </div>
-          {!isRightSidebarCollapsed && (
+        </div>
+        {!isRightSidebarCollapsed && (
           <>
             <ResizeHandle
               onResize={(delta) => {
@@ -274,11 +274,15 @@ function FileViewPage() {
                 members={members}
                 onCommentSelect={handleCommentSelect}
                 currentTime={currentTime}
+                onTyping={() => {
+                  if (videoRef.current) {
+                    videoRef.current.pause()
+                  }
+                }}
               />
             </div>
           </>
-          )}
-
+        )}
       </div>
     </div>
   )

--- a/src/ui/routes/projects/$projectId/files/$fileId.tsx
+++ b/src/ui/routes/projects/$projectId/files/$fileId.tsx
@@ -34,6 +34,7 @@ function FileViewPage() {
   const [leftSidebarWidth, setLeftSidebarWidth] = useState(280)
   const [rightSidebarWidth, setRightSidebarWidth] = useState(360)
   const [annotations, setAnnotations] = useState<Annotation[]>([])
+  const [currentTime, setCurrentTime] = useState(0)
   const $patchMetadata = client.api.files[':fileId'].metadata.$patch
   const { mutate: patchMetadata } = useMutation<
     InferResponseType<typeof $patchMetadata>,
@@ -197,11 +198,19 @@ function FileViewPage() {
     const newAnnotations = comment.annotations as Annotation[]
     if (newAnnotations && newAnnotations.length > 0) {
       setAnnotations(newAnnotations)
+    } else {
+      setAnnotations([])
+    }
+
+    if (comment.second !== null && comment.second !== undefined) {
+      if (videoRef.current) {
+        videoRef.current.currentTime(comment.second)
+        videoRef.current.pause()
+      }
+    } else if (newAnnotations && newAnnotations.length > 0) {
       if (videoRef.current) {
         videoRef.current.pause()
       }
-    } else {
-      setAnnotations([])
     }
   }
 
@@ -244,29 +253,32 @@ function FileViewPage() {
             file={fileData as unknown as AssetInfo}
             videoRef={videoRef}
             onPlay={handlePlay}
+            onTimeUpdate={setCurrentTime}
             annotations={annotations}
           />
-        </div>
-        {!isRightSidebarCollapsed && (
+          </div>
+          {!isRightSidebarCollapsed && (
           <>
             <ResizeHandle
               onResize={(delta) => {
-                setRightSidebarWidth((prev) => Math.max(240, Math.min(600, prev - delta)))
+                setRightSidebarWidth((prev) => Math.max(300, Math.min(600, prev - delta)))
               }}
               className="hidden md:block"
             />
             <div style={{ width: rightSidebarWidth }} className="flex-shrink-0">
               <FileViewerRightSidebar
-                teamId={teamId!}
+                teamId={teamId}
                 projectId={projectId}
                 file={fileData as unknown as AssetInfo}
                 onSaveField={handleSaveField}
                 members={members}
                 onCommentSelect={handleCommentSelect}
+                currentTime={currentTime}
               />
             </div>
           </>
-        )}
+          )}
+
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
Allow users to attach current video timestamps to comments in the video detail page. Timestamps are displayed in HH:MM:SS:FF format.

## Changes
- Added `formatTimestamp` utility for HH:MM:SS:FF formatting.
- Updated `CommentInfo` DTO and service layer to include the `second` field.
- Enhanced `ChatInput` with a clock toggle button and a live timestamp badge.
- Added clickable timestamp badges to `MessageCard`.
- Integrated video player time updates with the right sidebar and comment input.
- Implemented jump-to-timestamp and pause functionality in the file detail page and public share view.

## Verification
- Ran `bun run typecheck` and `bun run lint`.
- Updated and ran tests in `src/api/file.test.ts` and `src/services/asset/asset.test.ts`.
- Manual verification of UI layout (clock button on left, pill badges) matches the provided example images.