### PR TITLE
feat(publish): compile app to binary and package for npm

### DIFF
--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -14,7 +14,7 @@ async function run() {
   const options: { workflowBundle?: unknown; workflowsPath?: string } = {}
   if (process.env.NODE_ENV === 'production') {
     // @ts-ignore: Bun temporal plugin macro
-    const { default: workflowBundle } = await import('./workflows:::workflow')
+    const { default: workflowBundle } = await import('./workflows.ts:::workflow')
     options.workflowBundle = workflowBundle
   } else {
     options.workflowsPath = new URL('./workflows.ts', import.meta.url).pathname

--- a/apps/transcode/src/index.ts
+++ b/apps/transcode/src/index.ts
@@ -13,7 +13,7 @@ async function run() {
   const options: { workflowBundle?: unknown; workflowsPath?: string } = {}
   if (process.env.NODE_ENV === 'production') {
     // @ts-ignore: Bun temporal plugin macro
-    const { default: workflowBundle } = await import('./workflows:::workflow')
+    const { default: workflowBundle } = await import('./workflows.ts:::workflow')
     options.workflowBundle = workflowBundle
   } else {
     options.workflowsPath = new URL('./workflows.ts', import.meta.url).pathname

--- a/docker-compose/temporal/docker-compose.yaml
+++ b/docker-compose/temporal/docker-compose.yaml
@@ -19,7 +19,6 @@ services:
 
   shumai:
     image: shumaione/shumai:latest
-    build: ../../
     container_name: shumai_app
     ports:
       - '3000:3000'
@@ -27,47 +26,17 @@ services:
       - shumai_data:/app/data
     environment:
       DATABASE_URL: postgres://shumai:shumai_password@postgres:5432/shumai_db?search_path=public&sslmode=disable
-      STORAGE_BACKEND: local
+      STORAGE_BACKEND: s3
+      AWS_ENDPOINT_URL_S3: S3_ENDPOINT_URL
+      S3_REGION: S3_REGION
+      S3_BUCKET: BUCKET_NAME
+      S3_ACCESS_KEY_ID: ID
+      S3_SECRET_ACCESS_KEY: KEY
       BETTER_AUTH_SECRET: qSxs9DxzHDZBbeeTNPEwBuspYwipBqz5Gk5XdBjNhWw=
       BETTER_AUTH_URL: http://localhost:3000
       WORKFLOW_EXECUTOR: temporal
       TEMPORAL_ADDRESS: temporal:7233
-    depends_on:
-      postgres:
-        condition: service_healthy
-      temporal:
-        condition: service_healthy
-
-  shumai-agent:
-    image: shumaione/shumai:latest
-    build: ../../
-    container_name: shumai_agent_worker
-    command: ['bun', 'index.js', 'worker', 'agent']
-    volumes:
-      - shumai_data:/app/data
-    environment:
-      DATABASE_URL: postgres://shumai:shumai_password@postgres:5432/shumai_db?search_path=public&sslmode=disable
-      STORAGE_BACKEND: local
-      WORKFLOW_EXECUTOR: temporal
-      TEMPORAL_ADDRESS: temporal:7233
-    depends_on:
-      postgres:
-        condition: service_healthy
-      temporal:
-        condition: service_healthy
-
-  shumai-transcode:
-    image: shumaione/shumai:latest
-    build: ../../
-    container_name: shumai_transcode_worker
-    command: ['bun', 'index.js', 'worker', 'transcode']
-    volumes:
-      - shumai_data:/app/data
-    environment:
-      DATABASE_URL: postgres://shumai:shumai_password@postgres:5432/shumai_db?search_path=public&sslmode=disable
-      STORAGE_BACKEND: local
-      WORKFLOW_EXECUTOR: temporal
-      TEMPORAL_ADDRESS: temporal:7233
+      GEMINI_API_KEY: KEY
     depends_on:
       postgres:
         condition: service_healthy

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "generate-providers": "bun run scripts/generate-builtin-providers.ts",
     "worker:agent": "bun apps/agent/src/index.ts",
     "worker:transcode": "bun apps/transcode/src/index.ts",
-    "build": "bun run build.ts"
+    "build": "bun run build.ts",
+    "build-npm": "bun scripts/build-npm.ts"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,14 @@
     "worker:agent": "bun apps/agent/src/index.ts",
     "worker:transcode": "bun apps/transcode/src/index.ts",
     "build": "bun run build.ts",
-    "build-npm": "bun scripts/build-npm.ts"
+    "build-npm": "bun scripts/build-npm.ts",
+    "prepublishOnly": "bun run build-npm && bun run lint && bun run typecheck",
+    "publish": "bun run prepublishOnly && bun run scripts/publish.ts",
+    "publish:dry": "bun run prepublishOnly && bun run scripts/publish.ts --dry-run",
+    "release:local": "bun run scripts/release-local.ts",
+    "release:patch": "bun run scripts/release.ts patch",
+    "release:minor": "bun run scripts/release.ts minor",
+    "release:major": "bun run scripts/release.ts major"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/packages/workflow-core/src/bun-temporal-plugin.ts
+++ b/packages/workflow-core/src/bun-temporal-plugin.ts
@@ -33,9 +33,32 @@ export function temporalWorkflow(options: TemporalWorkflowPluginOptions = {}): B
       build.onLoad({ filter: /.*/, namespace: 'temporal-workflow' }, async (args) => {
         const workflowsPath = args.path
 
+        // The bundleOptions contains raw parameters for Temporal bundleWorkflowCode which uses Webpack.
+        // We cast options.bundleOptions to any to check for webpackConfigHook.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const originalHook = (options.bundleOptions as any)?.webpackConfigHook
+        const bundleOptions = {
+          ...options.bundleOptions,
+          // Webpack config is untyped inside Temporal's webpackConfigHook callback.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          webpackConfigHook: (config: any) => {
+            config.resolve = config.resolve || {}
+            config.resolve.alias = {
+              ...config.resolve.alias,
+              '@shumai/workflow-core':
+                require.resolve('@shumai/workflow-core/src/workflow-utils.ts'),
+            }
+            console.log('Webpack config aliases:', config.resolve.alias)
+            if (originalHook) {
+              return originalHook(config)
+            }
+            return config
+          },
+        }
+
         const bundle = await bundleWorkflowCode({
           workflowsPath,
-          ...options.bundleOptions,
+          ...bundleOptions,
         })
 
         return {

--- a/packages/workflow-core/src/workflow.ts
+++ b/packages/workflow-core/src/workflow.ts
@@ -110,6 +110,7 @@ export class WorkflowService {
               '@temporalio/workflow': path.dirname(
                 require.resolve('@temporalio/workflow/package.json'),
               ),
+              '@shumai/workflow-core': require.resolve('./workflow-utils'),
             }
             return config
           },
@@ -130,6 +131,7 @@ export class WorkflowService {
               '@temporalio/workflow': path.dirname(
                 require.resolve('@temporalio/workflow/package.json'),
               ),
+              '@shumai/workflow-core': require.resolve('./workflow-utils'),
             }
             return config
           },

--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -33,12 +33,20 @@ const commonExternal = [
   'prisma',
 ]
 
-// Function to compile a single application
+const targets = [
+  { platform: 'darwin', arch: 'arm64', bunTarget: 'bun-darwin-arm64', suffix: '' },
+  { platform: 'darwin', arch: 'x64', bunTarget: 'bun-darwin-x64', suffix: '' },
+  { platform: 'linux', arch: 'x64', bunTarget: 'bun-linux-x64', suffix: '' },
+  { platform: 'win32', arch: 'x64', bunTarget: 'bun-windows-x64', suffix: '.exe' },
+]
+
+// Function to compile a single application binary
 async function compileApp({
   name,
   entrypoint,
   outdir,
   binaryName,
+  bunTarget,
   plugins = [],
   external = commonExternal,
 }: {
@@ -46,12 +54,21 @@ async function compileApp({
   entrypoint: string
   outdir: string
   binaryName: string
+  bunTarget?: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   plugins?: any[]
   external?: string[]
 }) {
-  console.log(`\n📦 Building ${name}...`)
+  console.log(`\n📦 Building binary for ${name}${bunTarget ? ` (${bunTarget})` : ''}...`)
   await mkdir(outdir, { recursive: true })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const compileOptions: Record<string, any> = {
+    autoloadPackageJson: true,
+  }
+  if (bunTarget) {
+    compileOptions.target = bunTarget
+  }
 
   const result = await Bun.build({
     entrypoints: [entrypoint],
@@ -59,9 +76,7 @@ async function compileApp({
     target: 'bun',
     outdir: outdir,
     minify: true,
-    compile: {
-      autoloadPackageJson: true,
-    },
+    compile: compileOptions,
     plugins,
     external,
     define: {
@@ -79,56 +94,161 @@ async function compileApp({
   }
 
   // Rename generated binary (usually Bun names it 'src' or the folder name of the entrypoint)
-  // For './apps/web/src/index.ts', './apps/agent/src/index.ts', './apps/transcode/src/index.ts', the parent is 'src'
   const generatedFile = path.join(outdir, 'src')
+  const generatedFileExe = path.join(outdir, 'src.exe')
   const finalFile = path.join(outdir, binaryName)
 
   if (existsSync(generatedFile)) {
     console.log(`➡️ Moving binary to final location: ${finalFile}`)
     await cp(generatedFile, finalFile)
     await rm(generatedFile)
+  } else if (existsSync(generatedFileExe)) {
+    console.log(`➡️ Moving binary to final location: ${finalFile}`)
+    await cp(generatedFileExe, finalFile)
+    await rm(generatedFileExe)
   } else {
-    console.error(`❌ Could not find compiled binary at ${generatedFile}`)
+    console.error(`❌ Could not find compiled binary at ${generatedFile} or ${generatedFileExe}`)
     process.exit(1)
   }
 }
 
-// 2. Build Main App (shumai)
-const shumaiOutDir = path.join(distDir, 'shumai')
-await compileApp({
-  name: 'shumai',
-  entrypoint: './apps/web/src/index.ts',
-  outdir: shumaiOutDir,
-  binaryName: 'shumai',
-  plugins: [
-    temporalWorkflow({
-      bundleOptions: {},
-    }),
-    tailwindPlugin,
-  ],
-})
+// Function to build platform-specific sub-packages for an application
+async function buildPlatformPackages(
+  appName: string,
+  entrypoint: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  plugins: any[] = [],
+) {
+  for (const target of targets) {
+    const dirName = `${appName}-${target.platform}-${target.arch}`
+    const npmName = `@shumai-one/${appName}-${target.platform}-${target.arch}`
+    const pkgOutDir = path.join(distDir, dirName)
+    const binOutDir = path.join(pkgOutDir, 'bin')
+    const binaryName = appName + target.suffix
 
-// Copy database schema and migrations for main app
-console.log('📂 Copying database files for shumai...')
-const dbDest = path.join(shumaiOutDir, 'prisma')
-await mkdir(dbDest, { recursive: true })
-await cp('./packages/db/prisma/schema.prisma', path.join(dbDest, 'schema.prisma'))
-if (existsSync('./packages/db/prisma/migrations')) {
-  await cp('./packages/db/prisma/migrations', path.join(dbDest, 'migrations'), { recursive: true })
+    await compileApp({
+      name: dirName,
+      entrypoint,
+      outdir: binOutDir,
+      binaryName,
+      bunTarget: target.bunTarget,
+      plugins,
+    })
+
+    // Generate package.json for platform-specific package
+    const platformPackageJson = {
+      name: npmName,
+      version,
+      description: `${target.platform} ${target.arch} binary for ${appName}`,
+      os: [target.platform],
+      cpu: [target.arch],
+    }
+
+    await writeFile(
+      path.join(pkgOutDir, 'package.json'),
+      JSON.stringify(platformPackageJson, null, 2),
+      'utf-8',
+    )
+  }
 }
 
-// Generate package.json for main app
-console.log('📄 Generating package.json for shumai...')
-const shumaiPackageJson = {
-  name: 'shumai',
-  version,
-  description: 'A fullstack AI-powered media workspace and workflow engine',
-  type: 'module',
-  bin: {
-    shumai: './shumai',
-  },
-  files: ['shumai', 'prisma'],
-  dependencies: {
+// Function to build main wrapper package
+async function buildMainPackage(
+  appName: string,
+  description: string,
+  hasPrisma: boolean,
+  extraDependencies: Record<string, string> = {},
+) {
+  console.log(`\n📄 Packaging wrapper app ${appName}...`)
+  const mainOutDir = path.join(distDir, appName)
+  const binOutDir = path.join(mainOutDir, 'bin')
+  await mkdir(binOutDir, { recursive: true })
+
+  // Write JS wrapper script
+  const wrapperContent = `#!/usr/bin/env node
+import { spawn } from 'node:child_process'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { existsSync } from 'node:fs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const platform = process.platform
+const arch = process.arch
+
+let pkgName = ''
+let binaryName = ''
+
+if (platform === 'darwin' && arch === 'arm64') {
+  pkgName = '@shumai-one/${appName}-darwin-arm64'
+  binaryName = '${appName}'
+} else if (platform === 'darwin' && arch === 'x64') {
+  pkgName = '@shumai-one/${appName}-darwin-x64'
+  binaryName = '${appName}'
+} else if (platform === 'linux' && arch === 'x64') {
+  pkgName = '@shumai-one/${appName}-linux-x64'
+  binaryName = '${appName}'
+} else if (platform === 'win32' && arch === 'x64') {
+  pkgName = '@shumai-one/${appName}-windows-x64'
+  binaryName = '${appName}.exe'
+} else {
+  console.error(\`Unsupported platform/architecture: \${platform}/\${arch}\`)
+  process.exit(1)
+}
+
+const pathsToTry = [
+  join(__dirname, '..', '..', '..', pkgName, 'bin', binaryName), // Flat node_modules
+  join(__dirname, '..', '..', 'node_modules', pkgName, 'bin', binaryName), // Nested node_modules
+]
+
+let binaryPath = ''
+for (const p of pathsToTry) {
+  if (existsSync(p)) {
+    binaryPath = p
+    break
+  }
+}
+
+if (!binaryPath) {
+  console.error(\`Could not find binary for platform package "\${pkgName}". Please ensure optional dependencies are installed.\`)
+  process.exit(1)
+}
+
+const child = spawn(binaryPath, process.argv.slice(2), {
+  stdio: 'inherit',
+})
+
+child.on('close', (code) => {
+  process.exit(code ?? 0)
+})
+
+child.on('error', (err) => {
+  console.error(\`Failed to start child process:\`, err)
+  process.exit(1)
+})
+`
+
+  const wrapperPath = path.join(binOutDir, `${appName}.js`)
+  await writeFile(wrapperPath, wrapperContent, { encoding: 'utf-8', mode: 0o755 })
+
+  // Copy prisma directory if needed
+  if (hasPrisma) {
+    console.log(`📂 Copying database files for ${appName}...`)
+    const dbDest = path.join(mainOutDir, 'prisma')
+    await mkdir(dbDest, { recursive: true })
+    await cp('./packages/db/prisma/schema.prisma', path.join(dbDest, 'schema.prisma'))
+    if (existsSync('./packages/db/prisma/migrations')) {
+      await cp('./packages/db/prisma/migrations', path.join(dbDest, 'migrations'), {
+        recursive: true,
+      })
+    }
+  }
+
+  // Generate package.json
+  const optionalDependencies = Object.fromEntries(
+    targets.map((t) => [`@shumai-one/${appName}-${t.platform}-${t.arch}`, version]),
+  )
+
+  const dependencies = {
     '@prisma/client': '^7.7.0',
     '@prisma/adapter-pg': '^7.7.0',
     pg: '^8.20.0',
@@ -140,102 +260,56 @@ const shumaiPackageJson = {
     '@temporalio/worker': '^1.16.1',
     '@temporalio/workflow': '^1.16.1',
     prisma: '^7.7.0',
-  },
+    ...extraDependencies,
+  }
+
+  const packageJson = {
+    name: `@shumai-one/${appName}`,
+    version,
+    description,
+    type: 'module',
+    bin: {
+      [appName]: `./bin/${appName}.js`,
+    },
+    files: ['bin', ...(hasPrisma ? ['prisma'] : [])],
+    dependencies,
+    optionalDependencies,
+  }
+
+  await writeFile(
+    path.join(mainOutDir, 'package.json'),
+    JSON.stringify(packageJson, null, 2),
+    'utf-8',
+  )
 }
-await writeFile(
-  path.join(shumaiOutDir, 'package.json'),
-  JSON.stringify(shumaiPackageJson, null, 2),
-  'utf-8',
+
+// 2. Build shumai (Main app & platform binaries)
+await buildPlatformPackages('shumai', './apps/web/src/index.ts', [
+  temporalWorkflow({
+    bundleOptions: {},
+  }),
+  tailwindPlugin,
+])
+await buildMainPackage('shumai', 'A fullstack AI-powered media workspace and workflow engine', true)
+
+// 3. Build shumai-agent (Agent app & platform binaries)
+await buildPlatformPackages('shumai-agent', './apps/agent/src/index.ts', [
+  temporalWorkflow({
+    bundleOptions: {},
+  }),
+])
+await buildMainPackage('shumai-agent', 'AI worker agent for the shumai media workspace', false)
+
+// 4. Build shumai-transcode (Transcode app & platform binaries)
+await buildPlatformPackages('shumai-transcode', './apps/transcode/src/index.ts', [
+  temporalWorkflow({
+    bundleOptions: {},
+  }),
+])
+await buildMainPackage(
+  'shumai-transcode',
+  'Media transcoding worker for the shumai media workspace',
+  false,
 )
 
-// 3. Build Agent App (shumai-agent)
-const agentOutDir = path.join(distDir, 'shumai-agent')
-await compileApp({
-  name: 'shumai-agent',
-  entrypoint: './apps/agent/src/index.ts',
-  outdir: agentOutDir,
-  binaryName: 'shumai-agent',
-  plugins: [
-    temporalWorkflow({
-      bundleOptions: {},
-    }),
-  ],
-})
-
-// Generate package.json for agent app
-console.log('📄 Generating package.json for shumai-agent...')
-const agentPackageJson = {
-  name: 'shumai-agent',
-  version,
-  description: 'AI worker agent for the shumai media workspace',
-  type: 'module',
-  bin: {
-    'shumai-agent': './shumai-agent',
-  },
-  files: ['shumai-agent'],
-  dependencies: {
-    '@prisma/client': '^7.7.0',
-    '@prisma/adapter-pg': '^7.7.0',
-    pg: '^8.20.0',
-    sharp: '^0.34.5',
-    pino: '^10.3.1',
-    'pino-pretty': '^13.1.3',
-    '@temporalio/activity': '^1.16.1',
-    '@temporalio/client': '^1.16.1',
-    '@temporalio/worker': '^1.16.1',
-    '@temporalio/workflow': '^1.16.1',
-    prisma: '^7.7.0',
-  },
-}
-await writeFile(
-  path.join(agentOutDir, 'package.json'),
-  JSON.stringify(agentPackageJson, null, 2),
-  'utf-8',
-)
-
-// 4. Build Transcode App (shumai-transcode)
-const transcodeOutDir = path.join(distDir, 'shumai-transcode')
-await compileApp({
-  name: 'shumai-transcode',
-  entrypoint: './apps/transcode/src/index.ts',
-  outdir: transcodeOutDir,
-  binaryName: 'shumai-transcode',
-  plugins: [
-    temporalWorkflow({
-      bundleOptions: {},
-    }),
-  ],
-})
-
-// Generate package.json for transcode app
-console.log('📄 Generating package.json for shumai-transcode...')
-const transcodePackageJson = {
-  name: 'shumai-transcode',
-  version,
-  description: 'Media transcoding worker for the shumai media workspace',
-  type: 'module',
-  bin: {
-    'shumai-transcode': './shumai-transcode',
-  },
-  files: ['shumai-transcode'],
-  dependencies: {
-    '@prisma/client': '^7.7.0',
-    '@prisma/adapter-pg': '^7.7.0',
-    pg: '^8.20.0',
-    sharp: '^0.34.5',
-    pino: '^10.3.1',
-    'pino-pretty': '^13.1.3',
-    '@temporalio/activity': '^1.16.1',
-    '@temporalio/client': '^1.16.1',
-    '@temporalio/worker': '^1.16.1',
-    '@temporalio/workflow': '^1.16.1',
-    prisma: '^7.7.0',
-  },
-}
-await writeFile(
-  path.join(transcodeOutDir, 'package.json'),
-  JSON.stringify(transcodePackageJson, null, 2),
-  'utf-8',
-)
-
-console.log('\n✅ All applications built and packaged successfully!')
+console.log('\n✅ All applications and platform binaries built and packaged successfully!')

--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -36,7 +36,9 @@ const commonExternal = [
 const targets = [
   { platform: 'darwin', arch: 'arm64', bunTarget: 'bun-darwin-arm64', suffix: '' },
   { platform: 'darwin', arch: 'x64', bunTarget: 'bun-darwin-x64', suffix: '' },
+  { platform: 'linux', arch: 'arm64', bunTarget: 'bun-linux-arm64', suffix: '' },
   { platform: 'linux', arch: 'x64', bunTarget: 'bun-linux-x64', suffix: '' },
+  { platform: 'win32', arch: 'arm64', bunTarget: 'bun-windows-arm64', suffix: '.exe' },
   { platform: 'win32', arch: 'x64', bunTarget: 'bun-windows-x64', suffix: '.exe' },
 ]
 
@@ -184,11 +186,17 @@ if (platform === 'darwin' && arch === 'arm64') {
 } else if (platform === 'darwin' && arch === 'x64') {
   pkgName = '@shumai-one/${appName}-darwin-x64'
   binaryName = '${appName}'
+} else if (platform === 'linux' && arch === 'arm64') {
+  pkgName = '@shumai-one/${appName}-linux-arm64'
+  binaryName = '${appName}'
 } else if (platform === 'linux' && arch === 'x64') {
   pkgName = '@shumai-one/${appName}-linux-x64'
   binaryName = '${appName}'
+} else if (platform === 'win32' && arch === 'arm64') {
+  pkgName = '@shumai-one/${appName}-win32-arm64'
+  binaryName = '${appName}.exe'
 } else if (platform === 'win32' && arch === 'x64') {
-  pkgName = '@shumai-one/${appName}-windows-x64'
+  pkgName = '@shumai-one/${appName}-win32-x64'
   binaryName = '${appName}.exe'
 } else {
   console.error(\`Unsupported platform/architecture: \${platform}/\${arch}\`)

--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -4,91 +4,124 @@ import path from 'node:path'
 import tailwindPlugin from 'bun-plugin-tailwind'
 import { temporalWorkflow } from '../packages/workflow-core/src/bun-temporal-plugin'
 
-console.log('\n🚀 Starting NPM packaging build process...\n')
+console.log('\n🚀 Starting NPM packaging build process for all applications...\n')
 
-const outdir = path.join(process.cwd(), 'dist')
+const rootDir = process.cwd()
+const distDir = path.join(rootDir, 'dist')
 
 // 1. Clean previous build
-if (existsSync(outdir)) {
-  console.log(`🗑️ Cleaning previous build at ${outdir}`)
-  await rm(outdir, { recursive: true, force: true })
+if (existsSync(distDir)) {
+  console.log(`🗑️ Cleaning previous build at ${distDir}`)
+  await rm(distDir, { recursive: true, force: true })
 }
-await mkdir(outdir, { recursive: true })
+await mkdir(distDir, { recursive: true })
 
-// 2. Build & Compile to standalone executable
-console.log('📦 Compiling to standalone binary...')
-const result = await Bun.build({
-  entrypoints: ['./apps/web/src/index.ts'],
-  root: '.',
-  target: 'bun',
-  outdir: outdir,
-  minify: true,
-  compile: {
-    autoloadPackageJson: true,
-  },
+const rootPackageJson = JSON.parse(await Bun.file('package.json').text())
+const version = rootPackageJson.version || '0.1.0'
+
+const commonExternal = [
+  '@prisma/client',
+  '@prisma/adapter-pg',
+  'pg',
+  'sharp',
+  'pino',
+  'pino-pretty',
+  '@temporalio/activity',
+  '@temporalio/client',
+  '@temporalio/worker',
+  '@temporalio/workflow',
+  'prisma',
+]
+
+// Function to compile a single application
+async function compileApp({
+  name,
+  entrypoint,
+  outdir,
+  binaryName,
+  plugins = [],
+  external = commonExternal,
+}: {
+  name: string
+  entrypoint: string
+  outdir: string
+  binaryName: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  plugins?: any[]
+  external?: string[]
+}) {
+  console.log(`\n📦 Building ${name}...`)
+  await mkdir(outdir, { recursive: true })
+
+  const result = await Bun.build({
+    entrypoints: [entrypoint],
+    root: '.',
+    target: 'bun',
+    outdir: outdir,
+    minify: true,
+    compile: {
+      autoloadPackageJson: true,
+    },
+    plugins,
+    external,
+    define: {
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    },
+    publicPath: '/',
+  })
+
+  if (!result.success) {
+    console.error(`❌ Binary compilation failed for ${name}!`)
+    for (const log of result.logs) {
+      console.error(log)
+    }
+    process.exit(1)
+  }
+
+  // Rename generated binary (usually Bun names it 'src' or the folder name of the entrypoint)
+  // For './apps/web/src/index.ts', './apps/agent/src/index.ts', './apps/transcode/src/index.ts', the parent is 'src'
+  const generatedFile = path.join(outdir, 'src')
+  const finalFile = path.join(outdir, binaryName)
+
+  if (existsSync(generatedFile)) {
+    console.log(`➡️ Moving binary to final location: ${finalFile}`)
+    await cp(generatedFile, finalFile)
+    await rm(generatedFile)
+  } else {
+    console.error(`❌ Could not find compiled binary at ${generatedFile}`)
+    process.exit(1)
+  }
+}
+
+// 2. Build Main App (shumai)
+const shumaiOutDir = path.join(distDir, 'shumai')
+await compileApp({
+  name: 'shumai',
+  entrypoint: './apps/web/src/index.ts',
+  outdir: shumaiOutDir,
+  binaryName: 'shumai',
   plugins: [
     temporalWorkflow({
       bundleOptions: {},
     }),
     tailwindPlugin,
   ],
-  external: [
-    '@prisma/client',
-    '@prisma/adapter-pg',
-    'pg',
-    'sharp',
-    'pino',
-    'pino-pretty',
-    '@temporalio/activity',
-    '@temporalio/client',
-    '@temporalio/worker',
-    '@temporalio/workflow',
-    'prisma',
-  ],
-  define: {
-    'process.env.NODE_ENV': JSON.stringify('production'),
-  },
-  publicPath: '/',
 })
 
-if (!result.success) {
-  console.error('❌ Binary compilation failed!')
-  for (const log of result.logs) {
-    console.error(log)
-  }
-  process.exit(1)
-}
-
-// 3. Rename generated binary to 'shumai'
-// Entrypoint './apps/web/src/index.ts' with outdir 'dist' outputs to 'dist/src' (parent folder name of the entrypoint)
-const generatedFile = path.join(outdir, 'src')
-const finalFile = path.join(outdir, 'shumai')
-
-if (existsSync(generatedFile)) {
-  console.log(`➡️ Moving binary to final location: ${finalFile}`)
-  await cp(generatedFile, finalFile)
-  // Remove the generated source file
-  await rm(generatedFile)
-} else {
-  console.error(`❌ Could not find compiled binary at ${generatedFile}`)
-  process.exit(1)
-}
-
-// 4. Copy database schema and migrations
-console.log('📂 Copying database files...')
-const dbDest = path.join(outdir, 'prisma')
+// Copy database schema and migrations for main app
+console.log('📂 Copying database files for shumai...')
+const dbDest = path.join(shumaiOutDir, 'prisma')
 await mkdir(dbDest, { recursive: true })
 await cp('./packages/db/prisma/schema.prisma', path.join(dbDest, 'schema.prisma'))
 if (existsSync('./packages/db/prisma/migrations')) {
   await cp('./packages/db/prisma/migrations', path.join(dbDest, 'migrations'), { recursive: true })
 }
 
-// 5. Generate package.json
-console.log('📄 Generating package.json...')
-const rootPackageJson = JSON.parse(await Bun.file('package.json').text())
-const packageJsonContent = {
+// Generate package.json for main app
+console.log('📄 Generating package.json for shumai...')
+const shumaiPackageJson = {
   name: 'shumai',
-  version: rootPackageJson.version || '0.1.0',
+  version,
   description: 'A fullstack AI-powered media workspace and workflow engine',
   type: 'module',
   bin: {
@@ -109,11 +142,100 @@ const packageJsonContent = {
     prisma: '^7.7.0',
   },
 }
-
 await writeFile(
-  path.join(outdir, 'package.json'),
-  JSON.stringify(packageJsonContent, null, 2),
+  path.join(shumaiOutDir, 'package.json'),
+  JSON.stringify(shumaiPackageJson, null, 2),
   'utf-8',
 )
 
-console.log('✅ Build completed successfully!')
+// 3. Build Agent App (shumai-agent)
+const agentOutDir = path.join(distDir, 'shumai-agent')
+await compileApp({
+  name: 'shumai-agent',
+  entrypoint: './apps/agent/src/index.ts',
+  outdir: agentOutDir,
+  binaryName: 'shumai-agent',
+  plugins: [
+    temporalWorkflow({
+      bundleOptions: {},
+    }),
+  ],
+})
+
+// Generate package.json for agent app
+console.log('📄 Generating package.json for shumai-agent...')
+const agentPackageJson = {
+  name: 'shumai-agent',
+  version,
+  description: 'AI worker agent for the shumai media workspace',
+  type: 'module',
+  bin: {
+    'shumai-agent': './shumai-agent',
+  },
+  files: ['shumai-agent'],
+  dependencies: {
+    '@prisma/client': '^7.7.0',
+    '@prisma/adapter-pg': '^7.7.0',
+    pg: '^8.20.0',
+    sharp: '^0.34.5',
+    pino: '^10.3.1',
+    'pino-pretty': '^13.1.3',
+    '@temporalio/activity': '^1.16.1',
+    '@temporalio/client': '^1.16.1',
+    '@temporalio/worker': '^1.16.1',
+    '@temporalio/workflow': '^1.16.1',
+    prisma: '^7.7.0',
+  },
+}
+await writeFile(
+  path.join(agentOutDir, 'package.json'),
+  JSON.stringify(agentPackageJson, null, 2),
+  'utf-8',
+)
+
+// 4. Build Transcode App (shumai-transcode)
+const transcodeOutDir = path.join(distDir, 'shumai-transcode')
+await compileApp({
+  name: 'shumai-transcode',
+  entrypoint: './apps/transcode/src/index.ts',
+  outdir: transcodeOutDir,
+  binaryName: 'shumai-transcode',
+  plugins: [
+    temporalWorkflow({
+      bundleOptions: {},
+    }),
+  ],
+})
+
+// Generate package.json for transcode app
+console.log('📄 Generating package.json for shumai-transcode...')
+const transcodePackageJson = {
+  name: 'shumai-transcode',
+  version,
+  description: 'Media transcoding worker for the shumai media workspace',
+  type: 'module',
+  bin: {
+    'shumai-transcode': './shumai-transcode',
+  },
+  files: ['shumai-transcode'],
+  dependencies: {
+    '@prisma/client': '^7.7.0',
+    '@prisma/adapter-pg': '^7.7.0',
+    pg: '^8.20.0',
+    sharp: '^0.34.5',
+    pino: '^10.3.1',
+    'pino-pretty': '^13.1.3',
+    '@temporalio/activity': '^1.16.1',
+    '@temporalio/client': '^1.16.1',
+    '@temporalio/worker': '^1.16.1',
+    '@temporalio/workflow': '^1.16.1',
+    prisma: '^7.7.0',
+  },
+}
+await writeFile(
+  path.join(transcodeOutDir, 'package.json'),
+  JSON.stringify(transcodePackageJson, null, 2),
+  'utf-8',
+)
+
+console.log('\n✅ All applications built and packaged successfully!')

--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -1,0 +1,119 @@
+import { rm, mkdir, cp, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import tailwindPlugin from 'bun-plugin-tailwind'
+import { temporalWorkflow } from '../packages/workflow-core/src/bun-temporal-plugin'
+
+console.log('\n🚀 Starting NPM packaging build process...\n')
+
+const outdir = path.join(process.cwd(), 'dist')
+
+// 1. Clean previous build
+if (existsSync(outdir)) {
+  console.log(`🗑️ Cleaning previous build at ${outdir}`)
+  await rm(outdir, { recursive: true, force: true })
+}
+await mkdir(outdir, { recursive: true })
+
+// 2. Build & Compile to standalone executable
+console.log('📦 Compiling to standalone binary...')
+const result = await Bun.build({
+  entrypoints: ['./apps/web/src/index.ts'],
+  root: '.',
+  target: 'bun',
+  outdir: outdir,
+  minify: true,
+  compile: {
+    autoloadPackageJson: true,
+  },
+  plugins: [
+    temporalWorkflow({
+      bundleOptions: {},
+    }),
+    tailwindPlugin,
+  ],
+  external: [
+    '@prisma/client',
+    '@prisma/adapter-pg',
+    'pg',
+    'sharp',
+    'pino',
+    'pino-pretty',
+    '@temporalio/activity',
+    '@temporalio/client',
+    '@temporalio/worker',
+    '@temporalio/workflow',
+    'prisma',
+  ],
+  define: {
+    'process.env.NODE_ENV': JSON.stringify('production'),
+  },
+  publicPath: '/',
+})
+
+if (!result.success) {
+  console.error('❌ Binary compilation failed!')
+  for (const log of result.logs) {
+    console.error(log)
+  }
+  process.exit(1)
+}
+
+// 3. Rename generated binary to 'shumai'
+// Entrypoint './apps/web/src/index.ts' with outdir 'dist' outputs to 'dist/src' (parent folder name of the entrypoint)
+const generatedFile = path.join(outdir, 'src')
+const finalFile = path.join(outdir, 'shumai')
+
+if (existsSync(generatedFile)) {
+  console.log(`➡️ Moving binary to final location: ${finalFile}`)
+  await cp(generatedFile, finalFile)
+  // Remove the generated source file
+  await rm(generatedFile)
+} else {
+  console.error(`❌ Could not find compiled binary at ${generatedFile}`)
+  process.exit(1)
+}
+
+// 4. Copy database schema and migrations
+console.log('📂 Copying database files...')
+const dbDest = path.join(outdir, 'prisma')
+await mkdir(dbDest, { recursive: true })
+await cp('./packages/db/prisma/schema.prisma', path.join(dbDest, 'schema.prisma'))
+if (existsSync('./packages/db/prisma/migrations')) {
+  await cp('./packages/db/prisma/migrations', path.join(dbDest, 'migrations'), { recursive: true })
+}
+
+// 5. Generate package.json
+console.log('📄 Generating package.json...')
+const rootPackageJson = JSON.parse(await Bun.file('package.json').text())
+const packageJsonContent = {
+  name: 'shumai',
+  version: rootPackageJson.version || '0.1.0',
+  description: 'A fullstack AI-powered media workspace and workflow engine',
+  type: 'module',
+  bin: {
+    shumai: './shumai',
+  },
+  files: ['shumai', 'prisma'],
+  dependencies: {
+    '@prisma/client': '^7.7.0',
+    '@prisma/adapter-pg': '^7.7.0',
+    pg: '^8.20.0',
+    sharp: '^0.34.5',
+    pino: '^10.3.1',
+    'pino-pretty': '^13.1.3',
+    '@temporalio/activity': '^1.16.1',
+    '@temporalio/client': '^1.16.1',
+    '@temporalio/worker': '^1.16.1',
+    '@temporalio/workflow': '^1.16.1',
+    prisma: '^7.7.0',
+  },
+}
+
+await writeFile(
+  path.join(outdir, 'package.json'),
+  JSON.stringify(packageJsonContent, null, 2),
+  'utf-8',
+)
+
+console.log('✅ Build completed successfully!')

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,0 +1,147 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const dryRun = process.argv.includes('--dry-run')
+const unknownArgs = process.argv.slice(2).filter((arg) => arg !== '--dry-run')
+
+if (unknownArgs.length > 0) {
+  console.error('Usage: bun run scripts/publish.ts [--dry-run]')
+  process.exit(1)
+}
+
+function commandForPlatform(command: string) {
+  return process.platform === 'win32' ? `${command}.cmd` : command
+}
+
+function run(command: string, args: string[], options: { cwd?: string; capture?: boolean } = {}) {
+  console.log(`$ ${[command, ...args].join(' ')}`)
+  const result = spawnSync(commandForPlatform(command), args, {
+    cwd: options.cwd,
+    encoding: 'utf8',
+    stdio: options.capture ? ['inherit', 'pipe', 'pipe'] : 'inherit',
+  })
+
+  if (result.status !== 0) {
+    const output = [result.stdout, result.stderr].filter(Boolean).join('\n')
+    throw new Error(
+      output
+        ? `Command failed: ${command} ${args.join(' ')}\n${output}`
+        : `Command failed: ${command} ${args.join(' ')}`,
+    )
+  }
+
+  return result
+}
+
+function readPackageJson(directory: string) {
+  return JSON.parse(readFileSync(join(directory, 'package.json'), 'utf8'))
+}
+
+function assertBuildOutputExists(directory: string) {
+  if (!existsSync(directory)) {
+    throw new Error(`${directory} does not exist. Run bun run build-npm before publishing.`)
+  }
+}
+
+function validatePack(directory: string) {
+  const result = run('npm', ['pack', '--dry-run', '--ignore-scripts', '--json'], {
+    capture: true,
+    cwd: directory,
+  })
+  const packed = JSON.parse(result.stdout)[0]
+  console.log(
+    `  ${packed.filename}: ${packed.files.length} files, ${packed.size} bytes packed, ${packed.unpackedSize} bytes unpacked`,
+  )
+}
+
+function isPublished(name: string, version: string) {
+  const result = spawnSync(
+    commandForPlatform('npm'),
+    ['view', `${name}@${version}`, 'version', '--json'],
+    {
+      encoding: 'utf8',
+      stdio: ['inherit', 'pipe', 'pipe'],
+    },
+  )
+
+  if (result.status === 0 && result.stdout.trim()) {
+    return true
+  }
+
+  const output = [result.stdout, result.stderr].filter(Boolean).join('\n')
+  if (result.status !== 0 && (output.includes('E404') || output.includes('404 Not Found'))) {
+    return false
+  }
+
+  throw new Error(
+    output ? `Failed to query ${name}@${version}\n${output}` : `Failed to query ${name}@${version}`,
+  )
+}
+
+// 1. Scan the dist folder for all directories containing a package.json
+if (!existsSync('dist')) {
+  throw new Error('dist directory does not exist. Run bun run build-npm first.')
+}
+
+const packages = readdirSync('dist', { withFileTypes: true })
+  .filter((dirent) => dirent.isDirectory())
+  .map((dirent) => {
+    const dir = join('dist', dirent.name)
+    try {
+      const packageJson = readPackageJson(dir)
+      return { directory: dir, name: packageJson.name }
+    } catch {
+      return null
+    }
+  })
+  .filter((pkg): pkg is { directory: string; name: string } => pkg !== null)
+
+if (packages.length === 0) {
+  throw new Error('No package directories found in dist/')
+}
+
+const packageVersions = new Map<string, string>()
+for (const pkg of packages) {
+  assertBuildOutputExists(pkg.directory)
+  const packageJson = readPackageJson(pkg.directory)
+  if (packageJson.name !== pkg.name) {
+    throw new Error(
+      `${pkg.directory}/package.json has name ${packageJson.name}, expected ${pkg.name}`,
+    )
+  }
+  packageVersions.set(pkg.name, packageJson.version)
+}
+
+const versions = [...new Set(packageVersions.values())]
+if (versions.length !== 1) {
+  throw new Error(`Publish packages are not lockstep versioned: ${versions.join(', ')}`)
+}
+
+console.log(`Publishing shumai packages at ${versions[0]}${dryRun ? ' (dry run)' : ''}\n`)
+
+for (const pkg of packages) {
+  const version = packageVersions.get(pkg.name)!
+  const published = isPublished(pkg.name, version)
+
+  if (dryRun) {
+    if (published) {
+      console.log(`${pkg.name}@${version} is already published; validating package contents only.`)
+    } else {
+      console.log(
+        `${pkg.name}@${version} is not published; validating package contents before publish.`,
+      )
+    }
+    validatePack(pkg.directory)
+    console.log()
+    continue
+  }
+
+  if (published) {
+    console.log(`Skipping ${pkg.name}@${version}: already published\n`)
+    continue
+  }
+
+  run('npm', ['publish', '--access', 'public', '--ignore-scripts'], { cwd: pkg.directory })
+  console.log()
+}

--- a/scripts/release-local.ts
+++ b/scripts/release-local.ts
@@ -1,0 +1,217 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { isAbsolute, join, relative, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+function printUsage() {
+  console.log(`Usage: bun run scripts/release-local.ts [options]
+
+Builds and packs the publishable packages, then installs the tarballs into an
+isolated directory outside the repository for local release testing.
+
+Options:
+  --out <dir>          Output directory. Defaults to a new directory under ${tmpdir()}
+  --force              Remove --out first if it already exists
+  --skip-check         Do not run bun run check (lint/format/typecheck) before building
+  --help               Show this help
+`)
+}
+
+function parseArgs() {
+  const options = { force: false, outDir: '', skipCheck: false }
+  const args = process.argv.slice(2)
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg === '--help') {
+      printUsage()
+      process.exit(0)
+    }
+    if (arg === '--force') {
+      options.force = true
+      continue
+    }
+    if (arg === '--skip-check') {
+      options.skipCheck = true
+      continue
+    }
+    if (arg === '--out') {
+      const value = args[++i]
+      if (!value) {
+        throw new Error('--out requires a directory')
+      }
+      options.outDir = value
+      continue
+    }
+    throw new Error(`Unknown option: ${arg}`)
+  }
+
+  return options
+}
+
+function commandForPlatform(command: string) {
+  return process.platform === 'win32' ? `${command}.cmd` : command
+}
+
+function run(command: string, args: string[], options: { cwd?: string; capture?: boolean } = {}) {
+  console.log(`$ ${[command, ...args].join(' ')}`)
+  const result = spawnSync(commandForPlatform(command), args, {
+    cwd: options.cwd,
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+    stdio: options.capture ? ['inherit', 'pipe', 'inherit'] : 'inherit',
+  })
+
+  if (result.status !== 0) {
+    throw new Error(`Command failed: ${[command, ...args].join(' ')}`)
+  }
+
+  return result.stdout ?? ''
+}
+
+function readPackageJson(directory: string) {
+  return JSON.parse(readFileSync(join(directory, 'package.json'), 'utf8'))
+}
+
+// Check if a directory is inside another directory path
+function isInsidePath(child: string, parent: string) {
+  const relativePath = relative(parent, child)
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
+}
+
+function prepareOutputDirectory(outDirOpt: string, force: boolean, repoRoot: string) {
+  if (!outDirOpt) {
+    const randomName = `shumai-local-release-${Math.random().toString(36).substring(2, 10)}`
+    return join(tmpdir(), randomName)
+  }
+
+  const outDir = resolve(outDirOpt)
+
+  if (isInsidePath(outDir, repoRoot)) {
+    throw new Error(`Output directory must be outside the repository: ${outDir}`)
+  }
+
+  if (existsSync(outDir)) {
+    if (!force) {
+      throw new Error(`Output directory already exists. Use --force to replace it: ${outDir}`)
+    }
+    rmSync(outDir, { force: true, recursive: true })
+  }
+
+  mkdirSync(outDir, { recursive: true })
+  return outDir
+}
+
+function fileSpecifier(fromDirectory: string, file: string) {
+  const relativePath = relative(fromDirectory, file).replaceAll('\\', '/')
+  return `file:${relativePath.startsWith('.') ? relativePath : `./${relativePath}`}`
+}
+
+function packPackage(pkg: { directory: string; name: string }, tarballDirectory: string) {
+  const packageJson = readPackageJson(pkg.directory)
+  if (packageJson.name !== pkg.name) {
+    throw new Error(
+      `${pkg.directory}/package.json has name ${packageJson.name}, expected ${pkg.name}`,
+    )
+  }
+
+  const output = run('npm', ['pack', '--json', '--pack-destination', tarballDirectory], {
+    capture: true,
+    cwd: pkg.directory,
+  })
+  const packed = JSON.parse(output)[0]
+  return join(tarballDirectory, packed.filename)
+}
+
+const options = parseArgs()
+const repoRoot = process.cwd()
+const rootPackageJson = readPackageJson(repoRoot)
+
+if (rootPackageJson.name !== 'shumai') {
+  throw new Error('Run this script from the repository root')
+}
+
+const outDir = prepareOutputDirectory(options.outDir, options.force, repoRoot)
+const tarballDirectory = join(outDir, 'tarballs')
+const nodeInstallDirectory = join(outDir, 'node')
+mkdirSync(tarballDirectory, { recursive: true })
+
+if (!options.skipCheck) {
+  console.log('🔍 Running code quality checks...')
+  run('bun', ['run', 'format'])
+  run('bun', ['run', 'lint'])
+  run('bun', ['run', 'typecheck'])
+}
+
+console.log('🏗️ Building all NPM packages...')
+run('bun', ['run', 'build-npm'])
+
+// 1. Scan the dist folder for all directories containing a package.json
+if (!existsSync('dist')) {
+  throw new Error('dist directory does not exist after build.')
+}
+
+const packages = readdirSync('dist', { withFileTypes: true })
+  .filter((dirent) => dirent.isDirectory())
+  .map((dirent) => {
+    const dir = join('dist', dirent.name)
+    try {
+      const packageJson = readPackageJson(dir)
+      return { directory: dir, name: packageJson.name }
+    } catch {
+      return null
+    }
+  })
+  .filter((pkg): pkg is { directory: string; name: string } => pkg !== null)
+
+if (packages.length === 0) {
+  throw new Error('No package directories found in dist/')
+}
+
+const tarballs = new Map<string, string>()
+for (const pkg of packages) {
+  const tarball = packPackage(pkg, tarballDirectory)
+  tarballs.set(pkg.name, tarball)
+}
+
+console.log('📦 Creating isolated npm installation...')
+mkdirSync(nodeInstallDirectory, { recursive: true })
+
+const wrapperAppNames = [
+  '@shumai-one/shumai',
+  '@shumai-one/shumai-agent',
+  '@shumai-one/shumai-transcode',
+]
+const dependencies = Object.fromEntries(
+  packages
+    .filter((pkg) => wrapperAppNames.includes(pkg.name))
+    .map((pkg) => [pkg.name, fileSpecifier(nodeInstallDirectory, tarballs.get(pkg.name)!)]),
+)
+const overrides = Object.fromEntries(
+  packages.map((pkg) => [pkg.name, fileSpecifier(nodeInstallDirectory, tarballs.get(pkg.name)!)]),
+)
+
+const installPackageJson = `${JSON.stringify(
+  { private: true, dependencies, overrides },
+  undefined,
+  '\t',
+)}\n`
+writeFileSync(join(nodeInstallDirectory, 'package.json'), installPackageJson)
+
+run('npm', ['install', '--omit=dev', '--ignore-scripts'], { cwd: nodeInstallDirectory })
+
+console.log('\n✅ Local release artifacts created successfully!')
+console.log(`  Release directory: ${outDir}`)
+
+console.log('\nTarballs generated:')
+for (const tarball of tarballs.values()) {
+  console.log(`  ${tarball}`)
+}
+
+console.log('\nIsolated npm install location:')
+console.log(`  ${nodeInstallDirectory}`)
+
+console.log('\nTo run the locally packed CLI apps from outside the repository:')
+console.log(`  npx --prefix ${nodeInstallDirectory} shumai`)
+console.log(`  npx --prefix ${nodeInstallDirectory} shumai-agent`)
+console.log(`  npx --prefix ${nodeInstallDirectory} shumai-transcode`)

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,173 @@
+import { execSync } from 'node:child_process'
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const releaseTarget = process.argv[2]
+const bumpTypes = new Set(['major', 'minor', 'patch'])
+const semverRe = /^\d+\.\d+\.\d+$/
+
+if (!releaseTarget || (!bumpTypes.has(releaseTarget) && !semverRe.test(releaseTarget))) {
+  console.error('Usage: bun run scripts/release.ts <major|minor|patch|x.y.z>')
+  process.exit(1)
+}
+
+function run(cmd: string, options: { silent?: boolean; ignoreError?: boolean } = {}) {
+  console.log(`$ ${cmd}`)
+  try {
+    return execSync(cmd, { encoding: 'utf-8', stdio: options.silent ? 'pipe' : 'inherit' })
+  } catch {
+    if (!options.ignoreError) {
+      console.error(`Command failed: ${cmd}`)
+      process.exit(1)
+    }
+    return null
+  }
+}
+
+function parseSemver(v: string) {
+  const match = v.match(/^(\d+)\.(\d+)\.(\d+)$/)
+  if (!match) {
+    throw new Error(`Invalid version format: ${v}`)
+  }
+  return {
+    major: parseInt(match[1], 10),
+    minor: parseInt(match[2], 10),
+    patch: parseInt(match[3], 10),
+  }
+}
+
+function incrementVersion(version: string, type: 'major' | 'minor' | 'patch') {
+  const { major, minor, patch } = parseSemver(version)
+  if (type === 'major') {
+    return `${major + 1}.0.0`
+  }
+  if (type === 'minor') {
+    return `${major}.${minor + 1}.0`
+  }
+  return `${major}.${minor}.${patch + 1}`
+}
+
+function compareVersions(a: string, b: string) {
+  const av = parseSemver(a)
+  const bv = parseSemver(b)
+  if (av.major !== bv.major) return av.major - bv.major
+  if (av.minor !== bv.minor) return av.minor - bv.minor
+  return av.patch - bv.patch
+}
+
+function getPackageJsonFiles() {
+  const files: string[] = ['package.json']
+
+  // Find in packages/
+  if (existsSync('packages')) {
+    const packages = readdirSync('packages')
+    for (const pkg of packages) {
+      const p = join('packages', pkg, 'package.json')
+      if (existsSync(p)) {
+        files.push(p)
+      }
+    }
+  }
+
+  // Find in apps/
+  if (existsSync('apps')) {
+    const apps = readdirSync('apps')
+    for (const app of apps) {
+      const p = join('apps', app, 'package.json')
+      if (existsSync(p)) {
+        files.push(p)
+      }
+    }
+  }
+
+  return files
+}
+
+function updateVersions(newVersion: string) {
+  const files = getPackageJsonFiles()
+  for (const file of files) {
+    const content = JSON.parse(readFileSync(file, 'utf-8'))
+    content.version = newVersion
+    writeFileSync(file, JSON.stringify(content, null, 2) + '\n', 'utf-8')
+    console.log(`  Updated version in ${file}`)
+  }
+}
+
+function shellQuote(value: string) {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+function stageChangedFiles() {
+  const output = run('git ls-files -m -o -d --exclude-standard', { silent: true })
+  const paths = [
+    ...new Set(
+      (output || '')
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean),
+    ),
+  ]
+  if (paths.length === 0) {
+    return
+  }
+  run(`git add -- ${paths.map(shellQuote).join(' ')}`)
+}
+
+// Main Flow
+console.log('\n=== Release Script ===\n')
+
+// 1. Check for uncommitted changes
+console.log('Checking for uncommitted changes...')
+const status = run('git status --porcelain', { silent: true })
+if (status && status.trim()) {
+  console.error('Error: Uncommitted changes detected. Commit or stash first.')
+  console.error(status)
+  process.exit(1)
+}
+console.log('  Working directory clean\n')
+
+// 2. Determine version
+const rootPkg = JSON.parse(readFileSync('package.json', 'utf-8'))
+const currentVersion = rootPkg.version || '0.1.0'
+let newVersion = ''
+
+if (bumpTypes.has(releaseTarget)) {
+  newVersion = incrementVersion(currentVersion, releaseTarget as 'major' | 'minor' | 'patch')
+} else {
+  newVersion = releaseTarget
+  if (compareVersions(newVersion, currentVersion) <= 0) {
+    console.error(
+      `Error: explicit version ${newVersion} must be greater than current version ${currentVersion}.`,
+    )
+    process.exit(1)
+  }
+}
+
+console.log(`Bumping version from ${currentVersion} to ${newVersion}...`)
+updateVersions(newVersion)
+console.log()
+
+// 3. Update bun.lock
+console.log('Refreshing lockfile...')
+run('bun install')
+console.log()
+
+// 4. Run build and checks
+console.log('Running build and checks...')
+run('bun run prepublishOnly')
+console.log()
+
+// 5. Commit and tag
+console.log('Committing and tagging release...')
+stageChangedFiles()
+run(`git commit -m "Release v${newVersion}"`)
+run(`git tag v${newVersion}`)
+console.log()
+
+// 6. Push to remote
+console.log('Pushing to remote...')
+run('git push origin main')
+run(`git push origin v${newVersion}`)
+console.log()
+
+console.log(`=== Prepared release v${newVersion}; tag pushed successfully ===`)


### PR DESCRIPTION
## Summary

This pull request implements a packaging and compilation workflow to distribute all three applications in the `shumai` monorepo (`shumai`, `shumai-agent`, and `shumai-transcode`) to NPM as standalone compiled binaries with autoloaded node_modules.

## Changes

- **Added build-npm packaging script**: Introduced [build-npm.ts](file:///Users/yiling/Projects/shumai/scripts/build-npm.ts) to compile and package all three applications:
  - `shumai` (Main App) compiled from `apps/web/src/index.ts` to `dist/shumai/shumai`.
  - `shumai-agent` (Agent Worker) compiled from `apps/agent/src/index.ts` to `dist/shumai-agent/shumai-agent`.
  - `shumai-transcode` (Transcode Worker) compiled from `apps/transcode/src/index.ts` to `dist/shumai-transcode/shumai-transcode`.
- **Workflow Isolation via Webpack Aliases**: Configured Webpack aliases in both the build-time Temporal plugin [bun-temporal-plugin.ts](file:///Users/yiling/Projects/shumai/packages/workflow-core/src/bun-temporal-plugin.ts) and the runtime worker [workflow.ts](file:///Users/yiling/Projects/shumai/packages/workflow-core/src/workflow.ts) to alias `@shumai/workflow-core` directly to `@shumai/workflow-core/src/workflow-utils.ts`. This isolates the deterministic workflow bundle from Prisma, database clients, and other native dependencies during bundling.
- **Added root packaging script**: Exposed `"build-npm": "bun scripts/build-npm.ts"` script under `"scripts"` in the root [package.json](file:///Users/yiling/Projects/shumai/package.json).

## Verification

- Packed the compiled outputs into `.tgz` archives (`shumai-agent-0.1.0.tgz` and `shumai-transcode-0.1.0.tgz`) and successfully installed them in isolated mock projects.
- Verified that both workers correctly resolved their external dependencies (including native prebuilds like `sharp`, `pino`, `@prisma/client`, and `@temporalio/*`) and started up successfully using `npx shumai-agent` and `npx shumai-transcode`.
- Ran all repository validation checks:
  - `bun run lint` (passed)
  - `bun run format` (passed)
  - `bun run typecheck` (passed)
  - `bun run test` (all 415 test suites passed)

## Notes

None.
