### PR TITLE
fix(ui): enable independent sidebar scroll, validate readonly fields, pin selection bar

### DIFF
--- a/src/api/file.test.ts
+++ b/src/api/file.test.ts
@@ -298,6 +298,23 @@ describe('file api', () => {
     })
   })
 
+  it('PATCH /files/:fileId/metadata rejects readonly fields with 422', async () => {
+    vi.mocked(metadataService.updateAssetMetadata).mockRejectedValue(
+      new Error('Field some-key is read-only'),
+    )
+
+    const app = new Hono().use('*', authMiddleware).route('/', fileRoute)
+    const res = await app.request('/files/test-id/metadata', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify([{ key: 'some-key', value: 'approved' }]),
+    })
+
+    expect(res.status).toBe(422)
+    const body = await res.json()
+    expect(body.error).toContain('Field some-key is read-only')
+  })
+
   it('PATCH /files/:fileId/order', async () => {
     vi.spyOn(assetService, 'updateAssetOrder').mockResolvedValue({
       id: 'test-id',

--- a/src/api/file.ts
+++ b/src/api/file.ts
@@ -101,7 +101,14 @@ const route = new Hono<{ Variables: { user: User } }>()
         id: fileId,
       })
 
-      await metadataService.updateAssetMetadata(fileId, req)
+      try {
+        await metadataService.updateAssetMetadata(fileId, req)
+      } catch (err) {
+        if (err instanceof Error && err.message.includes('is read-only')) {
+          return c.json({ error: err.message }, 422)
+        }
+        throw err
+      }
 
       const hasStatus = req.some((m) => m.key === 'status')
       if (hasStatus) {

--- a/src/services/metadata/metadata.test.ts
+++ b/src/services/metadata/metadata.test.ts
@@ -156,4 +156,39 @@ describe('MetadataService', () => {
     const height = values.find((v) => v.fieldId === 'resolution_height')
     expect(height?.numberValue).toBe(1080)
   })
+
+  it('should reject updating read-only fields', async () => {
+    const team = await prisma.team.create({
+      data: { name: 'test-team' },
+    })
+    const project = await prisma.project.create({
+      data: { name: 'test-project', teamId: team.id },
+    })
+    const asset = await prisma.asset.create({
+      data: {
+        name: 'test-asset',
+        project: { connect: { id: project.id } },
+        type: 'file',
+        status: 'uploaded',
+        sizeByte: 100,
+      },
+    })
+
+    // Create a read-only metadata field
+    const field = await prisma.metadataField.create({
+      data: {
+        key: 'readonly-field',
+        scope: 'PROJECT',
+        project: { connect: { id: project.id } },
+        config: { name: 'Readonly Field', type: 'text' },
+        readOnly: true,
+      },
+    })
+
+    const reqs = [{ key: field.key, value: 'some value' }]
+
+    await expect(metadataService.updateAssetMetadata(asset.id, reqs)).rejects.toThrow(
+      'Field readonly-field is read-only',
+    )
+  })
 })

--- a/src/services/metadata/metadata.ts
+++ b/src/services/metadata/metadata.ts
@@ -264,6 +264,13 @@ export class MetadataService {
 
     await this.client.$transaction(async (tx) => {
       for (const req of reqs) {
+        const field = await tx.metadataField.findUnique({
+          where: { key: req.key },
+        })
+        if (field?.readOnly) {
+          throw new Error(`Field ${field.key} is read-only`)
+        }
+
         const value = req.value
         let stringValue: string | null = null
         let numberValue: number | null = null

--- a/src/ui/components/chat/message-card.tsx
+++ b/src/ui/components/chat/message-card.tsx
@@ -3,11 +3,11 @@ import type { UserInfo } from '@/dtos/team'
 import { client } from '@/ui/api/client'
 import { Button } from '@/ui/components/ui/button'
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogHeader,
-    DialogTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
 } from '@/ui/components/ui/dialog'
 import { Separator } from '@/ui/components/ui/separator'
 import { formatTimeAgo } from '@/ui/lib/time'

--- a/src/ui/components/file-browser/file-browser.tsx
+++ b/src/ui/components/file-browser/file-browser.tsx
@@ -738,8 +738,7 @@ export function FileBrowser({
       <ContextMenu modal={false}>
         <ContextMenuTrigger asChild disabled={isShareView || isPublic}>
           <div
-            ref={scrollContainerRef}
-            className="flex-1 overflow-y-auto bg-background relative flex flex-col"
+            className="flex-1 bg-background relative flex flex-col min-h-0 overflow-hidden"
             onContextMenu={(e) => onContextMenu(e)}
           >
             {!isShareView && !isPublic && onFilterChange && onSortChange && (
@@ -758,76 +757,81 @@ export function FileBrowser({
                 rootFolderId={rootFolderId}
               />
             )}
-            {displayStyle === 'list' ? (
-              <FileBrowserListView
-                folders={folders}
-                files={files}
-                totalFolders={totalFolders}
-                totalFiles={totalFiles}
-                selectedItem={selectedItem}
-                selectedIds={selectedIds}
-                displayedFields={displayedFields}
-                onItemSelect={onItemSelect}
-                onItemDoubleClick={onItemDoubleClick}
-                renderItem={renderItem}
-                foldersExpanded={foldersExpanded}
-                setFoldersExpanded={setFoldersExpanded}
-                filesExpanded={filesExpanded}
-                setFilesExpanded={setFilesExpanded}
-                foldersRef={foldersRef}
-                filesRef={filesRef}
-                hasNextFoldersPage={hasNextFoldersPage}
-                hasNextFilesPage={hasNextFilesPage}
-                formatCount={formatCount}
-                formatSize={formatSize}
-                foldersSize={foldersSize}
-                filesSize={filesSize}
-                handleEmptyAreaClick={handleEmptyAreaClick}
-                dragState={dragState}
-                sort={sort}
-              />
-            ) : (
-              <FileBrowserGridView
-                folders={folders}
-                files={files}
-                totalFolders={totalFolders}
-                totalFiles={totalFiles}
-                renderItem={renderItem}
-                foldersExpanded={foldersExpanded}
-                setFoldersExpanded={setFoldersExpanded}
-                filesExpanded={filesExpanded}
-                setFilesExpanded={setFilesExpanded}
-                foldersRef={foldersRef}
-                filesRef={filesRef}
-                hasNextFoldersPage={hasNextFoldersPage}
-                hasNextFilesPage={hasNextFilesPage}
-                formatCount={formatCount}
-                formatSize={formatSize}
-                foldersSize={foldersSize}
-                filesSize={filesSize}
-                handleEmptyAreaClick={handleEmptyAreaClick}
-                dragState={dragState}
-                sort={sort}
-              />
-            )}
+            <div
+              ref={scrollContainerRef}
+              className="flex-1 overflow-y-auto min-h-0 relative flex flex-col"
+            >
+              {displayStyle === 'list' ? (
+                <FileBrowserListView
+                  folders={folders}
+                  files={files}
+                  totalFolders={totalFolders}
+                  totalFiles={totalFiles}
+                  selectedItem={selectedItem}
+                  selectedIds={selectedIds}
+                  displayedFields={displayedFields}
+                  onItemSelect={onItemSelect}
+                  onItemDoubleClick={onItemDoubleClick}
+                  renderItem={renderItem}
+                  foldersExpanded={foldersExpanded}
+                  setFoldersExpanded={setFoldersExpanded}
+                  filesExpanded={filesExpanded}
+                  setFilesExpanded={setFilesExpanded}
+                  foldersRef={foldersRef}
+                  filesRef={filesRef}
+                  hasNextFoldersPage={hasNextFoldersPage}
+                  hasNextFilesPage={hasNextFilesPage}
+                  formatCount={formatCount}
+                  formatSize={formatSize}
+                  foldersSize={foldersSize}
+                  filesSize={filesSize}
+                  handleEmptyAreaClick={handleEmptyAreaClick}
+                  dragState={dragState}
+                  sort={sort}
+                />
+              ) : (
+                <FileBrowserGridView
+                  folders={folders}
+                  files={files}
+                  totalFolders={totalFolders}
+                  totalFiles={totalFiles}
+                  renderItem={renderItem}
+                  foldersExpanded={foldersExpanded}
+                  setFoldersExpanded={setFoldersExpanded}
+                  filesExpanded={filesExpanded}
+                  setFilesExpanded={setFilesExpanded}
+                  foldersRef={foldersRef}
+                  filesRef={filesRef}
+                  hasNextFoldersPage={hasNextFoldersPage}
+                  hasNextFilesPage={hasNextFilesPage}
+                  formatCount={formatCount}
+                  formatSize={formatSize}
+                  foldersSize={foldersSize}
+                  filesSize={filesSize}
+                  handleEmptyAreaClick={handleEmptyAreaClick}
+                  dragState={dragState}
+                  sort={sort}
+                />
+              )}
 
-            {(isFetchingNextFoldersPage || isFetchingNextFilesPage) && (
-              <div className="flex justify-center items-center p-4">
-                <p>Loading more...</p>
-              </div>
-            )}
-
-            {folders.length === 0 &&
-              files.length === 0 &&
-              !isFetchingNextFoldersPage &&
-              !isFetchingNextFilesPage && (
-                <div className="empty-area flex h-full items-center justify-center text-sm text-muted-foreground">
-                  This folder is empty
+              {(isFetchingNextFoldersPage || isFetchingNextFilesPage) && (
+                <div className="flex justify-center items-center p-4">
+                  <p>Loading more...</p>
                 </div>
               )}
 
+              {folders.length === 0 &&
+                files.length === 0 &&
+                !isFetchingNextFoldersPage &&
+                !isFetchingNextFilesPage && (
+                  <div className="empty-area flex h-full items-center justify-center text-sm text-muted-foreground">
+                    This folder is empty
+                  </div>
+                )}
+            </div>
+
             {selectedCount > 0 && (
-              <div className="border-t border-border bg-card px-4 py-3 flex items-center justify-between">
+              <div className="border-t border-border bg-card px-4 py-3 flex items-center justify-between shrink-0">
                 <div className="text-sm text-muted-foreground">
                   {selectedFolders > 0 && selectedFiles > 0 && (
                     <span>

--- a/src/ui/components/file-system-manager.tsx
+++ b/src/ui/components/file-system-manager.tsx
@@ -409,7 +409,7 @@ export default function FileSystemManager({
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
     >
-      <div className="flex flex-1 flex-col bg-background">
+      <div className="flex flex-1 flex-col bg-background min-h-0">
         <div ref={containerRef} className="flex flex-1 overflow-hidden relative">
           {!isLeftSidebarCollapsed && (
             <div

--- a/src/ui/components/file-viewer-right-sidebar.tsx
+++ b/src/ui/components/file-viewer-right-sidebar.tsx
@@ -432,7 +432,7 @@ export function FileViewerRightSidebar({
                         config={field.config}
                         value={itemFieldValueMap[field.id!]?.value}
                         onSave={(val) => onSaveField(field.id!, val)}
-                        readOnly={readOnly}
+                        readOnly={readOnly || field.readOnly}
                       />
                     </div>
                   </div>

--- a/src/ui/routes/__root.tsx
+++ b/src/ui/routes/__root.tsx
@@ -78,7 +78,7 @@ function RootComponent() {
       </DualSidebar>
       <div className="flex flex-col flex-1 md:pl-16 overflow-hidden relative">
         <TopNav />
-        <main className="flex-1 overflow-y-auto overflow-x-hidden relative flex flex-col">
+        <main className="flex-1 overflow-hidden relative flex flex-col">
           <Outlet />
         </main>
       </div>

--- a/src/ui/routes/teams/$teamId/index.tsx
+++ b/src/ui/routes/teams/$teamId/index.tsx
@@ -205,7 +205,7 @@ function TeamPage() {
   const safeMembers = Array.isArray(members) ? members : []
 
   return (
-    <div className="p-4">
+    <div className="flex-1 overflow-y-auto p-4">
       <div className="flex flex-wrap items-center justify-between mb-4 gap-4">
         <h1 className="text-2xl font-bold">Projects</h1>
         <div className="flex flex-wrap items-center gap-4">


### PR DESCRIPTION
## Summary

This PR addresses three layout and data validation bugs in the Shumai files dashboard application:
1. **Independent Sidebar Scroll**: Fixed a layout bug where the left/right sidebars and the middle file list scrolled together. Now all sections scroll independently.
2. **Read-Only Fields Validation**: Fixed a bug where read-only metadata fields could be edited in the right sidebar, and the backend did not reject edits targeting them.
3. **Sticky Bottom Selection Bar**: Fixed a bug where the bottom selection/action bar inside the main files browser scrolled with the file items instead of being pinned to the bottom.

## Changes

- **Root Layout (`src/ui/routes/__root.tsx`)**: Changed root `<main>` style to `overflow-hidden` to bound the viewport layout and enable separate scrolling.
- **Projects Grid (`src/ui/routes/teams/$teamId/index.tsx`)**: Configured team projects page container with `flex-1 overflow-y-auto` to scroll internally.
- **File System Manager (`src/ui/components/file-system-manager.tsx`)**: Added `min-h-0` to the outer wrapper to allow correct flexbox column height shrinking.
- **Right Sidebar (`src/ui/components/file-viewer-right-sidebar.tsx`)**: Passed `readOnly={readOnly || field.readOnly}` to the metadata field renderer to prevent editing of read-only fields.
- **Metadata Service (`src/services/metadata/metadata.ts`)**: Implemented database validation inside `updateAssetMetadata` to block updates targeting fields configured with `readOnly: true`.
- **Hono Router (`src/api/file.ts`)**: Added error catching for metadata validation failures to return a `422 Unprocessable Entity` status code.
- **File Browser (`src/ui/components/file-browser/file-browser.tsx`)**: Restructured the layout by pinning the toolbar to the top and the bottom selection bar to the bottom (via flex layout with `shrink-0`), placing only the folders/files list inside the scrollable container.

## Verification

- **Automated Tests**: Added backend service-level test case in `src/services/metadata/metadata.test.ts` and API-level integration test case in `src/api/file.test.ts` to assert that read-only metadata updates fail with error / 422 respectively.
- **Full Test Suite**: Ran `bun run test` successfully with all 355 tests passing.
- **Static Analysis**: Verified that `bun run lint`, `bun run format`, and `bun run typecheck` all pass simultaneously without errors.

## Notes

No breaking changes are introduced.
