### PR TITLE
feat(workflow): lock task status and start heartbeat immediately upon queueing

### DIFF
--- a/src/workflow/local-executor.test.ts
+++ b/src/workflow/local-executor.test.ts
@@ -122,6 +122,37 @@ describe('LocalExecutor Integration Tests', () => {
       await new Promise((resolve) => setTimeout(resolve, 50))
     })
 
+    it('should atomically claim tasks using CAS updateMany to prevent double-execution when tick() runs concurrently', async () => {
+      mocks.agentChat.mockResolvedValue(undefined)
+
+      // Mock submit to prevent automatic execution by the Prisma Client Extension
+      const submitSpy = vi.spyOn(workflowService, 'submit').mockResolvedValue('dummy-id')
+
+      // Create a single pending task (will NOT be run automatically because submit is mocked)
+      const task = await prisma.workflowTask.create({
+        data: {
+          assetId: 'asset-concurrent-test',
+          type: WorkflowTaskType.chat,
+          status: WorkflowTaskStatus.pending,
+        },
+      })
+
+      // We trigger two ticks concurrently to simulate overlapping polling cycles or multi-replica triggers.
+      // Both ticks will query the database at approximately the same time.
+      const tick1 = executor.tick()
+      const tick2 = executor.tick()
+
+      const [promises1, promises2] = await Promise.all([tick1, tick2])
+      await Promise.all([...promises1, ...promises2])
+
+      // Verify that the mock workflow is called EXACTLY ONCE for this task ID,
+      // proving that one tick successfully claimed the task and the other was atomically blocked.
+      expect(mocks.agentChat).toHaveBeenCalledTimes(1)
+      expect(mocks.agentChat).toHaveBeenCalledWith(expect.objectContaining({ id: task.id }))
+
+      submitSpy.mockRestore()
+    })
+
     it('should query and retry stale tasks in tick() but ignore non-stale processing tasks', async () => {
       mocks.agentChat.mockResolvedValue(undefined)
 

--- a/src/workflow/local-executor.test.ts
+++ b/src/workflow/local-executor.test.ts
@@ -72,6 +72,56 @@ describe('LocalExecutor Integration Tests', () => {
       await new Promise((resolve) => setTimeout(resolve, 50))
     })
 
+    it('should immediately lock task and start heartbeat updates in database even when queued in limiter', async () => {
+      let resolveFirstTranscode: (value: unknown) => void = () => {}
+      const firstTranscodePromise = new Promise((resolve) => {
+        resolveFirstTranscode = resolve
+      })
+      mocks.transcodeMedia.mockImplementationOnce(() => firstTranscodePromise)
+      mocks.transcodeMedia.mockImplementationOnce(() => Promise.resolve())
+
+      // 1. Create task 1 (will run immediately and hold the transcode limiter slot)
+      const task1 = await prisma.workflowTask.create({
+        data: {
+          assetId: 'asset-1',
+          type: WorkflowTaskType.transcode,
+          status: WorkflowTaskStatus.pending,
+        },
+      })
+
+      // 2. Create task 2 (will be blocked and queued in memory by transcode limiter)
+      const task2 = await prisma.workflowTask.create({
+        data: {
+          assetId: 'asset-2',
+          type: WorkflowTaskType.transcode,
+          status: WorkflowTaskStatus.pending,
+        },
+      })
+
+      // Wait briefly for Prisma Client Extension's async submits to queue task2
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // 3. Verify task 1 is running
+      expect(mocks.transcodeMedia).toHaveBeenCalledWith(expect.objectContaining({ id: task1.id }))
+
+      // 4. Verify task 2 has NOT started executing yet
+      expect(mocks.transcodeMedia).not.toHaveBeenCalledWith(
+        expect.objectContaining({ id: task2.id }),
+      )
+
+      // 5. BUT verify task 2 is already locked in database and has heartbeat set!
+      const dbTask2 = await prisma.workflowTask.findUnique({
+        where: { id: task2.id },
+      })
+
+      expect(dbTask2?.status).toBe(WorkflowTaskStatus.processing)
+      expect(dbTask2?.heartbeat).toBeInstanceOf(Date)
+
+      // Clean up
+      resolveFirstTranscode(undefined)
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    })
+
     it('should query and retry stale tasks in tick() but ignore non-stale processing tasks', async () => {
       mocks.agentChat.mockResolvedValue(undefined)
 

--- a/src/workflow/local-executor.ts
+++ b/src/workflow/local-executor.ts
@@ -73,14 +73,22 @@ export class LocalExecutor implements Executor {
         this.processingTasks.add(task.id)
 
         // 1. Immediately mark task as processing and set initial heartbeat in DB
+        // atomically, only if the task is still pending.
         try {
-          await prisma.workflowTask.update({
-            where: { id: task.id },
+          const affected = await prisma.workflowTask.updateMany({
+            where: {
+              id: task.id,
+              status: WorkflowTaskStatus.pending,
+            },
             data: {
               status: WorkflowTaskStatus.processing,
               heartbeat: new Date(),
             },
           })
+          if (affected.count === 0) {
+            this.processingTasks.delete(task.id)
+            return
+          }
         } catch (err) {
           console.error(
             `[LocalExecutor] Failed to mark task ${task.id} as processing in submit:`,
@@ -159,14 +167,28 @@ export class LocalExecutor implements Executor {
 
         // 1. Immediately mark task as processing and set initial heartbeat in DB
         // to guarantee no other ticks/replicas can double-query it.
+        // We use updateMany to atomically claim it only if it is still pending or stale.
         try {
-          await prisma.workflowTask.update({
-            where: { id: task.id },
+          const affected = await prisma.workflowTask.updateMany({
+            where: {
+              id: task.id,
+              OR: [
+                { status: WorkflowTaskStatus.pending },
+                {
+                  status: WorkflowTaskStatus.processing,
+                  heartbeat: { lt: staleTime },
+                },
+              ],
+            },
             data: {
               status: WorkflowTaskStatus.processing,
               heartbeat: new Date(),
             },
           })
+          if (affected.count === 0) {
+            this.processingTasks.delete(task.id)
+            continue
+          }
         } catch (err) {
           console.error(`[LocalExecutor] Failed to mark task ${task.id} as processing:`, err)
           this.processingTasks.delete(task.id)

--- a/src/workflow/local-executor.ts
+++ b/src/workflow/local-executor.ts
@@ -68,12 +68,53 @@ export class LocalExecutor implements Executor {
 
     // In tests, we trigger processing immediately using the appropriate limiter
     if (process.env.NODE_ENV === 'test') {
-      setTimeout(() => {
+      setTimeout(async () => {
+        if (this.processingTasks.has(task.id)) return
+        this.processingTasks.add(task.id)
+
+        // 1. Immediately mark task as processing and set initial heartbeat in DB
+        try {
+          await prisma.workflowTask.update({
+            where: { id: task.id },
+            data: {
+              status: WorkflowTaskStatus.processing,
+              heartbeat: new Date(),
+            },
+          })
+        } catch (err) {
+          console.error(
+            `[LocalExecutor] Failed to mark task ${task.id} as processing in submit:`,
+            err,
+          )
+          this.processingTasks.delete(task.id)
+          return
+        }
+
+        // 2. Start heartbeat updater immediately
+        const heartbeatInterval = setInterval(async () => {
+          try {
+            await prisma.workflowTask.update({
+              where: { id: task.id },
+              data: { heartbeat: new Date() },
+            })
+          } catch (err) {
+            console.error(`[LocalExecutor] Failed to update heartbeat for task ${task.id}:`, err)
+          }
+        }, 5000)
+
         const limiter =
           task.type === WorkflowTaskType.transcode ? this.transcodeLimiter : this.generalLimiter
 
         limiter
-          .run(() => this.processTaskWrapper(task))
+          .run(async () => {
+            try {
+              await this.processTaskWrapper(task)
+            } finally {
+              // 3. Clean up the heartbeat updater and processing set when the task finishes
+              clearInterval(heartbeatInterval)
+              this.processingTasks.delete(task.id)
+            }
+          })
           .catch((err) => {
             console.error(`[LocalExecutor] Failed to process task ${task.id}:`, err)
           })
@@ -114,12 +155,50 @@ export class LocalExecutor implements Executor {
 
       for (const task of tasks) {
         if (this.processingTasks.has(task.id)) continue
+        this.processingTasks.add(task.id)
+
+        // 1. Immediately mark task as processing and set initial heartbeat in DB
+        // to guarantee no other ticks/replicas can double-query it.
+        try {
+          await prisma.workflowTask.update({
+            where: { id: task.id },
+            data: {
+              status: WorkflowTaskStatus.processing,
+              heartbeat: new Date(),
+            },
+          })
+        } catch (err) {
+          console.error(`[LocalExecutor] Failed to mark task ${task.id} as processing:`, err)
+          this.processingTasks.delete(task.id)
+          continue
+        }
+
+        // 2. Start heartbeat updater immediately so it updates heartbeat
+        // even while the task is queued waiting for limiter capacity.
+        const heartbeatInterval = setInterval(async () => {
+          try {
+            await prisma.workflowTask.update({
+              where: { id: task.id },
+              data: { heartbeat: new Date() },
+            })
+          } catch (err) {
+            console.error(`[LocalExecutor] Failed to update heartbeat for task ${task.id}:`, err)
+          }
+        }, 5000)
 
         const limiter =
           task.type === WorkflowTaskType.transcode ? this.transcodeLimiter : this.generalLimiter
 
         const promise = limiter
-          .run(() => this.processTaskWrapper(task))
+          .run(async () => {
+            try {
+              await this.processTaskWrapper(task)
+            } finally {
+              // 3. Clean up the heartbeat updater and processing set when the task finishes
+              clearInterval(heartbeatInterval)
+              this.processingTasks.delete(task.id)
+            }
+          })
           .catch((err) => {
             console.error(`[LocalExecutor] Failed to process task ${task.id}:`, err)
           })
@@ -132,36 +211,6 @@ export class LocalExecutor implements Executor {
   }
 
   private async processTaskWrapper(task: WorkflowTask) {
-    if (this.processingTasks.has(task.id)) return
-    this.processingTasks.add(task.id)
-
-    // 1. Immediately mark task as processing and set initial heartbeat in DB
-    try {
-      await prisma.workflowTask.update({
-        where: { id: task.id },
-        data: {
-          status: WorkflowTaskStatus.processing,
-          heartbeat: new Date(),
-        },
-      })
-    } catch (err) {
-      console.error(`[LocalExecutor] Failed to mark task ${task.id} as processing:`, err)
-      this.processingTasks.delete(task.id)
-      return
-    }
-
-    // 2. Start heartbeat updater every 5 seconds
-    const heartbeatInterval = setInterval(async () => {
-      try {
-        await prisma.workflowTask.update({
-          where: { id: task.id },
-          data: { heartbeat: new Date() },
-        })
-      } catch (err) {
-        console.error(`[LocalExecutor] Failed to update heartbeat for task ${task.id}:`, err)
-      }
-    }, 5000)
-
     try {
       switch (task.type) {
         case WorkflowTaskType.ai_embedding:
@@ -195,10 +244,6 @@ export class LocalExecutor implements Executor {
       } catch (updateErr) {
         console.error(`Failed to set task ${task.id} to failed:`, updateErr)
       }
-    } finally {
-      // 3. Clean up the heartbeat updater and processing set
-      clearInterval(heartbeatInterval)
-      this.processingTasks.delete(task.id)
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR implements immediate database status locking and active heartbeat loops at the queue boundary (inside `tick()` and `submit()`) in the `LocalExecutor` to eliminate task double-queueing race conditions.

## Changes

- **Queue-Level Status Locking**: Tasks are immediately updated to `status: processing` and assigned a starting `heartbeat` timestamp inside the `tick()` polling loop (and the `submit()` test loop) at the exact moment they are queued in the limiter. This prevents subsequent ticks or separate server processes/replicas from double-querying and double-submitting a pending task while it waits for a concurrency slot in memory.
- **In-Queue Heartbeats**: Heartbeat update intervals (`setInterval`) are started immediately upon queueing, ensuring that tasks that are queued in memory for longer than 30 seconds (due to pool capacity limits) continue updating their database heartbeats and do not get incorrectly re-queued by the stale-check logic.
- **Limiter Execution Isolation**: Simplified `processTaskWrapper` by moving heartbeat and status lifecycle setups to the queue boundary. The limiter's execution block is now purely responsible for executing the workflow switch-case and handling execution failures.
- **Verification Coverage**: Added a dedicated integration test `should immediately lock task and start heartbeat updates in database even when queued in limiter` inside `src/workflow/local-executor.test.ts` to explicitly assert that queued tasks are locked in the database and heartbeated before they are dequeued and executed by the limiter.

## Verification

- Verified that all 6 tests in `src/workflow/local-executor.test.ts` pass perfectly, including the new immediate lock test and the `ConcurrencyLimiter` microtask race condition unit test.
- Ran all codebase quality checks:
  - `bun run lint` (Passed)
  - `bun run format` (Passed)
  - `bun run typecheck` (Passed)
  - `bun run test` (Passed all 368 tests across 59 files)

## Notes

Option 2 (Immediate DB Locking + In-Queue Heartbeats) was chosen as it successfully prevents queue race conditions while preserving the non-blocking polling model (avoiding Head-of-Line blocking seen in Option 1).
