### PR TITLE
fix(workflow): remove redundant submit call from executeWait

### DIFF
--- a/src/workflow/workflow.test.ts
+++ b/src/workflow/workflow.test.ts
@@ -134,4 +134,52 @@ describe('WorkflowService', () => {
       'embedding feature is disabled or agent not found',
     )
   }, 15000)
+
+  it('should not double-submit the task when executeWait is called', async () => {
+    const team = await prisma.team.create({
+      data: { name: 'Test Team' },
+    })
+    const project = await prisma.project.create({
+      data: { name: 'Test Project', teamId: team.id },
+    })
+    const asset = await prisma.asset.create({
+      data: {
+        name: 'test-double.png',
+        storageKey: { create: { key: 'test/test-double.png' } },
+        status: 'uploaded',
+        type: 'file',
+        mediaType: 'image/png',
+        project: { connect: { id: project.id } },
+      },
+    })
+
+    const submitSpy = vi.spyOn(workflowService, 'submit')
+
+    const task = await prisma.workflowTask.create({
+      data: {
+        assetId: asset.id,
+        type: WorkflowTaskType.ai_embedding,
+        status: WorkflowTaskStatus.pending,
+        teamId: team.id,
+      },
+    })
+
+    // Wait briefly for the Prisma extension's async import/submit to fire
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(submitSpy).toHaveBeenCalledTimes(1)
+
+    // Complete the task in the database so executeWait returns immediately
+    await prisma.workflowTask.update({
+      where: { id: task.id },
+      data: { status: 'completed' },
+    })
+
+    await workflowService.executeWait(task)
+
+    // Verify it was not submitted a second time by executeWait
+    expect(submitSpy).toHaveBeenCalledTimes(1)
+
+    submitSpy.mockRestore()
+  })
 })

--- a/src/workflow/workflow.ts
+++ b/src/workflow/workflow.ts
@@ -21,8 +21,6 @@ export class WorkflowService {
   }
 
   async executeWait(task: WorkflowTask, timeoutMs: number = 30000): Promise<WorkflowTask> {
-    await this.submit(task)
-
     const start = Date.now()
     while (Date.now() - start < timeoutMs) {
       const updatedTask = await prisma.workflowTask.findUnique({


### PR DESCRIPTION
## Summary

This PR removes a redundant `this.submit(task)` call in `workflowService.executeWait(task)`. Since task creation already triggers automatic submission via the Prisma Client Extension in `src/db.ts`, this extra call leads to double submission of tasks, causing concurrency race conditions and `WorkflowExecutionAlreadyStartedError` failures in production under Temporal.

## Changes

- **src/workflow/workflow.ts**: Removed the duplicate `await this.submit(task)` call from `executeWait`.
- **src/workflow/workflow.test.ts**: Added a new test `should not double-submit the task when executeWait is called` to ensure `executeWait` does not invoke duplicate submissions.

## Verification

- Added an integration test verifying that `submit` is called exactly once when a task is created and `executeWait` is called.
- Ran `bun run lint`, `bun run format`, and `bun run typecheck` which all passed.
- Ran the full vitest suite (`bun run test`) which passed successfully:
  `Test Files: 58 passed (58), Tests: 366 passed (366)`

## Notes

None.