### PR TITLE
fix(ui): make sort dropdowns same width and hide order for custom

### DIFF
--- a/src/ui/components/search/sort-control.tsx
+++ b/src/ui/components/search/sort-control.tsx
@@ -1,5 +1,6 @@
 import { type FieldInfo as MetadataFieldInfo } from '@/dtos/metadata'
 import type { SearchSort } from '@/dtos/search'
+import { ArrowDownUp } from 'lucide-react'
 import { Button } from '@/ui/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/ui/components/ui/popover'
 import {
@@ -86,7 +87,7 @@ export function SortControl({ fields, sort, onSortChange, disabled }: SortContro
           <div className="grid gap-2">
             <span className="text-sm text-muted-foreground">Sort by</span>
             <Select value={currentFieldId} onValueChange={handleFieldChange}>
-              <SelectTrigger>
+              <SelectTrigger className="w-full">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent position="popper">
@@ -99,18 +100,19 @@ export function SortControl({ fields, sort, onSortChange, disabled }: SortContro
             </Select>
           </div>
 
-          <div className="flex items-center gap-3">
-            <span className="text-sm text-muted-foreground w-8">from</span>
-            <Select value={isAsc ? 'asc' : 'desc'} onValueChange={handleOrderChange}>
-              <SelectTrigger className="flex-1">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent position="popper">
-                <SelectItem value="asc">{dirOptions.asc}</SelectItem>
-                <SelectItem value="desc">{dirOptions.desc}</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+          {currentFieldId !== 'custom' && (
+            <div className="grid gap-2">
+              <span className="text-sm text-muted-foreground">Order</span>
+              <Button
+                variant="outline"
+                className="w-full justify-between font-normal"
+                onClick={() => handleOrderChange(isAsc ? 'desc' : 'asc')}
+              >
+                <span>{isAsc ? dirOptions.asc : dirOptions.desc}</span>
+                <ArrowDownUp className="size-4 opacity-50" />
+              </Button>
+            </div>
+          )}
         </div>
       </PopoverContent>
     </Popover>

--- a/src/ui/components/user-menu.tsx
+++ b/src/ui/components/user-menu.tsx
@@ -7,6 +7,10 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+  DropdownMenuPortal,
 } from '@/ui/components/ui/dropdown-menu'
 import { useTeamId } from '@/ui/hooks/use-team-id'
 import { signOut } from '@/ui/lib/auth-client'
@@ -14,6 +18,7 @@ import { useAuthStore } from '@/ui/stores/auth'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import { useTheme } from './theme-provider'
+import { Check } from 'lucide-react'
 
 export function UserMenu() {
   const { clearAuth } = useAuthStore()
@@ -30,7 +35,7 @@ export function UserMenu() {
     },
     enabled: !!teamId,
   })
-  const { setTheme } = useTheme()
+  const { setTheme, theme } = useTheme()
   const navigate = useNavigate()
 
   const handleLogout = async () => {
@@ -69,10 +74,34 @@ export function UserMenu() {
             <DropdownMenuSeparator />
           </>
         )}
-        <DropdownMenuLabel>Theme</DropdownMenuLabel>
-        <DropdownMenuItem onClick={() => setTheme('light')}>Light</DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme('dark')}>Dark</DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme('system')}>System</DropdownMenuItem>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>Theme</DropdownMenuSubTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem
+                className="justify-between flex items-center"
+                onClick={() => setTheme('light')}
+              >
+                <span>Light</span>
+                {theme === 'light' && <Check className="size-4" />}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="justify-between flex items-center"
+                onClick={() => setTheme('dark')}
+              >
+                <span>Dark</span>
+                {theme === 'dark' && <Check className="size-4" />}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="justify-between flex items-center"
+                onClick={() => setTheme('system')}
+              >
+                <span>System</span>
+                {theme === 'system' && <Check className="size-4" />}
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuPortal>
+        </DropdownMenuSub>
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onClick={() =>


### PR DESCRIPTION
## Summary

This PR addresses layout and interaction design issues in the sort control pop-up on the file list page, and improves the theme switcher in the user avatar dropdown menu:
1. It ensures the first row (column) and second row (order) are the same width and take up the full width of the pop-up.
2. It changes the sort order row to be a clickable toggle button instead of a dropdown select, adding a clean "ArrowDownUp" icon on the right end of the button.
3. It hides the second row (order toggle button) completely when the "Custom" sort option is selected, preventing the user from changing the sort order for custom sorts.
4. It shifts the theme switcher in the left sidebar's user avatar dropdown menu into a nested submenu wrapped in a `DropdownMenuPortal` to avoid layout clipping issues.
5. It conditionally displays a check icon (`Check` from `lucide-react`) on the right end of the currently active theme selection in the sub-menu.

## Changes

- Updated `src/ui/components/search/sort-control.tsx` to:
  - Add `className="w-full"` to the `SelectTrigger` element of the column select so it spans the full width of the pop-up.
  - Implement a clickable `Button` (with `variant="outline"` and `w-full justify-between`) for the sort order row that toggles the sort order on click.
  - Render an `ArrowDownUp` icon on the right end of the sort order toggle button.
  - Structure both rows identically with a grid layout (`grid gap-2`) and aligned labels ("Sort by" and "Order").
  - Wrap the second row (order selection button) with a conditional block that only renders when the selected field is not `"custom"`.

- Updated `src/ui/components/user-menu.tsx` to:
  - Nest the Light, Dark, and System theme selections inside a nested `DropdownMenuSub` component.
  - Wrap the `DropdownMenuSubContent` in a `DropdownMenuPortal` to render it cleanly without horizontal boundaries clipping it.
  - Destructure the active `theme` state from the `useTheme` hook and import the `Check` icon from `lucide-react`.
  - Add conditional checkmarks rendered at the right end of each theme item by styling them as `justify-between` flex elements.

## Verification

- Ran `bun run typecheck` which completed successfully with no errors.
- Ran `bun run lint` which completed successfully with no warnings.
- Ran `bun run format` to ensure the codebase remains beautifully formatted.
- Ran `bun run test` which completed successfully, with all 376 tests passing without regressions.