### PR TITLE
fix: agent error messages and IME input

### DIFF
--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -59,6 +59,46 @@ describe('Agent Activities', () => {
     expect(piAgent.createAgentSession).toHaveBeenCalled()
   })
 
+  it('should include error message in text when stopReason is error', async () => {
+    const mockHarness = {
+      prompt: vi.fn().mockResolvedValue({
+        content: [],
+        usage: { input: 0, output: 0 },
+        stopReason: 'error',
+        errorMessage: 'API key not valid',
+      }),
+    }
+    const mockSession = {
+      getEntries: vi.fn().mockResolvedValue([]),
+      getStorage: vi.fn().mockReturnValue({ sessionId: 'mock-session-id' }),
+    }
+
+    vi.mocked(piAgent.createAgentSession).mockResolvedValue({
+      session: mockSession as unknown as Session<DatabaseSessionMetadata>,
+      harness: mockHarness as unknown as AgentHarness,
+    })
+
+    const context = {
+      agent: { id: 'b1', provider: { name: 'google' }, modelRef: { modelId: 'gemini' } },
+      dbProviders: [],
+      teamSkills: [],
+      allowedDomains: [],
+    } as unknown as AgentExecutionContext
+
+    const res = await agentChatActivity({
+      teamId: 't1',
+      agentId: 'b1',
+      message: 'Hi',
+      imageUrls: [],
+      projectId: 'p1',
+      folderId: 'f1',
+      sessionId: 'mock-session-id',
+      context,
+    })
+
+    expect(res.text).toBe('Error: API key not valid')
+  })
+
   it('should call autofillAiActivity and run autofill tool', async () => {
     const mockHarness = {
       prompt: vi.fn().mockResolvedValue({

--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -153,7 +153,7 @@ If you need to create files in the local filesystem (for example, a temporary fi
       }
     })
 
-    const text = assistantMessage.content
+    let text = assistantMessage.content
       .filter((c) => c.type === 'text')
       .map((c) => {
         if ('text' in c && typeof c.text === 'string') {
@@ -162,6 +162,13 @@ If you need to create files in the local filesystem (for example, a temporary fi
         return ''
       })
       .join('\n')
+
+    if (assistantMessage.stopReason === 'error' && assistantMessage.errorMessage) {
+      if (text) {
+        text += '\n\n'
+      }
+      text += `Error: ${assistantMessage.errorMessage}`
+    }
 
     const usage: Usage = {
       model: modelId,

--- a/packages/webui/components/chat/message-input.tsx
+++ b/packages/webui/components/chat/message-input.tsx
@@ -279,6 +279,8 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
     }
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.nativeEvent.isComposing) return
+
       if (showMentionList && filteredEntities.length > 0) {
         if (e.key === 'ArrowUp') {
           e.preventDefault()


### PR DESCRIPTION
## Summary
Fixes two bugs:
1. Agent chat error messages were being swallowed; they are now appended to the comment text.
2. The message input field was prematurely submitting when the Enter key was used to confirm an IME (e.g., Chinese pinyin) selection.

## Changes
- Updated `packages/agent/src/activities/agent.ts` to append `errorMessage` to the response text if `stopReason` is `'error'`.
- Updated `packages/webui/components/chat/message-input.tsx` to ignore `onKeyDown` events when `e.nativeEvent.isComposing` is true.
- Added a new test case in `packages/agent/src/activities/agent.test.ts` to verify error message handling.

## Verification
- Ran `bun run test packages/agent/src/activities/agent.test.ts` (passed).
- Ran root-level `format`, `lint`, and `typecheck` (passed).
