### PR TITLE
refactor(docker): run as non-root bun user and add agent tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,18 +22,37 @@ RUN bun run build.ts
 # Stage 2: Runner
 FROM oven/bun:1 AS runner
 
-WORKDIR /app
-
 # Install ffmpeg/ffprobe
 COPY --from=mwader/static-ffmpeg:8.1 /ffmpeg /usr/local/bin/
 COPY --from=mwader/static-ffmpeg:8.1 /ffprobe /usr/local/bin/
 
-# Install system dependencies for sandbox runtime
-RUN apt-get update && apt-get install -y ripgrep bubblewrap socat && rm -rf /var/lib/apt/lists/*
+# Install system dependencies for sandbox runtime and agent
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    make \
+    man-db \
+    curl \
+    dnsutils \
+    less \
+    jq \
+    bc \
+    unzip \
+    rsync \
+    ripgrep \
+    procps \
+    lsof \
+    socat \
+    ca-certificates \
+    bubblewrap \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-# Copy sharp/img from builder (they are native and already installed)
-# COPY --from=builder /app/packages/transcode/node_modules/sharp ./node_modules/sharp
-# COPY --from=builder /app/packages/transcode/node_modules/@img ./node_modules/@img
+# Set up working directory and make it owned by the bun user
+RUN mkdir -p /app/data && chown -R bun:bun /app
+
+# Switch to the non-root bun user
+USER bun
+WORKDIR /app
 
 # Manually install temporalio packages and prisma
 # These need native bindings or CLI access in the runner environment
@@ -41,9 +60,9 @@ RUN bun add @temporalio/activity @temporalio/client @temporalio/worker @temporal
     bun add --dev --omit peer prisma sharp
 
 # Copy build artifacts and prisma config
-COPY --from=builder /app/dist ./
-COPY --from=builder /app/packages/db/prisma ./packages/db/prisma
-COPY --from=builder /app/prisma.config.ts.prod ./prisma.config.ts
+COPY --chown=bun:bun --from=builder /app/dist ./
+COPY --chown=bun:bun --from=builder /app/packages/db/prisma ./packages/db/prisma
+COPY --chown=bun:bun --from=builder /app/prisma.config.ts.prod ./prisma.config.ts
 
 # Expose port (Bun Hono defaults to 3000)
 EXPOSE 3000

--- a/packages/workflow-core/src/bun-temporal-plugin.test.ts
+++ b/packages/workflow-core/src/bun-temporal-plugin.test.ts
@@ -3,7 +3,7 @@ import { temporalWorkflow } from './bun-temporal-plugin'
 import * as worker from '@temporalio/worker'
 
 vi.mock('@temporalio/worker', () => ({
-  bundleWorkflowCode: vi.fn().mockResolvedValue({ code: 'mock-code', sourceMap: '' })
+  bundleWorkflowCode: vi.fn().mockResolvedValue({ code: 'mock-code', sourceMap: '' }),
 }))
 
 describe('temporalWorkflow plugin', () => {
@@ -13,14 +13,14 @@ describe('temporalWorkflow plugin', () => {
 
   it('should register onLoad and configure webpackConfigHook with @temporalio/workflow alias', async () => {
     const plugin = temporalWorkflow()
-    
+
     let onLoadCallback: ((...args: unknown[]) => unknown) | null = null
 
     const mockBuild = {
       onResolve: vi.fn(),
       onLoad: vi.fn((opts, callback) => {
         onLoadCallback = callback
-      })
+      }),
     }
 
     // Run setup

--- a/packages/workflow-core/src/bun-temporal-plugin.ts
+++ b/packages/workflow-core/src/bun-temporal-plugin.ts
@@ -47,9 +47,7 @@ export function temporalWorkflow(options: TemporalWorkflowPluginOptions = {}): B
               ...config.resolve.alias,
               '@shumai/workflow-core':
                 require.resolve('@shumai/workflow-core/src/workflow-utils.ts'),
-              '@temporalio/workflow': dirname(
-                require.resolve('@temporalio/workflow/package.json'),
-              ),
+              '@temporalio/workflow': dirname(require.resolve('@temporalio/workflow/package.json')),
             }
             console.log('Webpack config aliases:', config.resolve.alias)
             if (originalHook) {


### PR DESCRIPTION
## Summary

Hardens the Docker image by running the runner stage as the unprivileged `bun` user rather than `root`. It also adds Python 3 and other utility packages required by the agents inside the container environment.

## Changes

- Modified `Dockerfile`'s runner stage to install system dependencies (`python3`, `make`, `man-db`, `curl`, `dnsutils`, `less`, `jq`, `bc`, `unzip`, `rsync`, `ripgrep`, `procps`, `lsof`, `socat`, `ca-certificates`, `bubblewrap`).
- Set up `/app` and `/app/data` with ownership set to the non-root `bun` user.
- Switched stage runner context to `USER bun` prior to installing node modules and copying built artifacts.
- Copied build artifacts using `--chown=bun:bun` to maintain correct permissions.

## Verification

- Verified that all workspace checks pass (`bun run lint`, `bun run format`, `bun run typecheck`, `bun run test`).
- Built the docker image locally: `docker build -t shumaione/shumai:latest -f Dockerfile .`
- Verified the docker container runs as `bun` and has python3 installed:
  - `docker run --rm shumaione/shumai:latest whoami` -> outputs `bun`
  - `docker run --rm shumaione/shumai:latest python3 --version` -> outputs `Python 3.13.5`

## Notes

None.
