### PR TITLE
feat(auth): remove public signup

### DIFF
--- a/packages/api/src/api/authn.test.ts
+++ b/packages/api/src/api/authn.test.ts
@@ -18,7 +18,6 @@ describe('authn api', () => {
   it('GET /signup-info', async () => {
     mockGetSignupInfo.mockResolvedValue({
       userCount: 5,
-      enablePublicSignup: true,
     })
 
     const app = new Hono().route('/', authnRoute)
@@ -27,7 +26,6 @@ describe('authn api', () => {
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({
       userCount: 5,
-      enablePublicSignup: true,
     })
   })
 })

--- a/packages/api/src/api/authn.ts
+++ b/packages/api/src/api/authn.ts
@@ -18,7 +18,6 @@ const route = app
     const info = await teamService.getSignupInfo()
     return c.json({
       userCount: info.userCount,
-      enablePublicSignup: info.enablePublicSignup,
     })
   })
   .get('/me', async (c) => {

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -42,6 +42,18 @@ export const auth = betterAuth({
               },
             )
           }
+
+          const isValid = await inviteService.validateInvite(inviteCode)
+          if (!isValid) {
+            return ctx.json(
+              {
+                error: 'Invalid or expired invite code',
+              },
+              {
+                status: 400,
+              },
+            )
+          }
         }
       }
     }),

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -31,7 +31,7 @@ export const auth = betterAuth({
         const info = await teamService.getSignupInfo()
 
         if (info.userCount > 0) {
-          if (!inviteCode && !info.enablePublicSignup) {
+          if (!inviteCode) {
             console.log('[Better Auth Hook] Public signup is disabled')
             return ctx.json(
               {

--- a/packages/core/src/collection/collection.test.ts
+++ b/packages/core/src/collection/collection.test.ts
@@ -15,7 +15,6 @@ describe('CollectionService', () => {
       data: {
         name: 'Test Team',
         settings: {
-          enablePublicSignup: true,
           transcode: { videoStrategy: 'best_match' },
         },
         sandbox: { create: {} },

--- a/packages/core/src/invite/invite.ts
+++ b/packages/core/src/invite/invite.ts
@@ -61,6 +61,22 @@ export class InviteService {
     return inv
   }
 
+  async validateInvite(code: string): Promise<boolean> {
+    const inv = await prisma.invite.findUnique({
+      where: { code },
+    })
+
+    if (!inv) {
+      return false
+    }
+
+    if (inv.used) {
+      return false
+    }
+
+    return true
+  }
+
   async consumeInvite(code: string, userId: string): Promise<void> {
     await prisma.$transaction(async (tx) => {
       const inv = await tx.invite.findUniqueOrThrow({

--- a/packages/core/src/team/team.ts
+++ b/packages/core/src/team/team.ts
@@ -26,7 +26,6 @@ export class TeamService {
         data: {
           name: 'Default Team',
           settings: {
-            enablePublicSignup: true,
             transcode: { videoStrategy: 'best_match' },
           },
           sandbox: { create: {} },
@@ -249,14 +248,9 @@ export class TeamService {
 
   async getSignupInfo() {
     const count = await prisma.user.count()
-    const defaultTeam = await this.ensureDefaultTeam()
-    const settings = defaultTeam.settings as {
-      enablePublicSignup?: boolean
-    } | null
 
     return {
       userCount: count,
-      enablePublicSignup: settings?.enablePublicSignup ?? false,
     }
   }
 

--- a/packages/db/src/prisma-json-types.ts
+++ b/packages/db/src/prisma-json-types.ts
@@ -59,7 +59,6 @@ declare global {
 
     export interface Settings {
       transcode: TranscodeSettings
-      enablePublicSignup: boolean
     }
 
     // ----------------------------------------------------------------------

--- a/packages/dtos/src/auth.ts
+++ b/packages/dtos/src/auth.ts
@@ -2,7 +2,6 @@ import { z } from 'zod'
 
 export const signupInfoResponseSchema = z.object({
   userCount: z.number(),
-  enablePublicSignup: z.boolean(),
 })
 
 export type SignupInfoResponse = z.infer<typeof signupInfoResponseSchema>

--- a/packages/webui/routes/signup.tsx
+++ b/packages/webui/routes/signup.tsx
@@ -96,7 +96,7 @@ function SignupPage() {
   }
 
   const isFirstUser = signupInfo?.userCount === 0
-  const isPublicSignupDisabled = !isFirstUser && !signupInfo?.enablePublicSignup && !inviteCode
+  const isPublicSignupDisabled = !isFirstUser && !inviteCode
 
   if (isPublicSignupDisabled) {
     return (

--- a/packages/webui/routes/teams/$teamId/settings.tsx
+++ b/packages/webui/routes/teams/$teamId/settings.tsx
@@ -6,7 +6,6 @@ import { SandboxSettings } from '@/ui/components/settings/SandboxSettings'
 import { SkillsConfigCard } from '@/ui/components/settings/SkillsConfigCard'
 import { NotificationSettings } from '@/ui/components/settings/NotificationSettings'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/components/ui/card'
-import { Switch } from '@/ui/components/ui/switch'
 import { cn } from '@/ui/lib/utils'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
@@ -275,38 +274,6 @@ function TeamSettingsPage() {
                       </div>
                     </CardContent>
                   </Card>
-
-                  {me?.role === 'owner' && (
-                    <Card>
-                      <CardHeader>
-                        <CardTitle>Team Settings</CardTitle>
-                        <CardDescription>Manage your team&apos;s general settings.</CardDescription>
-                      </CardHeader>
-                      <CardContent>
-                        <div className="flex items-center justify-between">
-                          <div className="space-y-0.5">
-                            <h3 className="text-base font-medium">Enable Public Signup</h3>
-                            <p className="text-sm text-muted-foreground">
-                              Allow users to sign up without an invite code.
-                            </p>
-                          </div>
-                          <Switch
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                            checked={(settings as any)?.enablePublicSignup || false}
-                            onCheckedChange={(checked) =>
-                              updateSettings({
-                                teamId,
-                                data: {
-                                  key: 'enablePublicSignup',
-                                  value: checked,
-                                },
-                              })
-                            }
-                          />
-                        </div>
-                      </CardContent>
-                    </Card>
-                  )}
                 </div>
               )}
 


### PR DESCRIPTION
## Summary
This PR removes the public signup feature entirely. Public signup is now disabled by default once the first user has been created. The toggle in Team Settings has been removed.

## Changes
- Removed `enablePublicSignup` from `PrismaJson.Settings` and `signupInfoResponseSchema`.
- Updated `TeamService.getSignupInfo` to only return `userCount`.
- Updated authentication hook to block signups if `userCount > 0` and no `inviteCode` is provided.
- Removed the public signup toggle from the Team Settings UI.
- Simplified signup page logic to reflect the removal of the public signup option.

## Verification
- Ran `bun run lint` (passed).
- Ran `bun run format` (passed).
- Ran `bun run typecheck` (passed).
- Ran `bun run test` (all 370 tests passed).