### PR TITLE
fix(build): resolve build and typecheck failures

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -27,12 +27,6 @@ await Bun.build({
     tailwindPlugin,
     bunPluginPino({ transports: ['pino-pretty'] }),
   ],
-  external: [
-    '@temporalio/activity',
-    '@temporalio/client',
-    '@temporalio/worker',
-    '@temporalio/workflow',
-  ],
   // compile: {
   //   outfile: 'Shumai',
   //   autoloadBunfig: true,

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@swc/wasm": "^1.15.40",
         "@testcontainers/postgresql": "^11.14.0",
         "@types/bun": "^1.3.12",
         "@types/node": "^22",
@@ -20,6 +21,7 @@
         "eslint-plugin-prettier": "^5.5.5",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.5.0",
+        "loader-utils": "^3.3.1",
         "pino-pretty": "^13.1.3",
         "prisma": "^7.7.0",
         "testcontainers": "^11.14.0",
@@ -1059,6 +1061,8 @@
 
     "@swc/types": ["@swc/types@0.1.26", "", { "dependencies": { "@swc/counter": "^0.1.3" } }, "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw=="],
 
+    "@swc/wasm": ["@swc/wasm@1.15.40", "", {}, "sha512-FVS3SEJXBxjpxVUGSzaTaCdJjnXUalRftA/6hILMAJIcYHBoiBfJlxuH6s47iajlAJZP25e5Kf4HNHvvwyOEgw=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.0", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.0", "@tailwindcss/oxide-darwin-arm64": "4.3.0", "@tailwindcss/oxide-darwin-x64": "4.3.0", "@tailwindcss/oxide-freebsd-x64": "4.3.0", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0", "@tailwindcss/oxide-linux-arm64-musl": "4.3.0", "@tailwindcss/oxide-linux-x64-gnu": "4.3.0", "@tailwindcss/oxide-linux-x64-musl": "4.3.0", "@tailwindcss/oxide-wasm32-wasi": "4.3.0", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0", "@tailwindcss/oxide-win32-x64-msvc": "4.3.0" } }, "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg=="],
@@ -1998,6 +2002,8 @@
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "loader-runner": ["loader-runner@4.3.2", "", {}, "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w=="],
+
+    "loader-utils": ["loader-utils@3.3.1", "", {}, "sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 

--- a/package.json
+++ b/package.json
@@ -22,24 +22,26 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@swc/wasm": "^1.15.40",
     "@testcontainers/postgresql": "^11.14.0",
     "@types/bun": "^1.3.12",
     "@types/node": "^22",
     "bun-plugin-pino": "^1.5.0",
     "bun-plugin-tailwind": "^0.1.2",
     "bun-types": "^1.3.12",
-    "pino-pretty": "^13.1.3",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-react": "^7.37.5",
     "globals": "^16.5.0",
+    "loader-utils": "^3.3.1",
+    "pino-pretty": "^13.1.3",
     "prisma": "^7.7.0",
     "testcontainers": "^11.14.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vitest": "^4.1.4",
-    "vite-tsconfig-paths": "^6.1.1"
+    "vite-tsconfig-paths": "^6.1.1",
+    "vitest": "^4.1.4"
   },
   "dependencies": {
     "jittered-fractional-indexing": "^1.0.1"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,5 +28,5 @@
       "@shumai/transcode/src/*": ["packages/transcode/src/*"]
     }
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist", "**/dist"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
+    exclude: ['**/node_modules/**', '**/dist/**'],
     globalSetup: './packages/db/src/test-global-setup.ts',
     globals: false,
     pool: 'forks',


### PR DESCRIPTION
## Summary

This PR resolves the `bun run build.ts` and `bun run typecheck` failures without externalizing the `@temporalio` packages.

## Changes

- Installed `loader-utils` and `@swc/wasm` as root devDependencies, resolving the dependency requirements of `@swc/core` and `swc-loader` inside `@temporalio/worker` during bundling.
- Removed the `external` configuration in `build.ts` to allow `@temporalio/*` packages to be bundled.
- Added `dist` and `**/dist` to the root `tsconfig.json` exclude list to prevent TS6200 type conflict errors.
- Added `**/dist/**` to the `vitest.config.ts` exclude list to prevent Vitest from attempting to run compiled JavaScript tests.

## Verification

Ran all workspace quality checks successfully:
- `bun run typecheck` passes cleanly.
- `bun run build` completes successfully.
- `bun run lint` passes with 0 warnings.
- `bun run format` has no formatting issues.
- `bun run test` runs and all 415 tests pass.
