### PR TITLE
feat(workflow): add concurrency control and heartbeat loops to local executor

### DIFF
--- a/src/workflow/local-executor.test.ts
+++ b/src/workflow/local-executor.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { prisma } from '@/db'
 import { setupTestDbHooks } from '@/db-test-hooks'
 import { workflowService } from './workflow'
-import { LocalExecutor } from './local-executor'
+import { LocalExecutor, ConcurrencyLimiter } from './local-executor'
 import { WorkflowTaskStatus, WorkflowTaskType } from '@/generated/prisma/client'
 
 // Mock the individual workflows
@@ -194,6 +194,79 @@ describe('LocalExecutor Integration Tests', () => {
       // Clean up remaining tasks
       activeResolvers.slice(2).forEach((resolve) => resolve(undefined))
       await new Promise((resolve) => setTimeout(resolve, 50))
+    })
+  })
+
+  describe('ConcurrencyLimiter Unit Tests', () => {
+    it('should not allow concurrency limit violation during microtask race conditions', async () => {
+      const limiter = new ConcurrencyLimiter(1)
+
+      // Task A starts and runs
+      let resolveA: () => void = () => {}
+      const promiseA = limiter.run(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveA = resolve
+          }),
+      )
+
+      // Task B enters and is queued
+      let resolveB: () => void = () => {}
+      const promiseB = limiter.run(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveB = resolve
+          }),
+      )
+
+      // Wait briefly for Task B to queue up
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      expect(limiter.getActiveCount()).toBe(1)
+      expect(limiter.getQueueLength()).toBe(1)
+
+      // Complete Task A (schedules Task A's body to resume)
+      resolveA()
+
+      // Wait exactly one microtask tick to let Task A exit and trigger finally block (resolving Task B)
+      // This positions us in the microtask gap before Task B resumes execution
+      await Promise.resolve()
+
+      // Task C immediately enters the limiter synchronously
+      let resolveC: () => void = () => {}
+      const promiseC = limiter.run(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveC = resolve
+          }),
+      )
+
+      // Under the buggy implementation:
+      // - Task A's finally block decremented activeCount to 0.
+      // - Task C sees activeCount = 0 and runs immediately instead of queueing.
+      // - So queue length would be 0, and Task C is active.
+      //
+      // Under the fixed implementation:
+      // - Task A's finally block transferred the slot to Task B without decrementing activeCount.
+      // - So activeCount remains 1.
+      // - Task C sees activeCount = 1 and is correctly queued.
+      // - So queue length is 1, and Task C is NOT active.
+      expect(limiter.getActiveCount()).toBe(1)
+      expect(limiter.getQueueLength()).toBe(1)
+
+      // Clean up by resolving the rest in order
+      // 1. Let Task B resume and run
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      resolveB()
+
+      // 2. Let Task C resume and run
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      resolveC()
+
+      await Promise.all([promiseA, promiseB, promiseC])
+
+      expect(limiter.getActiveCount()).toBe(0)
+      expect(limiter.getQueueLength()).toBe(0)
     })
   })
 })

--- a/src/workflow/local-executor.test.ts
+++ b/src/workflow/local-executor.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { prisma } from '@/db'
+import { setupTestDbHooks } from '@/db-test-hooks'
+import { workflowService } from './workflow'
+import { LocalExecutor } from './local-executor'
+import { WorkflowTaskStatus, WorkflowTaskType } from '@/generated/prisma/client'
+
+// Mock the individual workflows
+const mocks = {
+  agentEmbeddingMedia: vi.fn(),
+  queryEmbeddingForSearch: vi.fn(),
+  agentAutofillMedia: vi.fn(),
+  agentChat: vi.fn(),
+  transcodeMedia: vi.fn(),
+}
+
+vi.mock('./workflows/agent-embedding', () => ({
+  agentEmbeddingMedia: (task: unknown) => mocks.agentEmbeddingMedia(task),
+}))
+vi.mock('./workflows/query-embedding-for-search', () => ({
+  queryEmbeddingForSearch: (task: unknown) => mocks.queryEmbeddingForSearch(task),
+}))
+vi.mock('./workflows/agent-autofill', () => ({
+  agentAutofillMedia: (task: unknown) => mocks.agentAutofillMedia(task),
+}))
+vi.mock('./workflows/agent-chat', () => ({
+  agentChat: (task: unknown) => mocks.agentChat(task),
+}))
+vi.mock('@/transcode/workflows/transcode', () => ({
+  transcodeMedia: (task: unknown) => mocks.transcodeMedia(task),
+}))
+
+describe('LocalExecutor Integration Tests', () => {
+  setupTestDbHooks()
+
+  let executor: LocalExecutor
+
+  beforeEach(() => {
+    // Get the global executor instance which processes tasks submitted via the Prisma Client Extension
+    executor = (workflowService as unknown as { executor: LocalExecutor }).executor
+    vi.clearAllMocks()
+  })
+
+  describe('Heartbeat & Task Status transition', () => {
+    it('should immediately transition task to processing and set initial heartbeat', async () => {
+      let resolveChat: (value: unknown) => void = () => {}
+      const chatPromise = new Promise((resolve) => {
+        resolveChat = resolve
+      })
+      mocks.agentChat.mockImplementationOnce(() => chatPromise)
+
+      const task = await prisma.workflowTask.create({
+        data: {
+          assetId: 'test-asset',
+          type: WorkflowTaskType.chat,
+          status: WorkflowTaskStatus.pending,
+        },
+      })
+
+      // Wait briefly for the Prisma Client Extension's async submit (setTimeout 0) to execute and transition task
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      const intermediateTask = await prisma.workflowTask.findUnique({
+        where: { id: task.id },
+      })
+
+      expect(intermediateTask?.status).toBe(WorkflowTaskStatus.processing)
+      expect(intermediateTask?.heartbeat).toBeInstanceOf(Date)
+
+      // Clean up
+      resolveChat(undefined)
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    })
+
+    it('should query and retry stale tasks in tick() but ignore non-stale processing tasks', async () => {
+      mocks.agentChat.mockResolvedValue(undefined)
+
+      // 1. Create a stale task (processing, heartbeat 40 seconds ago)
+      const staleTask = await prisma.workflowTask.create({
+        data: {
+          assetId: 'asset-stale',
+          type: WorkflowTaskType.chat,
+          status: WorkflowTaskStatus.processing,
+          heartbeat: new Date(Date.now() - 40 * 1000),
+        },
+      })
+
+      // 2. Create a non-stale task (processing, heartbeat 5 seconds ago)
+      const activeTask = await prisma.workflowTask.create({
+        data: {
+          assetId: 'asset-active',
+          type: WorkflowTaskType.chat,
+          status: WorkflowTaskStatus.processing,
+          heartbeat: new Date(Date.now() - 5 * 1000),
+        },
+      })
+
+      // Trigger tick manually on the executor and await the returned task promises
+      const promises = await executor.tick()
+      await Promise.all(promises)
+
+      // The stale task should be picked up and processed (mocks.agentChat called for staleTask)
+      expect(mocks.agentChat).toHaveBeenCalledWith(expect.objectContaining({ id: staleTask.id }))
+
+      // The active task should NOT be called
+      expect(mocks.agentChat).not.toHaveBeenCalledWith(
+        expect.objectContaining({ id: activeTask.id }),
+      )
+    })
+  })
+
+  describe('Concurrency Control', () => {
+    it('should limit transcode tasks to a concurrency of 1', async () => {
+      let resolveFirstTranscode: (value: unknown) => void = () => {}
+      const firstTranscodePromise = new Promise((resolve) => {
+        resolveFirstTranscode = resolve
+      })
+      mocks.transcodeMedia.mockImplementationOnce(() => firstTranscodePromise)
+      mocks.transcodeMedia.mockImplementationOnce(() => Promise.resolve())
+
+      const task1 = await prisma.workflowTask.create({
+        data: {
+          assetId: 'asset-1',
+          type: WorkflowTaskType.transcode,
+          status: WorkflowTaskStatus.pending,
+        },
+      })
+
+      const task2 = await prisma.workflowTask.create({
+        data: {
+          assetId: 'asset-2',
+          type: WorkflowTaskType.transcode,
+          status: WorkflowTaskStatus.pending,
+        },
+      })
+
+      // Wait briefly for Prisma Client Extension's async submits to trigger
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // The first task should be actively running
+      expect(mocks.transcodeMedia).toHaveBeenCalledWith(expect.objectContaining({ id: task1.id }))
+      // The second task should NOT have started yet because transcode pool limit is 1
+      expect(mocks.transcodeMedia).not.toHaveBeenCalledWith(
+        expect.objectContaining({ id: task2.id }),
+      )
+
+      // Resolve the first task to let the second task execute
+      resolveFirstTranscode(undefined)
+
+      // Wait briefly for the pool queue to process next item
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // The second task should now be running
+      expect(mocks.transcodeMedia).toHaveBeenCalledWith(expect.objectContaining({ id: task2.id }))
+    })
+
+    it('should limit general tasks to a concurrency of 5 and run them concurrently', async () => {
+      const activeResolvers: ((value: unknown) => void)[] = []
+      mocks.agentChat.mockImplementation(() => {
+        return new Promise((resolve) => {
+          activeResolvers.push(resolve)
+        })
+      })
+
+      // Create 7 general workflow tasks (limit is 5)
+      await Promise.all(
+        Array.from({ length: 7 }).map((_, i) =>
+          prisma.workflowTask.create({
+            data: {
+              assetId: `asset-chat-${i}`,
+              type: WorkflowTaskType.chat,
+              status: WorkflowTaskStatus.pending,
+            },
+          }),
+        ),
+      )
+
+      // Wait briefly for Prisma Client Extension's async submits to trigger
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Exactly 5 tasks should be running concurrently
+      expect(mocks.agentChat).toHaveBeenCalledTimes(5)
+
+      // Resolve 2 tasks to let the remaining 2 start
+      activeResolvers[0](undefined)
+      activeResolvers[1](undefined)
+
+      // Wait briefly for the pool to dequeue
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Now all 7 tasks should have started
+      expect(mocks.agentChat).toHaveBeenCalledTimes(7)
+
+      // Clean up remaining tasks
+      activeResolvers.slice(2).forEach((resolve) => resolve(undefined))
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    })
+  })
+})

--- a/src/workflow/local-executor.ts
+++ b/src/workflow/local-executor.ts
@@ -15,7 +15,7 @@ import { logger } from '@/logger'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ;(globalThis as any).__localLogger = logger
 
-class ConcurrencyLimiter {
+export class ConcurrencyLimiter {
   private activeCount = 0
   private queue: (() => void)[] = []
 
@@ -24,15 +24,18 @@ class ConcurrencyLimiter {
   async run<T>(fn: () => Promise<T>): Promise<T> {
     if (this.activeCount >= this.limit) {
       await new Promise<void>((resolve) => this.queue.push(resolve))
+    } else {
+      this.activeCount++
     }
-    this.activeCount++
+
     try {
       return await fn()
     } finally {
-      this.activeCount--
       const next = this.queue.shift()
       if (next) {
         next()
+      } else {
+        this.activeCount--
       }
     }
   }

--- a/src/workflow/local-executor.ts
+++ b/src/workflow/local-executor.ts
@@ -15,9 +15,45 @@ import { logger } from '@/logger'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ;(globalThis as any).__localLogger = logger
 
+class ConcurrencyLimiter {
+  private activeCount = 0
+  private queue: (() => void)[] = []
+
+  constructor(private readonly limit: number) {}
+
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.activeCount >= this.limit) {
+      await new Promise<void>((resolve) => this.queue.push(resolve))
+    }
+    this.activeCount++
+    try {
+      return await fn()
+    } finally {
+      this.activeCount--
+      const next = this.queue.shift()
+      if (next) {
+        next()
+      }
+    }
+  }
+
+  // Exposed for testing concurrency status
+  getActiveCount(): number {
+    return this.activeCount
+  }
+
+  getQueueLength(): number {
+    return this.queue.length
+  }
+}
+
 export class LocalExecutor implements Executor {
   private interval: Timer | null = null
   private processingTasks = new Set<string>()
+
+  // 1 concurrency for transcode, 5 for other workflows
+  private transcodeLimiter = new ConcurrencyLimiter(1)
+  private generalLimiter = new ConcurrencyLimiter(5)
 
   async submit(task: WorkflowTask): Promise<string> {
     if (task.status !== WorkflowTaskStatus.pending) {
@@ -27,12 +63,17 @@ export class LocalExecutor implements Executor {
       })
     }
 
-    // In tests, we trigger processing immediately
+    // In tests, we trigger processing immediately using the appropriate limiter
     if (process.env.NODE_ENV === 'test') {
       setTimeout(() => {
-        this.processTaskWrapper(task).catch((err) => {
-          console.error(`[LocalExecutor] Failed to process task ${task.id}:`, err)
-        })
+        const limiter =
+          task.type === WorkflowTaskType.transcode ? this.transcodeLimiter : this.generalLimiter
+
+        limiter
+          .run(() => this.processTaskWrapper(task))
+          .catch((err) => {
+            console.error(`[LocalExecutor] Failed to process task ${task.id}:`, err)
+          })
       }, 0)
     }
     return task.id
@@ -50,7 +91,9 @@ export class LocalExecutor implements Executor {
     }
   }
 
-  private async tick() {
+  // Returns the array of task promises so tests can await them to avoid early rollback.
+  async tick(): Promise<Promise<void>[]> {
+    const promises: Promise<void>[] = []
     try {
       const staleTime = new Date(Date.now() - 30 * 1000)
       const tasks = await prisma.workflowTask.findMany({
@@ -68,18 +111,53 @@ export class LocalExecutor implements Executor {
 
       for (const task of tasks) {
         if (this.processingTasks.has(task.id)) continue
-        this.processTaskWrapper(task).catch((err) => {
-          console.error(`[LocalExecutor] Failed to process task ${task.id}:`, err)
-        })
+
+        const limiter =
+          task.type === WorkflowTaskType.transcode ? this.transcodeLimiter : this.generalLimiter
+
+        const promise = limiter
+          .run(() => this.processTaskWrapper(task))
+          .catch((err) => {
+            console.error(`[LocalExecutor] Failed to process task ${task.id}:`, err)
+          })
+        promises.push(promise)
       }
     } catch (err) {
       console.error('Failed to fetch tasks:', err)
     }
+    return promises
   }
 
   private async processTaskWrapper(task: WorkflowTask) {
     if (this.processingTasks.has(task.id)) return
     this.processingTasks.add(task.id)
+
+    // 1. Immediately mark task as processing and set initial heartbeat in DB
+    try {
+      await prisma.workflowTask.update({
+        where: { id: task.id },
+        data: {
+          status: WorkflowTaskStatus.processing,
+          heartbeat: new Date(),
+        },
+      })
+    } catch (err) {
+      console.error(`[LocalExecutor] Failed to mark task ${task.id} as processing:`, err)
+      this.processingTasks.delete(task.id)
+      return
+    }
+
+    // 2. Start heartbeat updater every 5 seconds
+    const heartbeatInterval = setInterval(async () => {
+      try {
+        await prisma.workflowTask.update({
+          where: { id: task.id },
+          data: { heartbeat: new Date() },
+        })
+      } catch (err) {
+        console.error(`[LocalExecutor] Failed to update heartbeat for task ${task.id}:`, err)
+      }
+    }, 5000)
 
     try {
       switch (task.type) {
@@ -115,6 +193,8 @@ export class LocalExecutor implements Executor {
         console.error(`Failed to set task ${task.id} to failed:`, updateErr)
       }
     } finally {
+      // 3. Clean up the heartbeat updater and processing set
+      clearInterval(heartbeatInterval)
       this.processingTasks.delete(task.id)
     }
   }


### PR DESCRIPTION
## Summary

This PR implements concurrency control and automatic task heartbeats in the `LocalExecutor` to improve local task execution robustness, predictability, and safety. It also includes a fix for a classic microtask queue race condition in the concurrency limiter.

## Changes

- **Concurrency Pools**: Replaced the unbounded asynchronous spawning of local tasks in `LocalExecutor` with two in-memory concurrency pools managed via a custom, fully-typed `ConcurrencyLimiter` class:
  - `transcode` workflows are limited to a concurrency of **1**.
  - All other workflows (`ai_embedding`, `chat`, `ai_metadata_autofill`, etc.) share a general pool with a concurrency of **5**.
- **Microtask Race Condition Fix**: Refactored the `ConcurrencyLimiter` to use a safe semaphore-style slot-transfer pattern. In the buggy implementation, a small microtask gap existed between releasing a task (`resolve()`) and incrementing `activeCount`, allowing a fast synchronous task to slip through the limiter and violate the concurrency bounds. By immediately transferring the slot without leaving a gap (leaving `activeCount` incremented and resolving queued tasks directly), this race condition is resolved.
- **Task Heartbeat Loop**: Added an automatic periodic heartbeat loop inside the `LocalExecutor` that sets the initial heartbeat timestamp when starting execution, updates it every **5 seconds** inside a `setInterval`, and guarantees proper cleanup (via `clearInterval` and `processingTasks` removal) inside a `finally` block on task completion/failure.
- **Robust Tick Awaiting**: Updated the `tick()` method to return task promises, enabling integration tests to securely await background tasks without hitting premature test database transaction rollbacks.
- **Unit and Integration Tests**: Added a dedicated test suite (`src/workflow/local-executor.test.ts`) that verifies:
  - Concurrency pools and pool isolation.
  - Stale task query and reprocessing logic.
  - Heartbeat status transition.
  - A highly-precise, deterministic unit test reproducing and validating the `ConcurrencyLimiter` microtask race condition.

## Verification

- Successfully verified all tests pass:
  - Concurrency limit of 1 for transcode pools.
  - Concurrency limit of 5 for general workflow pools.
  - ConcurrencyLimiter microtask race condition unit test.
  - Stale task query and reprocessing under `tick()`.
  - Immediate database status transition to `processing` and setting of the initial `heartbeat` timestamp.
- Verified that all other checks in the codebase pass:
  - `bun run lint` (Passed)
  - `bun run format` (Passed)
  - `bun run typecheck` (Passed)
  - `bun run test` (Passed all 367 tests across 59 files)

## Notes

No external dependencies were added. The custom `ConcurrencyLimiter` ensures complete compatibility with TS paths, ESM imports, shared Prisma client connections, and global dependency injections in Bun.
