### PR TITLE
feat(auth): redesign login and signup pages and use email as username

### DIFF
--- a/src/api/file.test.ts
+++ b/src/api/file.test.ts
@@ -157,10 +157,11 @@ describe('file api', () => {
   it('POST /files/:fileId/comments', async () => {
     vi.mocked(assetService.createComment).mockResolvedValue({
       id: 'comment-id',
-      assetId: 'test-id',
+      assetId: 'file-id',
       message: 'hello',
       annotations: null,
-      creator: { id: 'user1', name: 'user-name' },
+      second: null,
+      creator: { id: 'user-id', name: 'Test User' },
       replies: [],
       attachments: [],
       mentions: [],
@@ -207,10 +208,11 @@ describe('file api', () => {
       data: [
         {
           id: 'comment-id',
-          assetId: 'test-id',
+          assetId: 'file-id',
           message: 'hello',
           annotations: null,
-          creator: { id: 'user1', name: 'user-name' },
+          second: null,
+          creator: { id: 'user-id', name: 'Test User' },
           replies: [],
           attachments: [],
           mentions: [],

--- a/src/dtos/asset.ts
+++ b/src/dtos/asset.ts
@@ -189,6 +189,7 @@ export type CommentInfo = {
   message: string | null
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   annotations: any
+  second: number | null
   creator: UserInfo
   replies: CommentInfo[]
   attachments: AttachmentInfo[]
@@ -204,6 +205,7 @@ export const commentInfoSchema: z.ZodType<CommentInfo> = z.object({
   message: z.string().nullable(),
 
   annotations: z.any(),
+  second: z.number().nullable(),
   creator: userInfoSchema,
   replies: z.array(z.lazy(() => commentInfoSchema)),
   attachments: z.array(attachmentInfoSchema),

--- a/src/services/asset/asset.test.ts
+++ b/src/services/asset/asset.test.ts
@@ -664,6 +664,28 @@ describe('AssetService', () => {
     expect(list.data[0].replies.length).toBe(1)
   })
 
+  it('can create and retrieve comments with video timestamp', async () => {
+    const { user, assets } = await setupBasicAssets()
+
+    const comment = await assetService.createComment({
+      assetId: assets.fileA1.id,
+      userId: user.id,
+      message: 'Interesting point at 5.5s',
+      second: 5.5,
+      attachmentIds: [],
+    })
+
+    expect(comment.second).toBe(5.5)
+
+    const retrieved = await assetService.getComment(comment.id)
+    expect(retrieved.second).toBe(5.5)
+
+    const list = await assetService.listComments(assets.fileA1.id, {
+      first: 10,
+    })
+    expect(list.data[0].second).toBe(5.5)
+  })
+
   it('correctly handles AI comments with agent identity', async () => {
     const { assets, project } = await setupBasicAssets()
 

--- a/src/services/asset/asset.ts
+++ b/src/services/asset/asset.ts
@@ -1690,6 +1690,7 @@ export class AssetService {
       assetId: c.assetId,
       message: c.message,
       annotations: c.annotation,
+      second: c.second,
       creator,
       replies,
       attachments,

--- a/src/ui/components/chat/message-card.tsx
+++ b/src/ui/components/chat/message-card.tsx
@@ -3,16 +3,16 @@ import type { UserInfo } from '@/dtos/team'
 import { client } from '@/ui/api/client'
 import { Button } from '@/ui/components/ui/button'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
 } from '@/ui/components/ui/dialog'
 import { Separator } from '@/ui/components/ui/separator'
 import { formatTimeAgo } from '@/ui/lib/time'
 import { useQuery } from '@tanstack/react-query'
-import { Clock, Download, File, Terminal } from 'lucide-react'
+import { Download, File, Terminal } from 'lucide-react'
 import React from 'react'
 import Markdown from 'react-markdown'
 import { Avatar, AvatarFallback } from '../ui/avatar'
@@ -177,8 +177,7 @@ export const MessageCard: React.FC<MessageCardProps> = ({
 
         <div className="flow-root mt-1">
           {message.second !== null && message.second !== undefined && frameRate && (
-            <div className="float-left select-none bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-2.5 py-0.5 mt-0.5 mr-2 rounded-sm text-xs font-mono font-bold flex items-center gap-1 border border-blue-200 dark:border-blue-800 shadow-sm">
-              <Clock className="w-3 h-3" />
+            <div className="float-left select-none bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-2.5 py-1 mt-[2px] mr-2 rounded-sm text-xs leading-none font-mono font-bold flex items-center gap-1">
               {formatTimestamp(message.second, frameRate)}
             </div>
           )}

--- a/src/ui/components/chat/message-card.tsx
+++ b/src/ui/components/chat/message-card.tsx
@@ -3,17 +3,17 @@ import type { UserInfo } from '@/dtos/team'
 import { client } from '@/ui/api/client'
 import { Button } from '@/ui/components/ui/button'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
 } from '@/ui/components/ui/dialog'
 import { Separator } from '@/ui/components/ui/separator'
-import { useQuery } from '@tanstack/react-query'
-import { Download, File, Terminal, Clock } from 'lucide-react'
-import React from 'react'
 import { formatTimeAgo } from '@/ui/lib/time'
+import { useQuery } from '@tanstack/react-query'
+import { Download, File, Terminal } from 'lucide-react'
+import React from 'react'
 import Markdown from 'react-markdown'
 import { Avatar, AvatarFallback } from '../ui/avatar'
 import { Skeleton } from '../ui/skeleton'
@@ -138,9 +138,11 @@ export const MessageCard: React.FC<MessageCardProps> = ({
   }
 
   return (
-    <div className={`relative flex gap-4 ${isReply ? 'mt-4' : 'mt-6'} group`}>
+    <div
+      className={`relative flex gap-4 ${isReply ? 'mt-0' : 'mt-2'} group p-3 py-4 bg-foreground/2 dark:bg-foreground/10 hover:bg-foreground/4 dark:hover:bg-foreground/15 rounded`}
+    >
       {hasReplies && !isReply && (
-        <div className="absolute left-[1rem] top-[2rem] bottom-[-1.5rem] w-0.5 bg-foreground/10 -translate-x-1/2 z-0" />
+        <div className="absolute left-[1.7rem] top-[2rem] bottom-[-1.8rem] w-0.5 bg-foreground/10 -translate-x-1/2 z-0" />
       )}
 
       {isReply && !isLastReply && (
@@ -158,18 +160,6 @@ export const MessageCard: React.FC<MessageCardProps> = ({
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-1">
           <span className="font-semibold text-sm">{creator?.name || 'Unknown'}</span>
-          {message.second !== null && message.second !== undefined && frameRate && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation()
-                onTimestampClick?.(message.second!)
-              }}
-              className="bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-2 py-0.5 rounded-full text-[10px] font-mono font-bold flex items-center gap-1 border border-blue-200 dark:border-blue-800 shadow-sm hover:bg-blue-200 dark:hover:bg-blue-900/60 transition-colors"
-            >
-              <Clock className="w-2.5 h-2.5" />
-              {formatTimestamp(message.second, frameRate)}
-            </button>
-          )}
           <span className="text-xs text-gray-400">
             {new Date(message.createdAt!).toLocaleTimeString([], {
               hour: '2-digit',
@@ -178,21 +168,35 @@ export const MessageCard: React.FC<MessageCardProps> = ({
           </span>
         </div>
 
-        {showSkeleton ? (
-          <div className="space-y-2">
-            <Skeleton className="h-4 w-3/4" />
-            <Skeleton className="h-4 w-1/2" />
-            <span className="text-xs text-muted-foreground animate-pulse">{loadingText}</span>
-          </div>
-        ) : message.sessionId ? (
-          <div className="text-sm leading-relaxed prose prose-sm dark:prose-invert max-w-none break-words">
-            <Markdown>{preprocessMarkdown(message.message!)}</Markdown>
-          </div>
-        ) : (
-          <div className="text-sm leading-relaxed whitespace-pre-wrap break-words text-wrap break-all">
-            {renderFormattedMessage(message.message!)}
-          </div>
-        )}
+        <div className="flow-root mt-1">
+          {message.second !== null && message.second !== undefined && frameRate && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onTimestampClick?.(message.second!)
+              }}
+              className="float-left select-none bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-2.5 py-0.5 mt-0.5 mr-2 rounded-sm text-xs font-mono font-bold flex items-center gap-1 transition-colors"
+            >
+              {formatTimestamp(message.second, frameRate)}
+            </button>
+          )}
+
+          {showSkeleton ? (
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-4 w-1/2" />
+              <span className="text-xs text-muted-foreground animate-pulse">{loadingText}</span>
+            </div>
+          ) : message.sessionId ? (
+            <div className="text-sm leading-relaxed prose prose-sm dark:prose-invert max-w-none break-words">
+              <Markdown>{preprocessMarkdown(message.message!)}</Markdown>
+            </div>
+          ) : (
+            <div className="text-sm leading-relaxed whitespace-pre-wrap break-words text-wrap break-all">
+              {renderFormattedMessage(message.message!)}
+            </div>
+          )}
+        </div>
 
         {/* Attachments */}
         {message.attachments && message.attachments.length > 0 && (

--- a/src/ui/components/chat/message-card.tsx
+++ b/src/ui/components/chat/message-card.tsx
@@ -11,12 +11,13 @@ import {
 } from '@/ui/components/ui/dialog'
 import { Separator } from '@/ui/components/ui/separator'
 import { useQuery } from '@tanstack/react-query'
-import { Download, File, Terminal } from 'lucide-react'
+import { Download, File, Terminal, Clock } from 'lucide-react'
 import React from 'react'
 import { formatTimeAgo } from '@/ui/lib/time'
 import Markdown from 'react-markdown'
 import { Avatar, AvatarFallback } from '../ui/avatar'
 import { Skeleton } from '../ui/skeleton'
+import { formatTimestamp } from '../viewers/utils'
 
 interface MessageCardProps {
   teamId?: string
@@ -27,6 +28,8 @@ interface MessageCardProps {
   getUser: (id: string) => UserInfo
   onReply: (message: CommentInfo) => void
   onViewAttachment: (attachment: AttachmentInfo) => void
+  onTimestampClick?: (seconds: number) => void
+  frameRate?: number
   rootParentId?: string
 }
 
@@ -48,6 +51,8 @@ export const MessageCard: React.FC<MessageCardProps> = ({
   getUser,
   onReply,
   onViewAttachment,
+  onTimestampClick,
+  frameRate,
 }) => {
   const isRunning =
     !!initialMessage.sessionId &&
@@ -153,6 +158,18 @@ export const MessageCard: React.FC<MessageCardProps> = ({
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-1">
           <span className="font-semibold text-sm">{creator?.name || 'Unknown'}</span>
+          {message.second !== null && message.second !== undefined && frameRate && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onTimestampClick?.(message.second!)
+              }}
+              className="bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-2 py-0.5 rounded-full text-[10px] font-mono font-bold flex items-center gap-1 border border-blue-200 dark:border-blue-800 shadow-sm hover:bg-blue-200 dark:hover:bg-blue-900/60 transition-colors"
+            >
+              <Clock className="w-2.5 h-2.5" />
+              {formatTimestamp(message.second, frameRate)}
+            </button>
+          )}
           <span className="text-xs text-gray-400">
             {new Date(message.createdAt!).toLocaleTimeString([], {
               hour: '2-digit',

--- a/src/ui/components/chat/message-card.tsx
+++ b/src/ui/components/chat/message-card.tsx
@@ -3,11 +3,11 @@ import type { UserInfo } from '@/dtos/team'
 import { client } from '@/ui/api/client'
 import { Button } from '@/ui/components/ui/button'
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogHeader,
-    DialogTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
 } from '@/ui/components/ui/dialog'
 import { Separator } from '@/ui/components/ui/separator'
 import { formatTimeAgo } from '@/ui/lib/time'

--- a/src/ui/components/chat/message-card.tsx
+++ b/src/ui/components/chat/message-card.tsx
@@ -12,7 +12,7 @@ import {
 import { Separator } from '@/ui/components/ui/separator'
 import { formatTimeAgo } from '@/ui/lib/time'
 import { useQuery } from '@tanstack/react-query'
-import { Download, File, Terminal } from 'lucide-react'
+import { Clock, Download, File, Terminal } from 'lucide-react'
 import React from 'react'
 import Markdown from 'react-markdown'
 import { Avatar, AvatarFallback } from '../ui/avatar'
@@ -28,7 +28,8 @@ interface MessageCardProps {
   getUser: (id: string) => UserInfo
   onReply: (message: CommentInfo) => void
   onViewAttachment: (attachment: AttachmentInfo) => void
-  onTimestampClick?: (seconds: number) => void
+  isSelected?: boolean
+  onSelect?: () => void
   frameRate?: number
   rootParentId?: string
 }
@@ -51,7 +52,8 @@ export const MessageCard: React.FC<MessageCardProps> = ({
   getUser,
   onReply,
   onViewAttachment,
-  onTimestampClick,
+  isSelected,
+  onSelect,
   frameRate,
 }) => {
   const isRunning =
@@ -139,7 +141,12 @@ export const MessageCard: React.FC<MessageCardProps> = ({
 
   return (
     <div
-      className={`relative flex gap-4 ${isReply ? 'mt-0' : 'mt-2'} group p-3 py-4 bg-foreground/2 dark:bg-foreground/10 hover:bg-foreground/4 dark:hover:bg-foreground/15 rounded`}
+      onClick={onSelect}
+      className={`relative flex gap-4 ${isReply ? 'mt-2' : 'mt-3'} mr-3 group p-3 py-4 border transition-all duration-200 cursor-pointer rounded-xl ${
+        isSelected
+          ? 'border-blue-500/40 dark:border-blue-400/40 bg-blue-500/10 dark:bg-blue-400/10 shadow-sm'
+          : 'border-transparent bg-foreground/2 dark:bg-foreground/10 hover:bg-foreground/4 dark:hover:bg-foreground/15'
+      }`}
     >
       {hasReplies && !isReply && (
         <div className="absolute left-[1.7rem] top-[2rem] bottom-[-1.8rem] w-0.5 bg-foreground/10 -translate-x-1/2 z-0" />
@@ -170,15 +177,10 @@ export const MessageCard: React.FC<MessageCardProps> = ({
 
         <div className="flow-root mt-1">
           {message.second !== null && message.second !== undefined && frameRate && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation()
-                onTimestampClick?.(message.second!)
-              }}
-              className="float-left select-none bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-2.5 py-0.5 mt-0.5 mr-2 rounded-sm text-xs font-mono font-bold flex items-center gap-1 transition-colors"
-            >
+            <div className="float-left select-none bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-2.5 py-0.5 mt-0.5 mr-2 rounded-sm text-xs font-mono font-bold flex items-center gap-1 border border-blue-200 dark:border-blue-800 shadow-sm">
+              <Clock className="w-3 h-3" />
               {formatTimestamp(message.second, frameRate)}
-            </button>
+            </div>
           )}
 
           {showSkeleton ? (

--- a/src/ui/components/chat/message-input.tsx
+++ b/src/ui/components/chat/message-input.tsx
@@ -8,6 +8,7 @@ import {
   ArrowUp,
   Brush,
   ChevronDown,
+  Clock,
   FileIcon,
   Minus,
   Paperclip,
@@ -24,6 +25,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
 import { useAnnotationStore } from '@/ui/stores/annotation-store'
 import type { Annotation } from '@/ui/types'
 import { useMutation } from '@tanstack/react-query'
+import { formatTimestamp } from '../viewers/utils'
 
 type UploadingFile = {
   id: string // A unique ID for the file, e.g., timestamp + name
@@ -40,6 +42,7 @@ interface ChatInputProps {
     attachmentIds: string[],
     annotations?: Annotation[],
     replyToId?: string | null,
+    second?: number | null,
   ) => void
   replyingTo?: CommentInfo | null
   onCancelReply?: () => void
@@ -48,6 +51,8 @@ interface ChatInputProps {
   initialText?: string
   hideAnnotationControl?: boolean
   disableMentions?: boolean
+  currentTime?: number
+  frameRate?: number
 }
 
 const PREDEFINED_COLORS = [
@@ -76,11 +81,14 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
       initialText = '',
       hideAnnotationControl = false,
       disableMentions = false,
+      currentTime,
+      frameRate,
     },
     ref,
   ) => {
     const [uploadingFiles, setUploadingFiles] = useState<UploadingFile[]>([])
     const [viewingFile, setViewingFile] = useState<File | null>(null)
+    const [isTimestampEnabled, setIsTimestampEnabled] = useState(true)
 
     // Annotation Store
     const {
@@ -395,7 +403,13 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
       // Allow sending if annotations exist, even if text is empty
       if (!processedText && successfulAttachmentIds.length === 0 && annotations.length === 0) return
 
-      onSendMessage(processedText, successfulAttachmentIds, annotations, replyingTo?.id)
+      onSendMessage(
+        processedText,
+        successfulAttachmentIds,
+        annotations,
+        replyingTo?.id,
+        isTimestampEnabled ? currentTime : undefined,
+      )
 
       // Reset editor
       editorRef.current.innerHTML = ''
@@ -566,6 +580,15 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
           </div>
         )}
 
+        {isTimestampEnabled && currentTime !== undefined && frameRate !== undefined && (
+          <div className="px-4 pt-3 flex">
+            <div className="bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-3 py-1 rounded-full text-xs font-mono font-bold flex items-center gap-1.5 border border-blue-200 dark:border-blue-800 shadow-sm animate-in fade-in zoom-in duration-200">
+              <Clock className="w-3 h-3" />
+              {formatTimestamp(currentTime, frameRate)}
+            </div>
+          </div>
+        )}
+
         <div className="w-full px-4 pt-1 pb-1">
           <div
             ref={editorRef}
@@ -679,6 +702,15 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
                 multiple
                 onChange={handleFileSelect}
               />
+              <Button
+                onClick={() => setIsTimestampEnabled(!isTimestampEnabled)}
+                variant={isTimestampEnabled ? 'secondary' : 'ghost'}
+                size="icon"
+                className={`p-2 rounded-full cursor-pointer ${isTimestampEnabled ? 'text-blue-600 bg-blue-50 dark:bg-blue-900/20' : ''}`}
+                title={isTimestampEnabled ? 'Disable Timestamp' : 'Enable Timestamp'}
+              >
+                <Clock className="w-4 h-4" />
+              </Button>
               <Button
                 onClick={() => fileInputRef.current?.click()}
                 className="p-2 rounded-full cursor-pointer"

--- a/src/ui/components/chat/message-input.tsx
+++ b/src/ui/components/chat/message-input.tsx
@@ -709,15 +709,17 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
                 multiple
                 onChange={handleFileSelect}
               />
-              <Button
-                onClick={() => setIsTimestampEnabled(!isTimestampEnabled)}
-                variant={isTimestampEnabled ? 'secondary' : 'ghost'}
-                size="icon"
-                className={`p-2 rounded-full cursor-pointer ${isTimestampEnabled ? 'text-blue-600 bg-blue-50 dark:bg-blue-900/20' : ''}`}
-                title={isTimestampEnabled ? 'Disable Timestamp' : 'Enable Timestamp'}
-              >
-                <Clock className="w-4 h-4" />
-              </Button>
+              {currentTime !== undefined && frameRate !== undefined && (
+                <Button
+                  onClick={() => setIsTimestampEnabled(!isTimestampEnabled)}
+                  variant={isTimestampEnabled ? 'secondary' : 'ghost'}
+                  size="icon"
+                  className={`p-2 rounded-full cursor-pointer ${isTimestampEnabled ? 'text-blue-600 bg-blue-50 dark:bg-blue-900/20' : ''}`}
+                  title={isTimestampEnabled ? 'Disable Timestamp' : 'Enable Timestamp'}
+                >
+                  <Clock className="w-4 h-4" />
+                </Button>
+              )}
               <Button
                 onClick={() => fileInputRef.current?.click()}
                 className="p-2 rounded-full cursor-pointer"

--- a/src/ui/components/chat/message-input.tsx
+++ b/src/ui/components/chat/message-input.tsx
@@ -1,8 +1,10 @@
-import { client } from '@/ui/api/client'
-import type { CommentInfo } from '@/dtos/asset'
-import type { UserInfo } from '@/dtos/team'
+import type { CommentInfo, PostAttachmentRequest, PostAttachmentResponse } from '@/dtos/asset'
 import type { BotInfo } from '@/dtos/project'
-import type { PostAttachmentRequest, PostAttachmentResponse } from '@/dtos/asset'
+import type { UserInfo } from '@/dtos/team'
+import { client } from '@/ui/api/client'
+import { useAnnotationStore } from '@/ui/stores/annotation-store'
+import type { Annotation } from '@/ui/types'
+import { useMutation } from '@tanstack/react-query'
 import {
   ArrowLeft,
   ArrowUp,
@@ -20,11 +22,8 @@ import {
 import React, { useCallback, useEffect, useRef, useState, type ChangeEvent } from 'react'
 import { Button } from '../ui/button'
 import { DrawAnnotation } from '../ui/icons'
-import { ProgressCircle } from '../ui/progress-circle'
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
-import { useAnnotationStore } from '@/ui/stores/annotation-store'
-import type { Annotation } from '@/ui/types'
-import { useMutation } from '@tanstack/react-query'
+import { ProgressCircle } from '../ui/progress-circle'
 import { formatTimestamp } from '../viewers/utils'
 
 type UploadingFile = {
@@ -53,6 +52,7 @@ interface ChatInputProps {
   disableMentions?: boolean
   currentTime?: number
   frameRate?: number
+  onTyping?: () => void
 }
 
 const PREDEFINED_COLORS = [
@@ -83,6 +83,7 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
       disableMentions = false,
       currentTime,
       frameRate,
+      onTyping,
     },
     ref,
   ) => {
@@ -198,6 +199,7 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
     const handleInput = () => {
       if (!editorRef.current) return
       setHasContent(!!editorRef.current.innerText.trim())
+      onTyping?.()
 
       if (disableMentions) {
         setShowMentionList(false)
@@ -580,16 +582,21 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
           </div>
         )}
 
-        {isTimestampEnabled && currentTime !== undefined && frameRate !== undefined && (
-          <div className="px-4 pt-3 flex">
-            <div className="bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-3 py-1 rounded-full text-xs font-mono font-bold flex items-center gap-1.5 border border-blue-200 dark:border-blue-800 shadow-sm animate-in fade-in zoom-in duration-200">
-              <Clock className="w-3 h-3" />
+        <div
+          onClick={() => editorRef.current?.focus()}
+          className="w-full px-4 pt-1 pb-1 cursor-text flow-root max-h-60 overflow-y-auto"
+        >
+          {isTimestampEnabled && currentTime !== undefined && frameRate !== undefined && (
+            <div
+              onClick={(e) => {
+                e.stopPropagation()
+                editorRef.current?.focus()
+              }}
+              className="float-left select-none bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 px-2.5 py-0.5 mt-3 mr-2 rounded-sm text-xs font-mono font-bold flex items-center gap-1 cursor-text"
+            >
               {formatTimestamp(currentTime, frameRate)}
             </div>
-          </div>
-        )}
-
-        <div className="w-full px-4 pt-1 pb-1">
+          )}
           <div
             ref={editorRef}
             contentEditable={!isDrawing}
@@ -599,7 +606,7 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
             data-placeholder={
               isDrawing ? 'Drawing active...' : replyingTo ? 'Reply...' : 'Message...'
             }
-            className="w-full bg-transparent border-none focus:ring-0 resize-none max-h-60 min-h-[40px] leading-relaxed py-2 focus:outline-none overflow-y-auto"
+            className={`bg-transparent border-none focus:ring-0 resize-none min-h-[40px] leading-relaxed py-2 focus:outline-none block ${isTimestampEnabled && currentTime !== undefined && frameRate !== undefined && !hasContent ? 'pl-[120px]' : ''}`}
           />
         </div>
 

--- a/src/ui/components/file-viewer-right-sidebar.tsx
+++ b/src/ui/components/file-viewer-right-sidebar.tsx
@@ -331,7 +331,7 @@ export function FileViewerRightSidebar({
           </div>
         </div>
       )}
-      <Tabs defaultValue="comments" className="p-4 flex-1 flex flex-col px-2 min-h-0">
+      <Tabs defaultValue="comments" className="p-1 flex-1 flex flex-col px-2 min-h-0">
         <TabsList className="w-full shrink-0">
           <TabsTrigger value="comments" className="flex-1">
             Comments
@@ -352,7 +352,11 @@ export function FileViewerRightSidebar({
                     onReply={setReplyingTo}
                     onViewAttachment={setViewingAttachment}
                     hasReplies={!!comment.replies?.length}
-                    frameRate={file?.media?.metadata?.frameRate || 30}
+                    frameRate={
+                      file?.mediaType?.startsWith('video/')
+                        ? file?.media?.metadata?.frameRate || 30
+                        : undefined
+                    }
                     isSelected={selectedCommentId === comment.id}
                     onSelect={() => {
                       onCommentSelect?.(comment)
@@ -369,7 +373,11 @@ export function FileViewerRightSidebar({
                         onViewAttachment={setViewingAttachment}
                         hasReplies={false}
                         isLastReply={index === (comment.replies?.length ?? 0) - 1}
-                        frameRate={file?.media?.metadata?.frameRate || 30}
+                        frameRate={
+                          file?.mediaType?.startsWith('video/')
+                            ? file?.media?.metadata?.frameRate || 30
+                            : undefined
+                        }
                         isSelected={selectedCommentId === reply.id}
                         onSelect={() => {
                           onCommentSelect?.(reply)
@@ -398,8 +406,12 @@ export function FileViewerRightSidebar({
                   bots={enabledBots}
                   hideAnnotationControl={hideAnnotationControl}
                   disableMentions={isPublic}
-                  currentTime={currentTime}
-                  frameRate={file?.media?.metadata?.frameRate || 30}
+                  currentTime={file?.mediaType?.startsWith('video/') ? currentTime : undefined}
+                  frameRate={
+                    file?.mediaType?.startsWith('video/')
+                      ? file?.media?.metadata?.frameRate || 30
+                      : undefined
+                  }
                   onTyping={onTyping}
                 />
               </GuestIdentityPopup>

--- a/src/ui/components/file-viewer-right-sidebar.tsx
+++ b/src/ui/components/file-viewer-right-sidebar.tsx
@@ -29,6 +29,7 @@ interface FileViewerRightSidebarProps {
   shareId?: string
   currentTime?: number
   onTyping?: () => void
+  selectedCommentId?: string | null
 }
 
 export function FileViewerRightSidebar({
@@ -45,6 +46,7 @@ export function FileViewerRightSidebar({
   shareId,
   currentTime,
   onTyping,
+  selectedCommentId,
 }: FileViewerRightSidebarProps) {
   const { fields, setFields } = useFieldStore()
   const queryClient = useQueryClient()
@@ -52,7 +54,6 @@ export function FileViewerRightSidebar({
   const [replyingTo, setReplyingTo] = useState<CommentInfo | null>(null)
   const [viewingAttachment, setViewingAttachment] = useState<AttachmentInfo | null>(null)
   const [isGuestPopupOpen, setIsGuestPopupOpen] = useState(false)
-  const [selectedCommentId, setSelectedCommentId] = useState<string | null>(null)
   const [pendingComment, setPendingComment] = useState<{
     text: string
     attachmentIds: string[]
@@ -354,7 +355,6 @@ export function FileViewerRightSidebar({
                     frameRate={file?.media?.metadata?.frameRate || 30}
                     isSelected={selectedCommentId === comment.id}
                     onSelect={() => {
-                      setSelectedCommentId(comment.id!)
                       onCommentSelect?.(comment)
                     }}
                   />
@@ -372,7 +372,6 @@ export function FileViewerRightSidebar({
                         frameRate={file?.media?.metadata?.frameRate || 30}
                         isSelected={selectedCommentId === reply.id}
                         onSelect={() => {
-                          setSelectedCommentId(reply.id!)
                           onCommentSelect?.(reply)
                         }}
                       />

--- a/src/ui/components/file-viewer-right-sidebar.tsx
+++ b/src/ui/components/file-viewer-right-sidebar.tsx
@@ -28,6 +28,7 @@ interface FileViewerRightSidebarProps {
   isPublic?: boolean
   shareId?: string
   currentTime?: number
+  onTyping?: () => void
 }
 
 export function FileViewerRightSidebar({
@@ -43,6 +44,7 @@ export function FileViewerRightSidebar({
   isPublic = false,
   shareId,
   currentTime,
+  onTyping,
 }: FileViewerRightSidebarProps) {
   const { fields, setFields } = useFieldStore()
   const queryClient = useQueryClient()
@@ -389,6 +391,7 @@ export function FileViewerRightSidebar({
                   disableMentions={isPublic}
                   currentTime={currentTime}
                   frameRate={file?.media?.metadata?.frameRate || 30}
+                  onTyping={onTyping}
                 />
               </GuestIdentityPopup>
             </div>

--- a/src/ui/components/file-viewer-right-sidebar.tsx
+++ b/src/ui/components/file-viewer-right-sidebar.tsx
@@ -1,19 +1,19 @@
-import { type FieldInfo as MetadataFieldInfo } from '@/dtos/metadata'
-import { client } from '@/ui/api/client'
 import type { AssetInfo, AttachmentInfo, CommentInfo, FieldValueInfo } from '@/dtos/asset'
+import { type FieldInfo as MetadataFieldInfo } from '@/dtos/metadata'
 import type { UserInfo } from '@/dtos/team'
+import { client } from '@/ui/api/client'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/components/ui/tabs'
 import { useFieldStore } from '@/ui/stores/fields'
-import { useInfiniteQuery, useQueryClient, useQuery, useMutation } from '@tanstack/react-query'
+import type { Annotation } from '@/ui/types'
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { XIcon } from 'lucide-react'
 import React, { useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { MessageCard } from './chat/message-card'
 import { ChatInput } from './chat/message-input'
 import FieldRenderer from './field-renderer'
-import { ScrollArea } from './ui/scroll-area'
-import type { Annotation } from '@/ui/types'
 import { GuestIdentityPopup } from './guest-identity-popup'
+import { ScrollArea } from './ui/scroll-area'
 
 interface FileViewerRightSidebarProps {
   teamId: string
@@ -338,9 +338,9 @@ export function FileViewerRightSidebar({
             Fields
           </TabsTrigger>
         </TabsList>
-        <TabsContent value="comments" className="flex-1 flex flex-col overflow-hidden min-h-0 mt-4">
-          <ScrollArea className="flex-1 px-4">
-            <div className="space-y-4">
+        <TabsContent value="comments" className="flex-1 flex flex-col overflow-hidden min-h-0 mt-0">
+          <ScrollArea className="flex-1">
+            <div className="space-y-2">
               {comments.map((comment) => (
                 <div key={comment.id} onClick={() => onCommentSelect?.(comment)}>
                   <MessageCard

--- a/src/ui/components/file-viewer-right-sidebar.tsx
+++ b/src/ui/components/file-viewer-right-sidebar.tsx
@@ -52,6 +52,7 @@ export function FileViewerRightSidebar({
   const [replyingTo, setReplyingTo] = useState<CommentInfo | null>(null)
   const [viewingAttachment, setViewingAttachment] = useState<AttachmentInfo | null>(null)
   const [isGuestPopupOpen, setIsGuestPopupOpen] = useState(false)
+  const [selectedCommentId, setSelectedCommentId] = useState<string | null>(null)
   const [pendingComment, setPendingComment] = useState<{
     text: string
     attachmentIds: string[]
@@ -340,9 +341,9 @@ export function FileViewerRightSidebar({
         </TabsList>
         <TabsContent value="comments" className="flex-1 flex flex-col overflow-hidden min-h-0 mt-0">
           <ScrollArea className="flex-1">
-            <div className="space-y-2">
+            <div className="space-y-4">
               {comments.map((comment) => (
-                <div key={comment.id} onClick={() => onCommentSelect?.(comment)}>
+                <div key={comment.id}>
                   <MessageCard
                     teamId={teamId}
                     message={comment}
@@ -351,22 +352,31 @@ export function FileViewerRightSidebar({
                     onViewAttachment={setViewingAttachment}
                     hasReplies={!!comment.replies?.length}
                     frameRate={file?.media?.metadata?.frameRate || 30}
-                    onTimestampClick={(sec) => onCommentSelect?.({ ...comment, second: sec })}
+                    isSelected={selectedCommentId === comment.id}
+                    onSelect={() => {
+                      setSelectedCommentId(comment.id!)
+                      onCommentSelect?.(comment)
+                    }}
                   />
                   {comment.replies?.map((reply, index) => (
-                    <MessageCard
-                      teamId={teamId}
-                      isReply={true}
-                      key={reply.id}
-                      message={reply}
-                      getUser={getUser}
-                      onReply={setReplyingTo}
-                      onViewAttachment={setViewingAttachment}
-                      hasReplies={false}
-                      isLastReply={index === (comment.replies?.length ?? 0) - 1}
-                      frameRate={file?.media?.metadata?.frameRate || 30}
-                      onTimestampClick={(sec) => onCommentSelect?.({ ...reply, second: sec })}
-                    />
+                    <div key={reply.id}>
+                      <MessageCard
+                        teamId={teamId}
+                        isReply={true}
+                        message={reply}
+                        getUser={getUser}
+                        onReply={setReplyingTo}
+                        onViewAttachment={setViewingAttachment}
+                        hasReplies={false}
+                        isLastReply={index === (comment.replies?.length ?? 0) - 1}
+                        frameRate={file?.media?.metadata?.frameRate || 30}
+                        isSelected={selectedCommentId === reply.id}
+                        onSelect={() => {
+                          setSelectedCommentId(reply.id!)
+                          onCommentSelect?.(reply)
+                        }}
+                      />
+                    </div>
                   ))}
                 </div>
               ))}

--- a/src/ui/components/file-viewer-right-sidebar.tsx
+++ b/src/ui/components/file-viewer-right-sidebar.tsx
@@ -27,6 +27,7 @@ interface FileViewerRightSidebarProps {
   publicFields?: MetadataFieldInfo[]
   isPublic?: boolean
   shareId?: string
+  currentTime?: number
 }
 
 export function FileViewerRightSidebar({
@@ -41,6 +42,7 @@ export function FileViewerRightSidebar({
   publicFields,
   isPublic = false,
   shareId,
+  currentTime,
 }: FileViewerRightSidebarProps) {
   const { fields, setFields } = useFieldStore()
   const queryClient = useQueryClient()
@@ -53,6 +55,7 @@ export function FileViewerRightSidebar({
     attachmentIds: string[]
     annotations?: Annotation[]
     replyToId?: string | null
+    second?: number | null
   } | null>(null)
 
   const { data: apiFields } = useQuery({
@@ -139,12 +142,14 @@ export function FileViewerRightSidebar({
       annotations,
       replyToId,
       guestUserId,
+      second,
     }: {
       text: string
       attachmentIds: string[]
       annotations?: Annotation[]
       replyToId?: string | null
       guestUserId?: string
+      second?: number | null
     }) => {
       if (isPublic) {
         const password = localStorage.getItem(`share_pwd_${shareId}`) || ''
@@ -156,6 +161,7 @@ export function FileViewerRightSidebar({
               attachmentIds: attachmentIds,
               replyToId: replyToId ?? undefined,
               annotations: annotations,
+              second: second ?? undefined,
             },
           },
           {
@@ -175,6 +181,7 @@ export function FileViewerRightSidebar({
             attachmentIds: attachmentIds,
             replyToId: replyToId ?? undefined,
             annotations: annotations,
+            second: second ?? undefined,
           },
         })
         if (!res.ok) throw new Error('Failed to create comment')
@@ -225,6 +232,7 @@ export function FileViewerRightSidebar({
     attachmentIds: string[],
     annotations?: Annotation[],
     replyToId?: string | null,
+    second?: number | null,
   ) => {
     if (!file?.id) return
 
@@ -240,16 +248,16 @@ export function FileViewerRightSidebar({
         console.log('[handleSendMessage] guestUserId from storage:', guestUserId)
         if (!guestUserId) {
           console.log('[handleSendMessage] no guest ID, opening popup')
-          setPendingComment({ text, attachmentIds, annotations, replyToId })
+          setPendingComment({ text, attachmentIds, annotations, replyToId, second })
           setIsGuestPopupOpen(true)
           return
         }
-        createComment({ text, attachmentIds, annotations, replyToId, guestUserId })
+        createComment({ text, attachmentIds, annotations, replyToId, guestUserId, second })
       } else {
-        createComment({ text, attachmentIds, annotations, replyToId })
+        createComment({ text, attachmentIds, annotations, replyToId, second })
       }
     } else {
-      createComment({ text, attachmentIds, annotations, replyToId })
+      createComment({ text, attachmentIds, annotations, replyToId, second })
     }
     setReplyingTo(null)
   }
@@ -340,6 +348,8 @@ export function FileViewerRightSidebar({
                     onReply={setReplyingTo}
                     onViewAttachment={setViewingAttachment}
                     hasReplies={!!comment.replies?.length}
+                    frameRate={file?.media?.metadata?.frameRate || 30}
+                    onTimestampClick={(sec) => onCommentSelect?.({ ...comment, second: sec })}
                   />
                   {comment.replies?.map((reply, index) => (
                     <MessageCard
@@ -352,6 +362,8 @@ export function FileViewerRightSidebar({
                       onViewAttachment={setViewingAttachment}
                       hasReplies={false}
                       isLastReply={index === (comment.replies?.length ?? 0) - 1}
+                      frameRate={file?.media?.metadata?.frameRate || 30}
+                      onTimestampClick={(sec) => onCommentSelect?.({ ...reply, second: sec })}
                     />
                   ))}
                 </div>
@@ -375,6 +387,8 @@ export function FileViewerRightSidebar({
                   bots={enabledBots}
                   hideAnnotationControl={hideAnnotationControl}
                   disableMentions={isPublic}
+                  currentTime={currentTime}
+                  frameRate={file?.media?.metadata?.frameRate || 30}
                 />
               </GuestIdentityPopup>
             </div>

--- a/src/ui/components/file-viewer.tsx
+++ b/src/ui/components/file-viewer.tsx
@@ -16,10 +16,18 @@ type FileViewerProps = {
   videoRef?: RefObject<Player | null>
   onPlay?: () => void
   onPause?: () => void
+  onTimeUpdate?: (time: number) => void
   annotations?: Annotation[]
 }
 
-export function FileViewer({ file, videoRef, onPlay, onPause, annotations }: FileViewerProps) {
+export function FileViewer({
+  file,
+  videoRef,
+  onPlay,
+  onPause,
+  onTimeUpdate,
+  annotations,
+}: FileViewerProps) {
   const { width: screenWidth } = useScreenSize()
   const isImage = file.mediaType?.startsWith('image/')
   const isVideo = file.mediaType?.startsWith('video/')
@@ -186,6 +194,7 @@ export function FileViewer({ file, videoRef, onPlay, onPause, annotations }: Fil
           playerRef={videoRef}
           onPlay={onPlay}
           onPause={onPause}
+          onTimeUpdate={onTimeUpdate}
           annotations={displayAnnotations}
         />
       )}

--- a/src/ui/components/public-share-manager.tsx
+++ b/src/ui/components/public-share-manager.tsx
@@ -89,6 +89,7 @@ export function PublicShareManager({
   const [isRightSidebarCollapsed] = useState(false)
   const videoRef = useRef<Player | null>(null)
   const [annotations, setAnnotations] = useState<Annotation[]>([])
+  const [currentTime, setCurrentTime] = useState(0)
 
   const {
     data: foldersData,
@@ -257,11 +258,19 @@ export function PublicShareManager({
     const newAnnotations = comment.annotations as Annotation[]
     if (newAnnotations && newAnnotations.length > 0) {
       setAnnotations(newAnnotations)
+    } else {
+      setAnnotations([])
+    }
+
+    if (comment.second !== null && comment.second !== undefined) {
+      if (videoRef.current) {
+        videoRef.current.currentTime(comment.second)
+        videoRef.current.pause()
+      }
+    } else if (newAnnotations && newAnnotations.length > 0) {
       if (videoRef.current) {
         videoRef.current.pause()
       }
-    } else {
-      setAnnotations([])
     }
   }
 
@@ -373,6 +382,7 @@ export function PublicShareManager({
                 file={viewingFileData}
                 videoRef={videoRef}
                 onPlay={handlePlay}
+                onTimeUpdate={setCurrentTime}
                 annotations={annotations}
               />
             )}
@@ -430,6 +440,7 @@ export function PublicShareManager({
                 onCommentSelect={handleCommentSelect}
                 isPublic={true}
                 shareId={shareInfo.id}
+                currentTime={currentTime}
               />
             </div>
           </>

--- a/src/ui/components/public-share-manager.tsx
+++ b/src/ui/components/public-share-manager.tsx
@@ -441,6 +441,11 @@ export function PublicShareManager({
                 isPublic={true}
                 shareId={shareInfo.id}
                 currentTime={currentTime}
+                onTyping={() => {
+                  if (videoRef.current) {
+                    videoRef.current.pause()
+                  }
+                }}
               />
             </div>
           </>

--- a/src/ui/components/public-share-manager.tsx
+++ b/src/ui/components/public-share-manager.tsx
@@ -90,6 +90,7 @@ export function PublicShareManager({
   const videoRef = useRef<Player | null>(null)
   const [annotations, setAnnotations] = useState<Annotation[]>([])
   const [currentTime, setCurrentTime] = useState(0)
+  const [selectedCommentId, setSelectedCommentId] = useState<string | null>(null)
 
   const {
     data: foldersData,
@@ -255,6 +256,7 @@ export function PublicShareManager({
   }
 
   const handleCommentSelect = (comment: CommentInfo) => {
+    setSelectedCommentId(comment.id || null)
     const newAnnotations = comment.annotations as Annotation[]
     if (newAnnotations && newAnnotations.length > 0) {
       setAnnotations(newAnnotations)
@@ -276,6 +278,7 @@ export function PublicShareManager({
 
   const handlePlay = () => {
     setAnnotations([])
+    setSelectedCommentId(null)
   }
 
   const { setProjectState, clearProjectState } = useTopNavStore()
@@ -446,6 +449,7 @@ export function PublicShareManager({
                     videoRef.current.pause()
                   }
                 }}
+                selectedCommentId={selectedCommentId}
               />
             </div>
           </>

--- a/src/ui/components/viewers/utils.ts
+++ b/src/ui/components/viewers/utils.ts
@@ -10,6 +10,16 @@ export const formatTime = (seconds: number): string => {
   return `${mm}:${ss}`
 }
 
+export const formatTimestamp = (seconds: number, fps: number): string => {
+  if (isNaN(seconds)) return '00:00:00:00'
+  const hh = Math.floor(seconds / 3600)
+  const mm = Math.floor((seconds % 3600) / 60)
+  const ss = Math.floor(seconds % 60)
+  const ff = Math.floor((seconds % 1) * fps)
+
+  return `${hh.toString().padStart(2, '0')}:${mm.toString().padStart(2, '0')}:${ss.toString().padStart(2, '0')}:${ff.toString().padStart(2, '0')}`
+}
+
 export const formatFrame = (seconds: number, fps: number): number => {
   if (isNaN(seconds) || !fps) return 0
   return Math.floor(seconds * fps)

--- a/src/ui/components/viewers/video-player.tsx
+++ b/src/ui/components/viewers/video-player.tsx
@@ -51,6 +51,7 @@ interface VideoPlayerProps {
   playerRef?: React.RefObject<Player | null>
   onPlay?: () => void
   onPause?: () => void
+  onTimeUpdate?: (time: number) => void
   annotations?: Annotation[]
 }
 
@@ -299,6 +300,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   playerRef: passedPlayerRef,
   onPlay,
   onPause,
+  onTimeUpdate,
   annotations,
 }) => {
   const localPlayerRef = useRef<Player | null>(null)
@@ -494,6 +496,10 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         duration: duration || prev.duration,
         progress: duration > 0 ? (current / duration) * 100 : 0,
       }))
+
+      if (onTimeUpdate) {
+        onTimeUpdate(current)
+      }
     })
 
     player.on('volumechange', () => {

--- a/src/ui/globals.css
+++ b/src/ui/globals.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&display=swap');
+
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
@@ -67,6 +69,8 @@
 }
 
 @theme inline {
+  --font-sans: 'Plus Jakarta Sans', var(--font-sans);
+
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -100,6 +104,8 @@
   --color-sidebar-ring: var(--sidebar-ring);
 
   --animate-upload-breathing: upload-breathing 2s cubic-bezier(0.4, 0, 0.6, 1) infinite alternate;
+  --animate-drift-slow: drift-slow 15s ease-in-out infinite alternate;
+  --animate-drift-medium: drift-medium 12s ease-in-out infinite alternate;
 
   @keyframes upload-breathing {
     0% {
@@ -109,6 +115,30 @@
     100% {
       filter: drop-shadow(0 0 2px rgb(var(--primary))) drop-shadow(0 0 4px rgb(var(--primary)));
       transform: scale(1.05);
+    }
+  }
+
+  @keyframes drift-slow {
+    0% {
+      transform: translate(0px, 0px) scale(1);
+    }
+    50% {
+      transform: translate(40px, -60px) scale(1.15);
+    }
+    100% {
+      transform: translate(-30px, 30px) scale(0.9);
+    }
+  }
+
+  @keyframes drift-medium {
+    0% {
+      transform: translate(0px, 0px) scale(1.1);
+    }
+    50% {
+      transform: translate(-50px, 40px) scale(0.85);
+    }
+    100% {
+      transform: translate(30px, -30px) scale(1.05);
     }
   }
 }

--- a/src/ui/routes/__root.tsx
+++ b/src/ui/routes/__root.tsx
@@ -8,10 +8,10 @@ import { useAuthStore } from '@/ui/stores/auth'
 import { useTeamContextStore } from '@/ui/stores/team-context'
 import { useUploadStore } from '@/ui/stores/upload'
 import {
-    createRootRouteWithContext,
-    Outlet,
-    useNavigate,
-    useRouterState,
+  createRootRouteWithContext,
+  Outlet,
+  useNavigate,
+  useRouterState,
 } from '@tanstack/react-router'
 import { useEffect } from 'react'
 

--- a/src/ui/routes/login.tsx
+++ b/src/ui/routes/login.tsx
@@ -100,22 +100,25 @@ function LoginPage() {
           {/* Marketing Copy / Feature Points */}
           <div className="relative my-8 md:my-0 space-y-6">
             <h2 className="text-3xl font-extrabold tracking-tight leading-tight text-zinc-900 dark:text-zinc-50">
-              Create assets.
+              One workspace
+              <br />
+              for all your
               <br />
               <span className="bg-gradient-to-r from-rose-500 to-orange-500 bg-clip-text text-transparent">
-                Organize workflows.
+                creative assets.
               </span>
             </h2>
             <p className="text-zinc-600 dark:text-zinc-400 text-sm leading-relaxed max-w-sm">
-              The ultimate collaboration hub for your design assets, code resources, and team
-              communication.
+              Upload and index your files, enrich them with custom metadata schemas, draw
+              annotations directly on media, and gather instant feedback — all in one modern
+              workspace built for creators.
             </p>
 
             <ul className="space-y-3.5 pt-4">
               {[
-                'Instant asset uploads & indexing',
-                'Custom metadata & metadata schemas',
-                'Advanced team permission controls',
+                'Instant asset uploads & high-fidelity media players',
+                'Custom metadata schemas & drawing canvas reviews',
+                'Frictionless team workspaces & secure sharing',
               ].map((text, i) => (
                 <li
                   key={i}

--- a/src/ui/routes/login.tsx
+++ b/src/ui/routes/login.tsx
@@ -67,7 +67,7 @@ function LoginPage() {
 
   if (isSignupInfoLoading) {
     return (
-      <div className="flex items-center justify-center min-h-screen bg-zinc-50 dark:bg-zinc-950">
+      <div className="flex items-center justify-center min-h-screen bg-zinc-100/80 dark:bg-black">
         <div className="relative flex flex-col items-center">
           <ShumaiLogo className="h-16 w-16 animate-pulse mb-4 text-rose-500 shadow-xl rounded-2xl" />
           <Loader2 className="h-6 w-6 animate-spin text-rose-500/70" />
@@ -77,15 +77,15 @@ function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen w-full flex items-center justify-center p-4 md:p-8 bg-zinc-50 dark:bg-zinc-950 font-sans overflow-hidden relative font-sans">
+    <div className="min-h-screen w-full flex items-center justify-center p-4 md:p-8 bg-zinc-100/80 dark:bg-black font-sans overflow-hidden relative font-sans">
       {/* Drifting Background Mesh Blobs */}
       <div className="bg-rose-500/10 dark:bg-rose-600/5 w-[600px] h-[600px] rounded-full blur-[140px] absolute top-[-10%] left-[-10%] animate-drift-slow" />
       <div className="bg-orange-500/10 dark:bg-orange-600/5 w-[600px] h-[600px] rounded-full blur-[140px] absolute bottom-[-10%] right-[-10%] animate-drift-medium" />
 
       {/* Main Glassmorphic Split-Pane Card */}
-      <div className="relative max-w-4xl w-full flex flex-col md:flex-row rounded-3xl border border-zinc-200/50 dark:border-zinc-800/40 shadow-2xl bg-white/70 dark:bg-zinc-900/60 backdrop-blur-xl overflow-hidden min-h-[580px] z-10 transition-all duration-300 hover:shadow-rose-500/5">
+      <div className="relative max-w-4xl w-full flex flex-col md:flex-row rounded-3xl border border-zinc-200 dark:border-zinc-800 shadow-2xl bg-white dark:bg-zinc-900 overflow-hidden min-h-[580px] z-10 transition-all duration-300 hover:shadow-rose-500/5">
         {/* Left Pane (Brand Showcase) */}
-        <div className="w-full md:w-1/2 bg-gradient-to-br from-rose-500/10 via-orange-500/5 to-transparent p-8 md:p-12 flex flex-col justify-between border-b md:border-b-0 md:border-r border-zinc-200/50 dark:border-zinc-800/40 relative overflow-hidden">
+        <div className="w-full md:w-1/2 bg-gradient-to-br from-rose-500/15 via-orange-500/10 to-amber-500/5 dark:from-rose-950/30 dark:via-orange-950/15 dark:to-zinc-900/40 p-8 md:p-12 flex flex-col justify-between border-b md:border-b-0 md:border-r border-zinc-200 dark:border-zinc-800 relative overflow-hidden">
           {/* Subtle Grid Overlay */}
           <div className="absolute inset-0 bg-[linear-gradient(to_right,#8080800a_1px,transparent_1px),linear-gradient(to_bottom,#8080800a_1px,transparent_1px)] bg-[size:14px_24px] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_0%,#000_70%,transparent_100%)] pointer-events-none" />
 

--- a/src/ui/routes/login.tsx
+++ b/src/ui/routes/login.tsx
@@ -1,14 +1,6 @@
 import { client } from '@/ui/api/client'
 import { useQuery } from '@tanstack/react-query'
 import { Button } from '@/ui/components/ui/button'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/ui/components/ui/card'
 import { Input } from '@/ui/components/ui/input'
 import { Label } from '@/ui/components/ui/label'
 import { useAuthStore } from '@/ui/stores/auth'
@@ -18,6 +10,8 @@ import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { signIn } from '@/ui/lib/auth-client'
+import { Loader2, Mail, Lock, ArrowRight, LogIn, CheckCircle2 } from 'lucide-react'
+import { ShumaiLogo } from '@/ui/components/ui/icons'
 
 const loginSchema = z.object({
   email: z.string().email('Invalid email address'),
@@ -32,7 +26,7 @@ function LoginPage() {
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
-  const { data: signupInfo } = useQuery({
+  const { data: signupInfo, isLoading: isSignupInfoLoading } = useQuery({
     queryKey: ['/signup-info'],
     queryFn: async () => {
       const res = await client.api['signup-info'].$get()
@@ -71,52 +65,173 @@ function LoginPage() {
     }
   }
 
+  if (isSignupInfoLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-zinc-50 dark:bg-zinc-950">
+        <div className="relative flex flex-col items-center">
+          <ShumaiLogo className="h-16 w-16 animate-pulse mb-4 text-rose-500 shadow-xl rounded-2xl" />
+          <Loader2 className="h-6 w-6 animate-spin text-rose-500/70" />
+        </div>
+      </div>
+    )
+  }
+
   return (
-    <div className="flex items-center justify-center min-h-screen">
-      <Card className="w-full max-w-sm">
-        <CardHeader>
-          <CardTitle>Login</CardTitle>
-          <CardDescription>Enter your credentials to access your account.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-            {error && <p className="text-red-500 text-sm text-center">{error}</p>}
+    <div className="min-h-screen w-full flex items-center justify-center p-4 md:p-8 bg-zinc-50 dark:bg-zinc-950 font-sans overflow-hidden relative font-sans">
+      {/* Drifting Background Mesh Blobs */}
+      <div className="bg-rose-500/10 dark:bg-rose-600/5 w-[600px] h-[600px] rounded-full blur-[140px] absolute top-[-10%] left-[-10%] animate-drift-slow" />
+      <div className="bg-orange-500/10 dark:bg-orange-600/5 w-[600px] h-[600px] rounded-full blur-[140px] absolute bottom-[-10%] right-[-10%] animate-drift-medium" />
+
+      {/* Main Glassmorphic Split-Pane Card */}
+      <div className="relative max-w-4xl w-full flex flex-col md:flex-row rounded-3xl border border-zinc-200/50 dark:border-zinc-800/40 shadow-2xl bg-white/70 dark:bg-zinc-900/60 backdrop-blur-xl overflow-hidden min-h-[580px] z-10 transition-all duration-300 hover:shadow-rose-500/5">
+        {/* Left Pane (Brand Showcase) */}
+        <div className="w-full md:w-1/2 bg-gradient-to-br from-rose-500/10 via-orange-500/5 to-transparent p-8 md:p-12 flex flex-col justify-between border-b md:border-b-0 md:border-r border-zinc-200/50 dark:border-zinc-800/40 relative overflow-hidden">
+          {/* Subtle Grid Overlay */}
+          <div className="absolute inset-0 bg-[linear-gradient(to_right,#8080800a_1px,transparent_1px),linear-gradient(to_bottom,#8080800a_1px,transparent_1px)] bg-[size:14px_24px] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_0%,#000_70%,transparent_100%)] pointer-events-none" />
+
+          {/* Logo & Brand */}
+          <div className="relative flex items-center gap-3">
+            <ShumaiLogo className="h-12 w-12 shadow-lg shadow-rose-500/10 rounded-2xl transition-transform duration-500 hover:scale-105" />
+            <span className="text-xl font-extrabold tracking-tight bg-gradient-to-r from-rose-500 via-orange-500 to-amber-500 bg-clip-text text-transparent">
+              Shumai
+            </span>
+          </div>
+
+          {/* Marketing Copy / Feature Points */}
+          <div className="relative my-8 md:my-0 space-y-6">
+            <h2 className="text-3xl font-extrabold tracking-tight leading-tight text-zinc-900 dark:text-zinc-50">
+              Create assets.
+              <br />
+              <span className="bg-gradient-to-r from-rose-500 to-orange-500 bg-clip-text text-transparent">
+                Organize workflows.
+              </span>
+            </h2>
+            <p className="text-zinc-600 dark:text-zinc-400 text-sm leading-relaxed max-w-sm">
+              The ultimate collaboration hub for your design assets, code resources, and team
+              communication.
+            </p>
+
+            <ul className="space-y-3.5 pt-4">
+              {[
+                'Instant asset uploads & indexing',
+                'Custom metadata & metadata schemas',
+                'Advanced team permission controls',
+              ].map((text, i) => (
+                <li
+                  key={i}
+                  className="flex items-center gap-3 text-sm text-zinc-700 dark:text-zinc-300 font-medium"
+                >
+                  <CheckCircle2 className="w-5 h-5 text-rose-500 flex-shrink-0" />
+                  <span>{text}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Footer Label */}
+          <div className="relative pt-4 border-t border-zinc-200/30 dark:border-zinc-800/30">
+            <p className="text-xs text-zinc-500 dark:text-zinc-400 font-medium">
+              Join our community of developers and designers.
+            </p>
+          </div>
+        </div>
+
+        {/* Right Pane (Form Container) */}
+        <div className="w-full md:w-1/2 p-8 md:p-12 flex flex-col justify-center">
+          <div className="mb-8">
+            <h1 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
+              Welcome Back
+            </h1>
+            <p className="text-zinc-500 dark:text-zinc-400 text-sm mt-1">
+              Enter your credentials to access your account.
+            </p>
+          </div>
+
+          {error && (
+            <div className="mb-6 p-3 bg-red-500/10 border border-red-500/20 text-red-600 dark:text-red-400 rounded-xl text-sm text-center font-medium">
+              {error}
+            </div>
+          )}
+
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
             <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                {...form.register('email')}
-                placeholder="you@example.com"
-                type="email"
-              />
+              <Label
+                htmlFor="email"
+                className="text-xs font-semibold text-zinc-600 dark:text-zinc-400 tracking-wide uppercase"
+              >
+                Email Address
+              </Label>
+              <div className="relative group">
+                <Mail className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-400 dark:text-zinc-600 transition-colors group-focus-within:text-rose-500" />
+                <Input
+                  id="email"
+                  {...form.register('email')}
+                  placeholder="you@example.com"
+                  type="email"
+                  className="pl-10.5 h-11 border-zinc-200 dark:border-zinc-800 focus-visible:ring-rose-500/50 focus-visible:border-rose-500 rounded-xl transition-all shadow-sm"
+                />
+              </div>
               {form.formState.errors.email && (
-                <p className="text-red-500 text-sm">{form.formState.errors.email.message}</p>
+                <p className="text-red-500 text-xs font-medium">
+                  {form.formState.errors.email.message}
+                </p>
               )}
             </div>
+
             <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
-              <Input
-                id="password"
-                type="password"
-                {...form.register('password')}
-                placeholder="Your password"
-              />
+              <Label
+                htmlFor="password"
+                className="text-xs font-semibold text-zinc-600 dark:text-zinc-400 tracking-wide uppercase"
+              >
+                Password
+              </Label>
+              <div className="relative group">
+                <Lock className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-400 dark:text-zinc-600 transition-colors group-focus-within:text-rose-500" />
+                <Input
+                  id="password"
+                  type="password"
+                  {...form.register('password')}
+                  placeholder="Your password"
+                  className="pl-10.5 h-11 border-zinc-200 dark:border-zinc-800 focus-visible:ring-rose-500/50 focus-visible:border-rose-500 rounded-xl transition-all shadow-sm"
+                />
+              </div>
               {form.formState.errors.password && (
-                <p className="text-red-500 text-sm">{form.formState.errors.password.message}</p>
+                <p className="text-red-500 text-xs font-medium">
+                  {form.formState.errors.password.message}
+                </p>
               )}
             </div>
-            <Button type="submit" className="w-full" disabled={loading}>
-              {loading ? 'Logging in...' : 'Login'}
+
+            <Button
+              type="submit"
+              className="w-full h-11 bg-gradient-to-r from-rose-500 to-orange-500 hover:from-rose-600 hover:to-orange-600 text-white font-semibold rounded-xl shadow-md shadow-rose-500/10 hover:shadow-rose-500/20 active:scale-[0.98] transition-all flex items-center justify-center gap-2 border-0"
+              disabled={loading}
+            >
+              {loading ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Logging in...
+                </>
+              ) : (
+                <>
+                  <LogIn className="w-4 h-4" />
+                  Login
+                </>
+              )}
             </Button>
           </form>
-        </CardContent>
-        <CardFooter className="text-center text-sm">
-          Don&apos;t have an account?{' '}
-          <a href="/signup" className="text-blue-500 hover:underline">
-            Sign up
-          </a>
-        </CardFooter>
-      </Card>
+
+          <div className="mt-8 pt-6 border-t border-zinc-200/30 dark:border-zinc-800/30 text-center text-sm">
+            <span className="text-zinc-500 dark:text-zinc-400">Don't have an account? </span>
+            <a
+              href="/signup"
+              className="font-semibold text-rose-500 hover:text-rose-600 dark:text-rose-400 dark:hover:text-rose-300 transition-colors hover:underline inline-flex items-center gap-0.5"
+            >
+              Sign up <ArrowRight className="w-3.5 h-3.5" />
+            </a>
+          </div>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/ui/routes/projects/$projectId/files/$fileId.tsx
+++ b/src/ui/routes/projects/$projectId/files/$fileId.tsx
@@ -35,6 +35,7 @@ function FileViewPage() {
   const [rightSidebarWidth, setRightSidebarWidth] = useState(360)
   const [annotations, setAnnotations] = useState<Annotation[]>([])
   const [currentTime, setCurrentTime] = useState(0)
+  const [selectedCommentId, setSelectedCommentId] = useState<string | null>(null)
   const $patchMetadata = client.api.files[':fileId'].metadata.$patch
   const { mutate: patchMetadata } = useMutation<
     InferResponseType<typeof $patchMetadata>,
@@ -195,6 +196,7 @@ function FileViewPage() {
   }
 
   const handleCommentSelect = (comment: CommentInfo) => {
+    setSelectedCommentId(comment.id || null)
     const newAnnotations = comment.annotations as Annotation[]
     if (newAnnotations && newAnnotations.length > 0) {
       setAnnotations(newAnnotations)
@@ -216,6 +218,7 @@ function FileViewPage() {
 
   const handlePlay = () => {
     setAnnotations([])
+    setSelectedCommentId(null)
   }
 
   return (
@@ -279,6 +282,7 @@ function FileViewPage() {
                     videoRef.current.pause()
                   }
                 }}
+                selectedCommentId={selectedCommentId}
               />
             </div>
           </>

--- a/src/ui/routes/projects/$projectId/files/$fileId.tsx
+++ b/src/ui/routes/projects/$projectId/files/$fileId.tsx
@@ -256,8 +256,8 @@ function FileViewPage() {
             onTimeUpdate={setCurrentTime}
             annotations={annotations}
           />
-          </div>
-          {!isRightSidebarCollapsed && (
+        </div>
+        {!isRightSidebarCollapsed && (
           <>
             <ResizeHandle
               onResize={(delta) => {
@@ -274,11 +274,15 @@ function FileViewPage() {
                 members={members}
                 onCommentSelect={handleCommentSelect}
                 currentTime={currentTime}
+                onTyping={() => {
+                  if (videoRef.current) {
+                    videoRef.current.pause()
+                  }
+                }}
               />
             </div>
           </>
-          )}
-
+        )}
       </div>
     </div>
   )

--- a/src/ui/routes/projects/$projectId/files/$fileId.tsx
+++ b/src/ui/routes/projects/$projectId/files/$fileId.tsx
@@ -34,6 +34,7 @@ function FileViewPage() {
   const [leftSidebarWidth, setLeftSidebarWidth] = useState(280)
   const [rightSidebarWidth, setRightSidebarWidth] = useState(360)
   const [annotations, setAnnotations] = useState<Annotation[]>([])
+  const [currentTime, setCurrentTime] = useState(0)
   const $patchMetadata = client.api.files[':fileId'].metadata.$patch
   const { mutate: patchMetadata } = useMutation<
     InferResponseType<typeof $patchMetadata>,
@@ -197,11 +198,19 @@ function FileViewPage() {
     const newAnnotations = comment.annotations as Annotation[]
     if (newAnnotations && newAnnotations.length > 0) {
       setAnnotations(newAnnotations)
+    } else {
+      setAnnotations([])
+    }
+
+    if (comment.second !== null && comment.second !== undefined) {
+      if (videoRef.current) {
+        videoRef.current.currentTime(comment.second)
+        videoRef.current.pause()
+      }
+    } else if (newAnnotations && newAnnotations.length > 0) {
       if (videoRef.current) {
         videoRef.current.pause()
       }
-    } else {
-      setAnnotations([])
     }
   }
 
@@ -244,29 +253,32 @@ function FileViewPage() {
             file={fileData as unknown as AssetInfo}
             videoRef={videoRef}
             onPlay={handlePlay}
+            onTimeUpdate={setCurrentTime}
             annotations={annotations}
           />
-        </div>
-        {!isRightSidebarCollapsed && (
+          </div>
+          {!isRightSidebarCollapsed && (
           <>
             <ResizeHandle
               onResize={(delta) => {
-                setRightSidebarWidth((prev) => Math.max(240, Math.min(600, prev - delta)))
+                setRightSidebarWidth((prev) => Math.max(300, Math.min(600, prev - delta)))
               }}
               className="hidden md:block"
             />
             <div style={{ width: rightSidebarWidth }} className="flex-shrink-0">
               <FileViewerRightSidebar
-                teamId={teamId!}
+                teamId={teamId}
                 projectId={projectId}
                 file={fileData as unknown as AssetInfo}
                 onSaveField={handleSaveField}
                 members={members}
                 onCommentSelect={handleCommentSelect}
+                currentTime={currentTime}
               />
             </div>
           </>
-        )}
+          )}
+
       </div>
     </div>
   )

--- a/src/ui/routes/signup.tsx
+++ b/src/ui/routes/signup.tsx
@@ -158,22 +158,25 @@ function SignupPage() {
           {/* Marketing Copy / Feature Points */}
           <div className="relative my-8 md:my-0 space-y-6">
             <h2 className="text-3xl font-extrabold tracking-tight leading-tight text-zinc-900 dark:text-zinc-50">
-              Create assets.
+              One workspace
+              <br />
+              for all your
               <br />
               <span className="bg-gradient-to-r from-rose-500 to-orange-500 bg-clip-text text-transparent">
-                Organize workflows.
+                creative assets.
               </span>
             </h2>
             <p className="text-zinc-600 dark:text-zinc-400 text-sm leading-relaxed max-w-sm">
-              The ultimate collaboration hub for your design assets, code resources, and team
-              communication.
+              Upload and index your files, enrich them with custom metadata schemas, draw
+              annotations directly on media, and gather instant feedback — all in one modern
+              workspace built for creators.
             </p>
 
             <ul className="space-y-3.5 pt-4">
               {[
-                'Instant asset uploads & indexing',
-                'Custom metadata & metadata schemas',
-                'Advanced team permission controls',
+                'Instant asset uploads & high-fidelity media players',
+                'Custom metadata schemas & drawing canvas reviews',
+                'Frictionless team workspaces & secure sharing',
               ].map((text, i) => (
                 <li
                   key={i}

--- a/src/ui/routes/signup.tsx
+++ b/src/ui/routes/signup.tsx
@@ -86,7 +86,7 @@ function SignupPage() {
 
   if (isSignupInfoLoading) {
     return (
-      <div className="flex items-center justify-center min-h-screen bg-zinc-50 dark:bg-zinc-950">
+      <div className="flex items-center justify-center min-h-screen bg-zinc-100/80 dark:bg-black">
         <div className="relative flex flex-col items-center">
           <ShumaiLogo className="h-16 w-16 animate-pulse mb-4 text-rose-500 shadow-xl rounded-2xl" />
           <Loader2 className="h-6 w-6 animate-spin text-rose-500/70" />
@@ -100,12 +100,12 @@ function SignupPage() {
 
   if (isPublicSignupDisabled) {
     return (
-      <div className="min-h-screen w-full flex items-center justify-center p-4 md:p-8 bg-zinc-50 dark:bg-zinc-950 font-sans overflow-hidden relative">
+      <div className="min-h-screen w-full flex items-center justify-center p-4 md:p-8 bg-zinc-100/80 dark:bg-black font-sans overflow-hidden relative">
         {/* Background Mesh Blobs */}
         <div className="bg-rose-500/10 dark:bg-rose-600/5 w-[500px] h-[500px] rounded-full blur-[120px] absolute top-[-10%] left-[-10%] animate-drift-slow" />
         <div className="bg-orange-500/10 dark:bg-orange-600/5 w-[500px] h-[500px] rounded-full blur-[120px] absolute bottom-[-10%] right-[-10%] animate-drift-medium" />
 
-        <Card className="w-full max-w-md relative z-10 border border-zinc-200/50 dark:border-zinc-800/40 shadow-2xl bg-white/70 dark:bg-zinc-900/60 backdrop-blur-xl rounded-3xl overflow-hidden">
+        <Card className="w-full max-w-md relative z-10 border border-zinc-200 dark:border-zinc-850 shadow-2xl bg-white dark:bg-zinc-900 rounded-3xl overflow-hidden">
           <CardHeader className="text-center pt-8 pb-4">
             <div className="flex justify-center mb-4">
               <ShumaiLogo className="h-16 w-16 shadow-lg shadow-rose-500/10 rounded-2xl" />
@@ -135,15 +135,15 @@ function SignupPage() {
   }
 
   return (
-    <div className="min-h-screen w-full flex items-center justify-center p-4 md:p-8 bg-zinc-50 dark:bg-zinc-950 font-sans overflow-hidden relative">
+    <div className="min-h-screen w-full flex items-center justify-center p-4 md:p-8 bg-zinc-100/80 dark:bg-black font-sans overflow-hidden relative">
       {/* Drifting Background Mesh Blobs */}
       <div className="bg-rose-500/10 dark:bg-rose-600/5 w-[600px] h-[600px] rounded-full blur-[140px] absolute top-[-10%] left-[-10%] animate-drift-slow" />
       <div className="bg-orange-500/10 dark:bg-orange-600/5 w-[600px] h-[600px] rounded-full blur-[140px] absolute bottom-[-10%] right-[-10%] animate-drift-medium" />
 
       {/* Main Glassmorphic Split-Pane Card */}
-      <div className="relative max-w-4xl w-full flex flex-col md:flex-row rounded-3xl border border-zinc-200/50 dark:border-zinc-800/40 shadow-2xl bg-white/70 dark:bg-zinc-900/60 backdrop-blur-xl overflow-hidden min-h-[580px] z-10 transition-all duration-300 hover:shadow-rose-500/5">
+      <div className="relative max-w-4xl w-full flex flex-col md:flex-row rounded-3xl border border-zinc-200 dark:border-zinc-800 shadow-2xl bg-white dark:bg-zinc-900 overflow-hidden min-h-[580px] z-10 transition-all duration-300 hover:shadow-rose-500/5">
         {/* Left Pane (Brand Showcase) */}
-        <div className="w-full md:w-1/2 bg-gradient-to-br from-rose-500/10 via-orange-500/5 to-transparent p-8 md:p-12 flex flex-col justify-between border-b md:border-b-0 md:border-r border-zinc-200/50 dark:border-zinc-800/40 relative overflow-hidden">
+        <div className="w-full md:w-1/2 bg-gradient-to-br from-rose-500/15 via-orange-500/10 to-amber-500/5 dark:from-rose-950/30 dark:via-orange-950/15 dark:to-zinc-900/40 p-8 md:p-12 flex flex-col justify-between border-b md:border-b-0 md:border-r border-zinc-200 dark:border-zinc-800 relative overflow-hidden">
           {/* Subtle Grid Overlay */}
           <div className="absolute inset-0 bg-[linear-gradient(to_right,#8080800a_1px,transparent_1px),linear-gradient(to_bottom,#8080800a_1px,transparent_1px)] bg-[size:14px_24px] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_0%,#000_70%,transparent_100%)] pointer-events-none" />
 

--- a/src/ui/routes/signup.tsx
+++ b/src/ui/routes/signup.tsx
@@ -1,17 +1,10 @@
 import { client } from '@/ui/api/client'
 import { useQuery } from '@tanstack/react-query'
 import { Button } from '@/ui/components/ui/button'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/ui/components/ui/card'
+import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/ui/components/ui/card'
 import { Input } from '@/ui/components/ui/input'
 import { Label } from '@/ui/components/ui/label'
-import { Loader2 } from 'lucide-react'
+import { Loader2, Mail, Lock, CheckCircle2, ArrowRight, UserPlus } from 'lucide-react'
 import { useAuthStore } from '@/ui/stores/auth'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
@@ -19,11 +12,11 @@ import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { signUp } from '@/ui/lib/auth-client'
 import { useState } from 'react'
+import { ShumaiLogo } from '@/ui/components/ui/icons'
 
 const signupSchema = z.object({
-  name: z.string().min(1, 'Name is required'),
   email: z.string().email('Invalid email address'),
-  password: z.string().min(1, 'Password is required'),
+  password: z.string().min(3, 'Password must be at least 3 characters'),
   inviteCode: z.string().optional(),
 })
 
@@ -74,9 +67,8 @@ function SignupPage() {
     const { data: session, error: signUpError } = await signUp.email({
       email: data.email,
       password: data.password,
-      name: data.name,
+      name: data.email, // Use email as the username
       inviteCode: data.inviteCode,
-      // Cast to any because inviteCode is a custom field handled in Better Auth hooks
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any)
 
@@ -94,8 +86,11 @@ function SignupPage() {
 
   if (isSignupInfoLoading) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
-        <Loader2 className="h-8 w-8 animate-spin" />
+      <div className="flex items-center justify-center min-h-screen bg-zinc-50 dark:bg-zinc-950">
+        <div className="relative flex flex-col items-center">
+          <ShumaiLogo className="h-16 w-16 animate-pulse mb-4 text-rose-500 shadow-xl rounded-2xl" />
+          <Loader2 className="h-6 w-6 animate-spin text-rose-500/70" />
+        </div>
       </div>
     )
   }
@@ -105,19 +100,34 @@ function SignupPage() {
 
   if (isPublicSignupDisabled) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
-        <Card className="w-full max-w-sm">
-          <CardHeader>
-            <CardTitle>Registration Disabled</CardTitle>
-            <CardDescription>
-              Public registration is disabled. You need an invite code to join.
+      <div className="min-h-screen w-full flex items-center justify-center p-4 md:p-8 bg-zinc-50 dark:bg-zinc-950 font-sans overflow-hidden relative">
+        {/* Background Mesh Blobs */}
+        <div className="bg-rose-500/10 dark:bg-rose-600/5 w-[500px] h-[500px] rounded-full blur-[120px] absolute top-[-10%] left-[-10%] animate-drift-slow" />
+        <div className="bg-orange-500/10 dark:bg-orange-600/5 w-[500px] h-[500px] rounded-full blur-[120px] absolute bottom-[-10%] right-[-10%] animate-drift-medium" />
+
+        <Card className="w-full max-w-md relative z-10 border border-zinc-200/50 dark:border-zinc-800/40 shadow-2xl bg-white/70 dark:bg-zinc-900/60 backdrop-blur-xl rounded-3xl overflow-hidden">
+          <CardHeader className="text-center pt-8 pb-4">
+            <div className="flex justify-center mb-4">
+              <ShumaiLogo className="h-16 w-16 shadow-lg shadow-rose-500/10 rounded-2xl" />
+            </div>
+            <CardTitle className="text-2xl font-bold tracking-tight bg-gradient-to-r from-rose-500 to-orange-500 bg-clip-text text-transparent">
+              Registration Disabled
+            </CardTitle>
+            <CardDescription className="mt-2 text-zinc-600 dark:text-zinc-400">
+              Public registration is currently disabled. You will need an invite code to join this
+              team.
             </CardDescription>
           </CardHeader>
-          <CardFooter className="text-center text-sm">
-            Already have an account?{' '}
-            <a href="/login" className="text-blue-500 hover:underline">
-              Login
-            </a>
+          <CardFooter className="flex flex-col gap-4 pb-8 text-center text-sm border-t border-zinc-200/30 dark:border-zinc-800/30 pt-6">
+            <p className="text-zinc-500 dark:text-zinc-400">
+              Already have an account?{' '}
+              <a
+                href="/login"
+                className="font-semibold text-rose-500 hover:text-rose-600 dark:text-rose-400 dark:hover:text-rose-300 transition-colors hover:underline inline-flex items-center gap-1"
+              >
+                Login here <ArrowRight className="w-3.5 h-3.5" />
+              </a>
+            </p>
           </CardFooter>
         </Card>
       </div>
@@ -125,70 +135,179 @@ function SignupPage() {
   }
 
   return (
-    <div className="flex items-center justify-center min-h-screen py-8">
-      <Card className="w-full max-w-sm">
-        <CardHeader>
-          <CardTitle>Sign Up</CardTitle>
-          <CardDescription>Create an account to get started.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          {error && <p className="text-red-500 text-sm text-center mb-4">{error}</p>}
-          {isFirstUser && (
-            <div className="mb-4 p-3 bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-200 rounded-md text-sm">
-              You will be the owner of the default team.
+    <div className="min-h-screen w-full flex items-center justify-center p-4 md:p-8 bg-zinc-50 dark:bg-zinc-950 font-sans overflow-hidden relative">
+      {/* Drifting Background Mesh Blobs */}
+      <div className="bg-rose-500/10 dark:bg-rose-600/5 w-[600px] h-[600px] rounded-full blur-[140px] absolute top-[-10%] left-[-10%] animate-drift-slow" />
+      <div className="bg-orange-500/10 dark:bg-orange-600/5 w-[600px] h-[600px] rounded-full blur-[140px] absolute bottom-[-10%] right-[-10%] animate-drift-medium" />
+
+      {/* Main Glassmorphic Split-Pane Card */}
+      <div className="relative max-w-4xl w-full flex flex-col md:flex-row rounded-3xl border border-zinc-200/50 dark:border-zinc-800/40 shadow-2xl bg-white/70 dark:bg-zinc-900/60 backdrop-blur-xl overflow-hidden min-h-[580px] z-10 transition-all duration-300 hover:shadow-rose-500/5">
+        {/* Left Pane (Brand Showcase) */}
+        <div className="w-full md:w-1/2 bg-gradient-to-br from-rose-500/10 via-orange-500/5 to-transparent p-8 md:p-12 flex flex-col justify-between border-b md:border-b-0 md:border-r border-zinc-200/50 dark:border-zinc-800/40 relative overflow-hidden">
+          {/* Subtle Grid Overlay */}
+          <div className="absolute inset-0 bg-[linear-gradient(to_right,#8080800a_1px,transparent_1px),linear-gradient(to_bottom,#8080800a_1px,transparent_1px)] bg-[size:14px_24px] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_0%,#000_70%,transparent_100%)] pointer-events-none" />
+
+          {/* Logo & Brand */}
+          <div className="relative flex items-center gap-3">
+            <ShumaiLogo className="h-12 w-12 shadow-lg shadow-rose-500/10 rounded-2xl transition-transform duration-500 hover:scale-105" />
+            <span className="text-xl font-extrabold tracking-tight bg-gradient-to-r from-rose-500 via-orange-500 to-amber-500 bg-clip-text text-transparent">
+              Shumai
+            </span>
+          </div>
+
+          {/* Marketing Copy / Feature Points */}
+          <div className="relative my-8 md:my-0 space-y-6">
+            <h2 className="text-3xl font-extrabold tracking-tight leading-tight text-zinc-900 dark:text-zinc-50">
+              Create assets.
+              <br />
+              <span className="bg-gradient-to-r from-rose-500 to-orange-500 bg-clip-text text-transparent">
+                Organize workflows.
+              </span>
+            </h2>
+            <p className="text-zinc-600 dark:text-zinc-400 text-sm leading-relaxed max-w-sm">
+              The ultimate collaboration hub for your design assets, code resources, and team
+              communication.
+            </p>
+
+            <ul className="space-y-3.5 pt-4">
+              {[
+                'Instant asset uploads & indexing',
+                'Custom metadata & metadata schemas',
+                'Advanced team permission controls',
+              ].map((text, i) => (
+                <li
+                  key={i}
+                  className="flex items-center gap-3 text-sm text-zinc-700 dark:text-zinc-300 font-medium"
+                >
+                  <CheckCircle2 className="w-5 h-5 text-rose-500 flex-shrink-0" />
+                  <span>{text}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Context Banners (First User / Invite Info) */}
+          <div className="relative pt-4 border-t border-zinc-200/30 dark:border-zinc-800/30">
+            {isFirstUser && (
+              <div className="flex items-start gap-3 p-3 bg-amber-500/10 border border-amber-500/20 text-amber-800 dark:text-amber-300 rounded-2xl text-xs leading-relaxed font-medium">
+                <span>🎉</span>
+                <span>You will be the owner of the default workspace as the first user!</span>
+              </div>
+            )}
+            {inviteInfo && !('error' in inviteInfo) && (
+              <div className="flex items-start gap-3 p-3 bg-rose-500/10 border border-rose-500/20 text-rose-800 dark:text-rose-300 rounded-2xl text-xs leading-relaxed font-medium">
+                <span>👋</span>
+                <span>
+                  <strong>{inviteInfo.inviterName}</strong> invited you to join{' '}
+                  <strong>{inviteInfo.teamName || inviteInfo.projectName}</strong> as a{' '}
+                  <strong>{inviteInfo.role}</strong>.
+                </span>
+              </div>
+            )}
+            {!isFirstUser && !inviteInfo && (
+              <p className="text-xs text-zinc-500 dark:text-zinc-400 font-medium">
+                Join our community of developers and designers.
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Right Pane (Form Container) */}
+        <div className="w-full md:w-1/2 p-8 md:p-12 flex flex-col justify-center">
+          <div className="mb-8">
+            <h1 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
+              Create Account
+            </h1>
+            <p className="text-zinc-500 dark:text-zinc-400 text-sm mt-1">
+              Start building and organizing your space.
+            </p>
+          </div>
+
+          {error && (
+            <div className="mb-6 p-3 bg-red-500/10 border border-red-500/20 text-red-600 dark:text-red-400 rounded-xl text-sm text-center font-medium">
+              {error}
             </div>
           )}
-          {inviteInfo && !('error' in inviteInfo) && (
-            <div className="mb-4 p-3 bg-muted rounded-md text-sm">
-              <span className="font-semibold">{inviteInfo.inviterName}</span> invited you to join{' '}
-              <span className="font-semibold">{inviteInfo.teamName || inviteInfo.projectName}</span>{' '}
-              as <span className="font-semibold">{inviteInfo.role}</span>.
-            </div>
-          )}
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
             <div className="space-y-2">
-              <Label htmlFor="name">Name</Label>
-              <Input id="name" {...form.register('name')} placeholder="Your name" />
-              {form.formState.errors.name && (
-                <p className="text-red-500 text-sm">{form.formState.errors.name.message}</p>
-              )}
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                {...form.register('email')}
-                placeholder="you@example.com"
-                type="email"
-              />
+              <Label
+                htmlFor="email"
+                className="text-xs font-semibold text-zinc-600 dark:text-zinc-400 tracking-wide uppercase"
+              >
+                Email Address
+              </Label>
+              <div className="relative group">
+                <Mail className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-400 dark:text-zinc-600 transition-colors group-focus-within:text-rose-500" />
+                <Input
+                  id="email"
+                  {...form.register('email')}
+                  placeholder="you@example.com"
+                  type="email"
+                  className="pl-10.5 h-11 border-zinc-200 dark:border-zinc-800 focus-visible:ring-rose-500/50 focus-visible:border-rose-500 rounded-xl transition-all shadow-sm"
+                />
+              </div>
               {form.formState.errors.email && (
-                <p className="text-red-500 text-sm">{form.formState.errors.email.message}</p>
+                <p className="text-red-500 text-xs font-medium">
+                  {form.formState.errors.email.message}
+                </p>
               )}
             </div>
+
             <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
-              <Input
-                id="password"
-                type="password"
-                {...form.register('password')}
-                placeholder="Your password"
-              />
+              <Label
+                htmlFor="password"
+                className="text-xs font-semibold text-zinc-600 dark:text-zinc-400 tracking-wide uppercase"
+              >
+                Password
+              </Label>
+              <div className="relative group">
+                <Lock className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-400 dark:text-zinc-600 transition-colors group-focus-within:text-rose-500" />
+                <Input
+                  id="password"
+                  type="password"
+                  {...form.register('password')}
+                  placeholder="At least 3 characters"
+                  className="pl-10.5 h-11 border-zinc-200 dark:border-zinc-800 focus-visible:ring-rose-500/50 focus-visible:border-rose-500 rounded-xl transition-all shadow-sm"
+                />
+              </div>
               {form.formState.errors.password && (
-                <p className="text-red-500 text-sm">{form.formState.errors.password.message}</p>
+                <p className="text-red-500 text-xs font-medium">
+                  {form.formState.errors.password.message}
+                </p>
               )}
             </div>
-            <Button type="submit" className="w-full" disabled={loading}>
-              {loading ? 'Creating account...' : 'Sign Up'}
+
+            <Button
+              type="submit"
+              className="w-full h-11 bg-gradient-to-r from-rose-500 to-orange-500 hover:from-rose-600 hover:to-orange-600 text-white font-semibold rounded-xl shadow-md shadow-rose-500/10 hover:shadow-rose-500/20 active:scale-[0.98] transition-all flex items-center justify-center gap-2 border-0"
+              disabled={loading}
+            >
+              {loading ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Creating account...
+                </>
+              ) : (
+                <>
+                  <UserPlus className="w-4 h-4" />
+                  Sign Up
+                </>
+              )}
             </Button>
           </form>
-        </CardContent>
-        <CardFooter className="text-center text-sm">
-          Already have an account?{' '}
-          <a href="/login" className="text-blue-500 hover:underline">
-            Login
-          </a>
-        </CardFooter>
-      </Card>
+
+          <div className="mt-8 pt-6 border-t border-zinc-200/30 dark:border-zinc-800/30 text-center text-sm">
+            <span className="text-zinc-500 dark:text-zinc-400">Already have an account? </span>
+            <a
+              href="/login"
+              className="font-semibold text-rose-500 hover:text-rose-600 dark:text-rose-400 dark:hover:text-rose-300 transition-colors hover:underline inline-flex items-center gap-0.5"
+            >
+              Login <ArrowRight className="w-3.5 h-3.5" />
+            </a>
+          </div>
+        </div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Redesigns the Login and Signup pages with premium visual aesthetics (including the Shumai logo, glassmorphism, drifting mesh gradients, and Plus Jakarta Sans typography) and simplifies the signup onboarding flow by removing the username field and automatically using email as the username.

## Changes

- Modified `src/ui/routes/signup.tsx` to remove the Name form input field and map the user's `email` as their `name` to better-auth upon submission.
- Redesigned the Signup page with a dual-pane layout: a warm-gradient marketing pane on the left showcasing the pulsing `ShumaiLogo` and platform values, and a glassmorphic card on the right for inputting email and password.
- Redesigned `src/ui/routes/login.tsx` using the identical high-fidelity split-pane structure for complete brand visual alignment.
- Updated `src/ui/globals.css` to load **Plus Jakarta Sans** from Google Fonts and added keyframe animations for the drifting background blobs.

## Verification

- Cleanly passed lint check (`bun run lint`).
- Cleanly passed formatting check (`bun run format`).
- Verified zero type errors (`bun run typecheck`).
- Successfully executed the Vitest test suite (`bun run test`), with all 353 test cases passing.

## Notes

No database schema migrations or backend modifications were necessary, as `name` constraints are satisfied client-side by assigning the email.