### PR TITLE
feat(ui): skeleton loaders and local uploading cards

### DIFF
--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -356,25 +356,29 @@ export function FileBrowser({
       if (!res.ok) throw new Error('Failed to create upload task')
       return (await res.json()) as InferResponseType<typeof $createUploadTask>
     },
-    onSuccess: async (data) => {
-      const newLocalFiles: AssetInfo[] = filesToUpload.map((f) => {
-        const urlInfo = (
-          data.presignedUrls as { id?: string; url?: string; fileId?: string }[] | undefined
-        )?.find((p) => p.id === f.id)
-        const hasUrl = !!urlInfo && !!urlInfo.url
-        return {
-          id: urlInfo?.fileId || f.id,
-          name: f.file.name,
-          sizeByte: f.file.size,
-          fileCount: 0,
-          type: 'file',
-          status: hasUrl ? 'uploading' : 'error',
-          mediaType: f.file.type || null,
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-        }
-      })
-      setLocalUploadingFiles((prev) => [...newLocalFiles, ...prev])
+    onSuccess: async (data, variables) => {
+      const isCurrentFolderUpload = variables.json.parentId === assetId
+
+      if (isCurrentFolderUpload) {
+        const newLocalFiles: AssetInfo[] = filesToUpload.map((f) => {
+          const urlInfo = (
+            data.presignedUrls as { id?: string; url?: string; fileId?: string }[] | undefined
+          )?.find((p) => p.id === f.id)
+          const hasUrl = !!urlInfo && !!urlInfo.url
+          return {
+            id: urlInfo?.fileId || f.id,
+            name: f.file.name,
+            sizeByte: f.file.size,
+            fileCount: 0,
+            type: 'file',
+            status: hasUrl ? 'uploading' : 'error',
+            mediaType: f.file.type || null,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          }
+        })
+        setLocalUploadingFiles((prev) => [...newLocalFiles, ...prev])
+      }
 
       // The RPC client returns an object that we cast to the expected type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -361,13 +361,14 @@ export function FileBrowser({
         const urlInfo = (
           data.presignedUrls as { id?: string; url?: string; fileId?: string }[] | undefined
         )?.find((p) => p.id === f.id)
+        const hasUrl = !!urlInfo && !!urlInfo.url
         return {
           id: urlInfo?.fileId || f.id,
           name: f.file.name,
           sizeByte: f.file.size,
           fileCount: 0,
           type: 'file',
-          status: 'uploading',
+          status: hasUrl ? 'uploading' : 'error',
           mediaType: f.file.type || null,
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
@@ -606,10 +607,12 @@ export function FileBrowser({
               }
             } finally {
               decrementUploading()
-              setLocalUploadingFiles((prev) => prev.filter((f) => f.id !== uploadInfo.fileId))
-              queryClient.invalidateQueries({
+              await queryClient.invalidateQueries({
                 queryKey: ['search', teamId, assetId],
               })
+              setLocalUploadingFiles((prev) =>
+                prev.filter((f) => f.id !== uploadInfo.fileId && f.id !== file.id),
+              )
             }
           }
         }

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -125,6 +125,14 @@ export function FileBrowser({
   const queryClient = useQueryClient()
   const navigate = useNavigate()
 
+  const [localUploadingFiles, setLocalUploadingFiles] = useState<AssetInfo[]>([])
+
+  const displayedFiles = useMemo(() => {
+    const existingIds = new Set(files.map((f) => f.id))
+    const filteredLocal = localUploadingFiles.filter((f) => !existingIds.has(f.id))
+    return [...filteredLocal, ...files]
+  }, [files, localUploadingFiles])
+
   const { data: shareLinksData } = useQuery({
     queryKey: ['shares', teamId, projectId],
     queryFn: async () => {
@@ -320,7 +328,7 @@ export function FileBrowser({
     projectId,
     assetId,
     folders,
-    files,
+    files: displayedFiles,
     selectedIds,
   })
 
@@ -349,6 +357,24 @@ export function FileBrowser({
       return (await res.json()) as InferResponseType<typeof $createUploadTask>
     },
     onSuccess: async (data) => {
+      const newLocalFiles: AssetInfo[] = filesToUpload.map((f) => {
+        const urlInfo = (
+          data.presignedUrls as { id?: string; url?: string; fileId?: string }[] | undefined
+        )?.find((p) => p.id === f.id)
+        return {
+          id: urlInfo?.fileId || f.id,
+          name: f.file.name,
+          sizeByte: f.file.size,
+          fileCount: 0,
+          type: 'file',
+          status: 'uploading',
+          mediaType: f.file.type || null,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }
+      })
+      setLocalUploadingFiles((prev) => [...newLocalFiles, ...prev])
+
       // The RPC client returns an object that we cast to the expected type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await uploadFiles(filesToUpload, data.presignedUrls as any, data.taskId!)
@@ -392,7 +418,7 @@ export function FileBrowser({
   }, [filesInView, hasNextFilesPage, isFetchingNextFilesPage, fetchNextFilesPage])
 
   const foldersSize = folders.reduce((acc, f) => acc + (f.sizeByte || 0), 0)
-  const filesSize = files.reduce((acc, f) => acc + (f.sizeByte || 0), 0)
+  const filesSize = displayedFiles.reduce((acc, f) => acc + (f.sizeByte || 0), 0)
 
   const formatCount = (count: number, isFile: boolean) => {
     const isNameFilter = filterConditions?.some(
@@ -496,7 +522,7 @@ export function FileBrowser({
     folders.find((item) => item.id === id),
   ).length
   const selectedFiles = Array.from(selectedIds).filter((id) =>
-    files.find((item) => item.id === id),
+    displayedFiles.find((item) => item.id === id),
   ).length
 
   const handleUploadFilesClick = () => {
@@ -565,9 +591,6 @@ export function FileBrowser({
                       errorMessage: `upload failed with status: ${resp.status}`,
                     },
                   })
-                  queryClient.invalidateQueries({
-                    queryKey: ['search', teamId, assetId],
-                  })
                   return
                 }
               } catch (error) {
@@ -579,13 +602,14 @@ export function FileBrowser({
                     errorMessage: `upload failed with error: ${error instanceof Error ? error.message : String(error)}`,
                   },
                 })
-                queryClient.invalidateQueries({
-                  queryKey: ['search', teamId, assetId],
-                })
                 return
               }
             } finally {
               decrementUploading()
+              setLocalUploadingFiles((prev) => prev.filter((f) => f.id !== uploadInfo.fileId))
+              queryClient.invalidateQueries({
+                queryKey: ['search', teamId, assetId],
+              })
             }
           }
         }
@@ -764,7 +788,7 @@ export function FileBrowser({
               {displayStyle === 'list' ? (
                 <FileBrowserListView
                   folders={folders}
-                  files={files}
+                  files={displayedFiles}
                   totalFolders={totalFolders}
                   totalFiles={totalFiles}
                   selectedItem={selectedItem}
@@ -792,7 +816,7 @@ export function FileBrowser({
               ) : (
                 <FileBrowserGridView
                   folders={folders}
-                  files={files}
+                  files={displayedFiles}
                   totalFolders={totalFolders}
                   totalFiles={totalFiles}
                   renderItem={renderItem}
@@ -821,7 +845,7 @@ export function FileBrowser({
               )}
 
               {folders.length === 0 &&
-                files.length === 0 &&
+                displayedFiles.length === 0 &&
                 !isFetchingNextFoldersPage &&
                 !isFetchingNextFilesPage && (
                   <div className="empty-area flex h-full items-center justify-center text-sm text-muted-foreground">
@@ -856,7 +880,9 @@ export function FileBrowser({
                   variant="ghost"
                   size="sm"
                   onClick={() =>
-                    handleDownload([...folders, ...files].filter((i) => selectedIds.has(i.id!)))
+                    handleDownload(
+                      [...folders, ...displayedFiles].filter((i) => selectedIds.has(i.id!)),
+                    )
                   }
                   className="gap-2"
                 >
@@ -871,7 +897,7 @@ export function FileBrowser({
           item={contextMenuItem}
           selectedIds={selectedIds}
           folders={folders}
-          files={files}
+          files={displayedFiles}
           onRename={handleRename}
           onDelete={handleDelete}
           onDownload={handleDownload}

--- a/packages/webui/components/file-browser/file-card.tsx
+++ b/packages/webui/components/file-browser/file-card.tsx
@@ -238,11 +238,25 @@ export function FileCard({
       <div className="relative aspect-square overflow-hidden bg-muted/30">
         {displayItem.status === 'uploading' ||
         displayItem.status === 'processing' ||
-        displayItem.status === 'uploaded' ? (
+        displayItem.status === 'uploaded' ||
+        displayItem.status === 'error' ? (
           <div className="flex h-full w-full items-center justify-center bg-background/50">
-            <Skeleton className="absolute inset-0 h-full w-full" />
-            <span className="z-10 font-medium capitalize text-muted-foreground">
-              {displayItem.status === 'uploaded' ? 'Processing' : displayItem.status}
+            {displayItem.status !== 'error' && (
+              <Skeleton className="absolute inset-0 h-full w-full" />
+            )}
+            <span
+              className={cn(
+                'z-10 font-medium px-2 text-center text-sm',
+                displayItem.status === 'error'
+                  ? 'text-destructive font-semibold'
+                  : 'text-muted-foreground capitalize',
+              )}
+            >
+              {displayItem.status === 'uploaded'
+                ? 'Processing'
+                : displayItem.status === 'error'
+                  ? 'Failed to upload'
+                  : displayItem.status}
             </span>
           </div>
         ) : (

--- a/packages/webui/components/file-browser/file-list-item.tsx
+++ b/packages/webui/components/file-browser/file-list-item.tsx
@@ -216,6 +216,12 @@ export function FileListItem({
             disabled={!isEditing}
             className="h-auto p-0 text-sm font-medium text-foreground truncate"
           />
+          {displayItem.status === 'error' && (
+            <span className="text-xs text-destructive font-semibold shrink-0">
+              (Failed to upload)
+            </span>
+          )}
+
           {displayItem.versionStack && (
             <Badge variant="outline" className="px-1 py-0 text-xs shrink-0">
               v

--- a/packages/webui/components/loading-skeletons.tsx
+++ b/packages/webui/components/loading-skeletons.tsx
@@ -1,0 +1,169 @@
+import { Skeleton } from '@/ui/components/ui/skeleton'
+
+export function ProjectFolderSkeleton() {
+  return (
+    <div className="flex h-screen flex-col bg-background min-h-0">
+      {/* Top navigation/breadcrumbs placeholder */}
+      <div className="flex h-14 items-center justify-between border-b px-6 shrink-0">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-24" />
+          <span className="text-muted-foreground">/</span>
+          <Skeleton className="h-4 w-32" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-8 w-8 rounded-md" />
+          <Skeleton className="h-8 w-20 rounded-md" />
+        </div>
+      </div>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Sidebar (Folder tree placeholder) */}
+        <div className="w-[240px] border-r p-4 space-y-4 hidden md:block shrink-0">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-4 rounded" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+          <div className="pl-4 space-y-3">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-3 w-3 rounded" />
+              <Skeleton className="h-3 w-28" />
+            </div>
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-3 w-3 rounded" />
+              <Skeleton className="h-3 w-20" />
+            </div>
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-3 w-3 rounded" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+          </div>
+        </div>
+
+        {/* File Browser area */}
+        <div className="flex-1 p-6 space-y-6 overflow-y-auto">
+          {/* File browser toolbar */}
+          <div className="flex items-center justify-between border-b pb-4">
+            <div className="flex items-center gap-4">
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-4 w-20" />
+            </div>
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-8 w-8 rounded" />
+              <Skeleton className="h-8 w-8 rounded" />
+              <Skeleton className="h-8 w-32 rounded" />
+            </div>
+          </div>
+
+          {/* Cards Grid */}
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-4 w-24" />
+            </div>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+              {Array.from({ length: 10 }).map((_, i) => (
+                <div key={i} className="flex flex-col rounded-lg border bg-card p-3 space-y-3">
+                  <Skeleton className="aspect-square w-full rounded-md" />
+                  <div className="space-y-2">
+                    <Skeleton className="h-4 w-3/4" />
+                    <div className="flex justify-between items-center">
+                      <Skeleton className="h-3 w-1/4" />
+                      <Skeleton className="h-3 w-1/3" />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function FileDetailSkeleton() {
+  return (
+    <div className="h-screen flex flex-col bg-background">
+      {/* Top navigation */}
+      <div className="flex h-14 items-center justify-between border-b px-6 shrink-0">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-16" />
+          <span className="text-muted-foreground">/</span>
+          <Skeleton className="h-4 w-28" />
+          <span className="text-muted-foreground">/</span>
+          <Skeleton className="h-4 w-32" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-8 w-20 rounded" />
+        </div>
+      </div>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Left Pane (Version stack) */}
+        <div className="w-[280px] border-r p-4 flex flex-col gap-4 shrink-0 hidden md:flex">
+          <Skeleton className="h-5 w-24" />
+          <div className="space-y-3 flex-1 overflow-y-auto">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex gap-3 p-2 rounded border">
+                <Skeleton className="h-12 w-12 rounded bg-muted shrink-0" />
+                <div className="space-y-2 flex-1">
+                  <Skeleton className="h-3 w-2/3" />
+                  <Skeleton className="h-2 w-1/2" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Center Pane (Viewer area) */}
+        <div className="flex-1 bg-muted/20 p-6 flex flex-col justify-between relative min-w-0">
+          <div className="flex-1 flex items-center justify-center">
+            <Skeleton className="w-full max-w-4xl aspect-video rounded-lg shadow-lg" />
+          </div>
+          <div className="mt-4 flex items-center justify-between shrink-0">
+            <div className="flex items-center gap-4">
+              <Skeleton className="h-8 w-8 rounded-full" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+
+        {/* Right Pane (Metadata and Comments) */}
+        <div className="w-[360px] border-l p-4 flex flex-col gap-6 shrink-0 hidden lg:flex bg-card">
+          {/* Metadata Section */}
+          <div className="space-y-4">
+            <Skeleton className="h-5 w-32" />
+            <div className="space-y-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="flex justify-between items-center py-1 border-b">
+                  <Skeleton className="h-3 w-20" />
+                  <Skeleton className="h-3 w-32" />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Comments Section */}
+          <div className="flex-1 flex flex-col gap-4">
+            <Skeleton className="h-5 w-24" />
+            <div className="space-y-3 flex-1 overflow-y-auto">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="flex gap-3 p-3 rounded-lg border bg-muted/10">
+                  <Skeleton className="h-8 w-8 rounded-full shrink-0" />
+                  <div className="space-y-2 flex-1">
+                    <div className="flex justify-between">
+                      <Skeleton className="h-3 w-24" />
+                      <Skeleton className="h-2 w-12" />
+                    </div>
+                    <Skeleton className="h-3 w-full" />
+                    <Skeleton className="h-3 w-5/6" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/webui/routes/projects/$projectId/files/$fileId.tsx
+++ b/packages/webui/routes/projects/$projectId/files/$fileId.tsx
@@ -3,6 +3,7 @@ import { FileViewer } from '@/ui/components/file-viewer'
 import { FileViewerLeftSidebar } from '@/ui/components/file-viewer-left-sidebar'
 import { FileViewerRightSidebar } from '@/ui/components/file-viewer-right-sidebar'
 import { ResizeHandle } from '@/ui/components/resize-handle'
+import { FileDetailSkeleton } from '@/ui/components/loading-skeletons'
 import { useMemberStore } from '@/ui/stores/members'
 import { useTeamContextStore } from '@/ui/stores/team-context'
 import { useTopNavStore } from '@/ui/stores/top-nav'
@@ -171,7 +172,7 @@ function FileViewPage() {
   ])
 
   if (isLoading && !fileData) {
-    return <div>Loading...</div>
+    return <FileDetailSkeleton />
   }
 
   if (isError || !fileData || !projectInfo || !teamId) {

--- a/packages/webui/routes/projects/$projectId/folders/$folderId.tsx
+++ b/packages/webui/routes/projects/$projectId/folders/$folderId.tsx
@@ -1,5 +1,6 @@
 import { client } from '@/ui/api/client'
 import FileSystemManager from '@/ui/components/file-system-manager'
+import { ProjectFolderSkeleton } from '@/ui/components/loading-skeletons'
 import { useTeamContextStore } from '@/ui/stores/team-context'
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
@@ -41,7 +42,7 @@ function FolderPage() {
   })
 
   if (!teamId || !rootFolderId || !rootFolder) {
-    return <div>Loading project...</div>
+    return <ProjectFolderSkeleton />
   }
 
   return (
@@ -59,5 +60,5 @@ export const Route = createFileRoute('/projects/$projectId/folders/$folderId')({
   component: FolderPage,
   loader: ({ context: { queryClient }, params: { projectId } }) =>
     queryClient.ensureQueryData(projectInfoQueryOptions(projectId)),
-  pendingComponent: () => <div>Loading project...</div>,
+  pendingComponent: () => <ProjectFolderSkeleton />,
 })

--- a/packages/webui/routes/projects/$projectId/index.tsx
+++ b/packages/webui/routes/projects/$projectId/index.tsx
@@ -1,5 +1,6 @@
 import { client } from '@/ui/api/client'
 import FileSystemManager from '@/ui/components/file-system-manager'
+import { ProjectFolderSkeleton } from '@/ui/components/loading-skeletons'
 import { useTeamContextStore } from '@/ui/stores/team-context'
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
@@ -41,7 +42,7 @@ function ProjectPage() {
   })
 
   if (!teamId || !rootFolderId || !rootFolder) {
-    return <div>Loading project...</div>
+    return <ProjectFolderSkeleton />
   }
 
   return (
@@ -59,5 +60,5 @@ export const Route = createFileRoute('/projects/$projectId/')({
   component: ProjectPage,
   loader: ({ context: { queryClient }, params: { projectId } }) =>
     queryClient.ensureQueryData(projectInfoQueryOptions(projectId)),
-  pendingComponent: () => <div>Loading project...</div>,
+  pendingComponent: () => <ProjectFolderSkeleton />,
 })

--- a/packages/webui/routes/projects/$projectId/recently-deleted.tsx
+++ b/packages/webui/routes/projects/$projectId/recently-deleted.tsx
@@ -1,5 +1,6 @@
 import { client } from '@/ui/api/client'
 import FileSystemManager from '@/ui/components/file-system-manager'
+import { ProjectFolderSkeleton } from '@/ui/components/loading-skeletons'
 import { useTeamContextStore } from '@/ui/stores/team-context'
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
@@ -41,7 +42,7 @@ function RecentlyDeletedPage() {
   })
 
   if (!teamId || !rootFolderId || !rootFolder) {
-    return <div>Loading project...</div>
+    return <ProjectFolderSkeleton />
   }
 
   return (
@@ -59,5 +60,5 @@ export const Route = createFileRoute('/projects/$projectId/recently-deleted')({
   component: RecentlyDeletedPage,
   loader: ({ context: { queryClient }, params: { projectId } }) =>
     queryClient.ensureQueryData(projectInfoQueryOptions(projectId)),
-  pendingComponent: () => <div>Loading project...</div>,
+  pendingComponent: () => <ProjectFolderSkeleton />,
 })

--- a/packages/webui/routes/projects/$projectId/shares/$shareId.tsx
+++ b/packages/webui/routes/projects/$projectId/shares/$shareId.tsx
@@ -1,5 +1,6 @@
 import { client } from '@/ui/api/client'
 import ShareManager from '@/ui/components/share-manager'
+import { ProjectFolderSkeleton } from '@/ui/components/loading-skeletons'
 import { useTeamContextStore } from '@/ui/stores/team-context'
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
@@ -41,7 +42,7 @@ function SharePage() {
   })
 
   if (!teamId || !rootFolderId || !rootFolder) {
-    return <div>Loading project...</div>
+    return <ProjectFolderSkeleton />
   }
 
   return (
@@ -59,5 +60,5 @@ export const Route = createFileRoute('/projects/$projectId/shares/$shareId')({
   component: SharePage,
   loader: ({ context: { queryClient }, params: { projectId } }) =>
     queryClient.ensureQueryData(projectInfoQueryOptions(projectId)),
-  pendingComponent: () => <div>Loading share link...</div>,
+  pendingComponent: () => <ProjectFolderSkeleton />,
 })

--- a/packages/webui/routes/share/$shareId.tsx
+++ b/packages/webui/routes/share/$shareId.tsx
@@ -1,4 +1,5 @@
 import { client } from '@/ui/api/client'
+import { ProjectFolderSkeleton } from '@/ui/components/loading-skeletons'
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 
@@ -20,7 +21,8 @@ function ShareLayout() {
     },
   })
 
-  if (isLoading) return <div className="flex h-screen items-center justify-center">Loading...</div>
+  if (isLoading) return <ProjectFolderSkeleton />
+
   if (error || !shareInfo)
     return (
       <div className="flex h-screen items-center justify-center text-destructive">


### PR DESCRIPTION
## Summary

Enhances the user interface with high-fidelity Shadcn skeleton loading screens for all main routes, and implements immediate local file upload cards in the file browser during uploading.

## Changes

- Added `packages/webui/components/loading-skeletons.tsx` containing `ProjectFolderSkeleton` and `FileDetailSkeleton` components.
- Modified folder, project root, recently deleted, shares, and public share layout routes to render `ProjectFolderSkeleton` during loading.
- Modified the file detail route to render `FileDetailSkeleton` during loading.
- Implemented immediate client-side `localUploadingFiles` mapping when file uploads start in `FileBrowser`, showing the upload progress card at the head of the files list.
- Configured individual file upload success/failure handlers to clean up temporary cards and trigger selective query invalidation.

## Verification

- Verified type safety via `bun run typecheck` which passed successfully.
- Verified code styles via `bun run lint` and `bun run format` which passed successfully.
- Verified test suite via `bun run test` (all 371 tests passed).

## Notes

None.
