### PR TITLE
feat(webui): implement virtualization for file list and grid views

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "shumai",
       "dependencies": {
+        "@tanstack/react-virtual": "^3.13.26",
         "jittered-fractional-indexing": "^1.0.1",
       },
       "devDependencies": {
@@ -223,6 +224,7 @@
         "@tanstack/react-query": "5.90.10",
         "@tanstack/react-router": "^1.136.8",
         "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-virtual": "^3.13.26",
         "better-auth": "^1.6.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1110,6 +1112,8 @@
 
     "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
 
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.26", "", { "dependencies": { "@tanstack/virtual-core": "3.16.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-DosdgjOxCLahkn0o+ilmZYwEjo1glfMGuRT/j3PQ18yr5XqA8N/BCaL9IJ3B5TRl+nnzyK2IOFgAILwzN3a9xQ=="],
+
     "@tanstack/router-cli": ["@tanstack/router-cli@1.167.12", "", { "dependencies": { "@tanstack/router-generator": "1.167.12", "chokidar": "^5.0.0", "yargs": "^17.7.2" }, "bin": { "tsr": "bin/tsr.cjs" } }, "sha512-7olQwX4Pyki8tsgc73iU2sK1ZhEtwTe8vYZn6qBfmH2FkrdzQ2kfbgO+4bBZEhckAFNwNqCklTZJYydCM3YuBA=="],
 
     "@tanstack/router-core": ["@tanstack/router-core@1.171.8", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-PbrTBbofFcacrH3RLgHYILRqTFnAGq+gXrXoA/vo7qUSkJpSO4GWfLtrtCahD4VayzRm19IPwcjPPLEugag6pw=="],
@@ -1123,6 +1127,8 @@
     "@tanstack/store": ["@tanstack/store@0.11.0", "", {}, "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw=="],
 
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.16.0", "", {}, "sha512-Er2N7q3WOiH6y2JLxsxNX+u2/sLqSsL0bxFgDjuiPiA7vKhZRm+IzcS17vRee3GNXr64UsesA5CAp9yTiIYw9A=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.162.0", "", {}, "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA=="],
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "vite-tsconfig-paths": "^6.1.1"
   },
   "dependencies": {
+    "@tanstack/react-virtual": "^3.13.26",
     "jittered-fractional-indexing": "^1.0.1"
   }
 }

--- a/packages/core/src/cache/lru-ttl-cache.test.ts
+++ b/packages/core/src/cache/lru-ttl-cache.test.ts
@@ -26,13 +26,13 @@ describe('LruTtlCache', () => {
     const cache = new LruTtlCache<string, string>(2)
     cache.set('key1', 'value1', 1000)
     cache.set('key2', 'value2', 1000)
-    
+
     // Access key1 to make it most recently used
     cache.get('key1')
-    
+
     // Add key3, which should evict key2 (the least recently used)
     cache.set('key3', 'value3', 1000)
-    
+
     expect(cache.get('key1')).toBe('value1')
     expect(cache.get('key2')).toBeUndefined()
     expect(cache.get('key3')).toBe('value3')
@@ -41,9 +41,9 @@ describe('LruTtlCache', () => {
   it('should return undefined for expired items', () => {
     const cache = new LruTtlCache<string, string>(10)
     cache.set('key1', 'value1', 1000)
-    
+
     vi.advanceTimersByTime(1001)
-    
+
     expect(cache.get('key1')).toBeUndefined()
     expect(cache.size).toBe(0)
   })
@@ -51,28 +51,28 @@ describe('LruTtlCache', () => {
   it('should proactively evict expired items on get', () => {
     const sampleSize = 5
     const cache = new LruTtlCache<string, string>(100, sampleSize)
-    
+
     // Set 10 items, all will expire
     for (let i = 0; i < 10; i++) {
       cache.set(`key${i}`, `value${i}`, 1000)
     }
-    
+
     // Add one item that stays valid
     cache.set('valid', 'validValue', 5000)
-    
+
     // Advance time so the 10 items expire
     vi.advanceTimersByTime(1001)
-    
+
     // Total size should still be 11 (lazy eviction)
     expect(cache.size).toBe(11)
-    
+
     // Call get on the valid item once. It should trigger one evictSample call.
     // evictSample will check 5 items.
     cache.get('valid')
-    
+
     // Size should now be 11 - 5 = 6
     expect(cache.size).toBe(6)
-    
+
     // Call get again, it should evict the remaining 5 expired items
     cache.get('valid')
     expect(cache.size).toBe(1)
@@ -82,23 +82,23 @@ describe('LruTtlCache', () => {
   it('should loop through the cache with proactive eviction', () => {
     // sampleSize = 3 to make sure we cover all items in one go or skip k3 correctly
     const cache = new LruTtlCache<string, string>(10, 3)
-    
+
     cache.set('k1', 'v1', 1000)
     cache.set('k2', 'v2', 1000)
     cache.set('k3', 'v3', 5000)
-    
+
     vi.advanceTimersByTime(1001)
-    
+
     // First get: evicts k1, k2. Checks k3 (not expired).
     cache.get('k3')
     expect(cache.size).toBe(1)
-    
+
     // Add more items
     cache.set('k4', 'v4', 1000)
     cache.set('k5', 'v5', 1000)
-    
+
     vi.advanceTimersByTime(1001)
-    
+
     // Second get: evicts k4, k5.
     cache.get('k3')
     expect(cache.size).toBe(1)
@@ -127,25 +127,25 @@ describe('LruTtlCache', () => {
     // This test addresses the user's specific request:
     // "add 100 keys to cache, do a evictSample, and remove 99 keys manually, and do evictSample again, see what happen"
     const cache = new LruTtlCache<number, number>(200, 10)
-    
+
     // Add 100 keys
     for (let i = 0; i < 100; i++) {
       cache.set(i, i, 10000)
     }
-    
+
     // Initial get to trigger evictSample and initialize the iterator
-    cache.get(999) 
-    
+    cache.get(999)
+
     // Remove 99 keys manually (leaving key 99)
     for (let i = 0; i < 99; i++) {
       cache.delete(i)
     }
     expect(cache.size).toBe(1)
-    
+
     // Advance time so the remaining key 99 would expire if it was checked
     vi.advanceTimersByTime(20000)
-    
-    // Call get. evictSample should run. 
+
+    // Call get. evictSample should run.
     // The iterator was pointing to something that was deleted.
     // It should proceed to the next available element (key 99) and evict it.
     cache.get(999)

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -15,7 +15,6 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import { Download } from 'lucide-react'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useInView } from 'react-intersection-observer'
 import { toast } from 'sonner'
 import type { DragState } from '../dnd-types'
 import { MoveCopyDialog } from '../move-copy-dialog'
@@ -419,21 +418,6 @@ export function FileBrowser({
 
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
-  const { ref: foldersRef, inView: foldersInView } = useInView()
-  const { ref: filesRef, inView: filesInView } = useInView()
-
-  useEffect(() => {
-    if (foldersInView && hasNextFoldersPage && !isFetchingNextFoldersPage) {
-      fetchNextFoldersPage()
-    }
-  }, [foldersInView, hasNextFoldersPage, isFetchingNextFoldersPage, fetchNextFoldersPage])
-
-  useEffect(() => {
-    if (filesInView && hasNextFilesPage && !isFetchingNextFilesPage) {
-      fetchNextFilesPage()
-    }
-  }, [filesInView, hasNextFilesPage, isFetchingNextFilesPage, fetchNextFilesPage])
-
   const foldersSize = folders.reduce((acc, f) => acc + (f.sizeByte || 0), 0)
   const filesSize = displayedFiles.reduce((acc, f) => acc + (f.sizeByte || 0), 0)
 
@@ -821,10 +805,10 @@ export function FileBrowser({
                   setFoldersExpanded={setFoldersExpanded}
                   filesExpanded={filesExpanded}
                   setFilesExpanded={setFilesExpanded}
-                  foldersRef={foldersRef}
-                  filesRef={filesRef}
                   hasNextFoldersPage={hasNextFoldersPage}
                   hasNextFilesPage={hasNextFilesPage}
+                  fetchNextFoldersPage={fetchNextFoldersPage}
+                  fetchNextFilesPage={fetchNextFilesPage}
                   formatCount={formatCount}
                   formatSize={formatSize}
                   foldersSize={foldersSize}
@@ -832,6 +816,7 @@ export function FileBrowser({
                   handleEmptyAreaClick={handleEmptyAreaClick}
                   dragState={dragState}
                   sort={sort}
+                  scrollContainerRef={scrollContainerRef}
                 />
               ) : (
                 <FileBrowserGridView
@@ -844,10 +829,10 @@ export function FileBrowser({
                   setFoldersExpanded={setFoldersExpanded}
                   filesExpanded={filesExpanded}
                   setFilesExpanded={setFilesExpanded}
-                  foldersRef={foldersRef}
-                  filesRef={filesRef}
                   hasNextFoldersPage={hasNextFoldersPage}
                   hasNextFilesPage={hasNextFilesPage}
+                  fetchNextFoldersPage={fetchNextFoldersPage}
+                  fetchNextFilesPage={fetchNextFilesPage}
                   formatCount={formatCount}
                   formatSize={formatSize}
                   foldersSize={foldersSize}
@@ -855,6 +840,7 @@ export function FileBrowser({
                   handleEmptyAreaClick={handleEmptyAreaClick}
                   dragState={dragState}
                   sort={sort}
+                  scrollContainerRef={scrollContainerRef}
                 />
               )}
 

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -807,6 +807,8 @@ export function FileBrowser({
                   setFilesExpanded={setFilesExpanded}
                   hasNextFoldersPage={hasNextFoldersPage}
                   hasNextFilesPage={hasNextFilesPage}
+                  isFetchingNextFoldersPage={isFetchingNextFoldersPage}
+                  isFetchingNextFilesPage={isFetchingNextFilesPage}
                   fetchNextFoldersPage={fetchNextFoldersPage}
                   fetchNextFilesPage={fetchNextFilesPage}
                   formatCount={formatCount}
@@ -831,6 +833,8 @@ export function FileBrowser({
                   setFilesExpanded={setFilesExpanded}
                   hasNextFoldersPage={hasNextFoldersPage}
                   hasNextFilesPage={hasNextFilesPage}
+                  isFetchingNextFoldersPage={isFetchingNextFoldersPage}
+                  isFetchingNextFilesPage={isFetchingNextFilesPage}
                   fetchNextFoldersPage={fetchNextFoldersPage}
                   fetchNextFilesPage={fetchNextFilesPage}
                   formatCount={formatCount}

--- a/packages/webui/components/file-browser/file-list-item.tsx
+++ b/packages/webui/components/file-browser/file-list-item.tsx
@@ -163,7 +163,7 @@ export function FileListItem({
   }
 
   return (
-    <tr
+    <div
       ref={setDraggableRef}
       style={{ opacity }}
       onClick={handleClick}
@@ -174,11 +174,11 @@ export function FileListItem({
           e.preventDefault()
         }
       }}
-      className="group cursor-pointer select-none transition-colors whitespace-nowrap"
+      className="group cursor-pointer select-none transition-colors whitespace-nowrap flex w-full"
     >
-      <td
+      <div
         className={cn(
-          'px-4 py-2 sticky left-0 z-10 transition-colors border-r',
+          'px-4 py-2 sticky left-0 z-10 transition-colors border-r shrink-0',
           isSelected ? 'bg-muted' : 'bg-card group-hover:bg-muted',
         )}
         style={{
@@ -232,24 +232,24 @@ export function FileListItem({
             </Badge>
           )}
         </div>
-      </td>
-      <td
-        className="px-4 py-2 text-sm text-muted-foreground truncate"
+      </div>
+      <div
+        className="px-4 py-2 text-sm text-muted-foreground truncate border-r shrink-0 flex items-center"
         style={{
           width: columnSizing?.['size'] || 100,
           minWidth: columnSizing?.['size'] || 100,
         }}
       >
         {displayItem.type === 'folder' ? '-' : formatSize(displayItem.sizeByte)}
-      </td>
-      <td
-        className="px-4 py-2"
+      </div>
+      <div
+        className="px-4 py-2 border-r shrink-0 flex items-center"
         style={{
           width: columnSizing?.['modified'] || 200,
           minWidth: columnSizing?.['modified'] || 200,
         }}
       >
-        <div className="flex items-center justify-between overflow-hidden">
+        <div className="flex items-center justify-between overflow-hidden w-full">
           <span className="text-sm text-muted-foreground truncate">
             {formatDate(displayItem.updatedAt)}
           </span>
@@ -270,12 +270,12 @@ export function FileListItem({
             <MoreVertical className="h-4 w-4 text-muted-foreground hover:text-foreground" />
           </button>
         </div>
-      </td>
+      </div>
       {displayItem.type === 'file' &&
         fields.map((field) => (
-          <td
+          <div
             key={field.id}
-            className="px-4 py-2 truncate"
+            className="px-4 py-2 truncate border-r shrink-0 flex items-center"
             style={{
               width: columnSizing?.[field.id!] || 150,
               minWidth: columnSizing?.[field.id!] || 150,
@@ -287,8 +287,8 @@ export function FileListItem({
               onSave={canEdit ? (val) => onSaveField(field.id!, val) : undefined}
               readOnly={field.readOnly || !canEdit}
             />
-          </td>
+          </div>
         ))}
-    </tr>
+    </div>
   )
 }

--- a/packages/webui/components/file-browser/grid-view.tsx
+++ b/packages/webui/components/file-browser/grid-view.tsx
@@ -176,23 +176,21 @@ export function FileBrowserGridView({
     for (const virtualItem of virtualItems) {
       const row = rows[virtualItem.index]
       if (row?.type === 'row') {
-        if (row.kind === 'folder') {
-          const lastIndex = (row.rowIndex + 1) * cols
-          if (
-            lastIndex >= folders.length - cols * 2 &&
-            hasNextFoldersPage &&
-            !isFetchingNextFoldersPage
-          ) {
+        const isFolder = row.kind === 'folder'
+        const dataList = isFolder ? folders : files
+        const startIndex = row.rowIndex * cols
+        const isSkeleton = !dataList[startIndex] // Check if the first item in row is loaded
+        const isNearEnd = startIndex >= dataList.length - cols * 3
+
+        if (isFolder && hasNextFoldersPage && !isFetchingNextFoldersPage) {
+          if (isSkeleton || isNearEnd) {
             fetchNextFoldersPage()
+            break
           }
-        } else if (row.kind === 'file') {
-          const lastIndex = (row.rowIndex + 1) * cols
-          if (
-            lastIndex >= files.length - cols * 2 &&
-            hasNextFilesPage &&
-            !isFetchingNextFilesPage
-          ) {
+        } else if (!isFolder && hasNextFilesPage && !isFetchingNextFilesPage) {
+          if (isSkeleton || isNearEnd) {
             fetchNextFilesPage()
+            break
           }
         }
       }

--- a/packages/webui/components/file-browser/grid-view.tsx
+++ b/packages/webui/components/file-browser/grid-view.tsx
@@ -219,6 +219,7 @@ export function FileBrowserGridView({
               <div
                 key={`header-${row.kind}`}
                 ref={rowVirtualizer.measureElement}
+                data-index={virtualRow.index}
                 className="absolute top-0 left-0 w-full z-10 bg-background"
                 style={{
                   transform: `translateY(${virtualRow.start}px)`,
@@ -256,6 +257,7 @@ export function FileBrowserGridView({
             <div
               key={`row-${row.kind}-${row.rowIndex}`}
               ref={rowVirtualizer.measureElement}
+              data-index={virtualRow.index}
               className="absolute top-0 left-0 w-full grid gap-4"
               style={{
                 transform: `translateY(${virtualRow.start}px)`,

--- a/packages/webui/components/file-browser/grid-view.tsx
+++ b/packages/webui/components/file-browser/grid-view.tsx
@@ -73,6 +73,8 @@ interface FileBrowserGridViewProps {
   setFilesExpanded: (expanded: boolean) => void
   hasNextFoldersPage: boolean
   hasNextFilesPage: boolean
+  isFetchingNextFoldersPage: boolean
+  isFetchingNextFilesPage: boolean
   fetchNextFoldersPage: () => void
   fetchNextFilesPage: () => void
   formatCount: (count: number, isFile: boolean) => string
@@ -97,6 +99,8 @@ export function FileBrowserGridView({
   setFilesExpanded,
   hasNextFoldersPage,
   hasNextFilesPage,
+  isFetchingNextFoldersPage,
+  isFetchingNextFilesPage,
   fetchNextFoldersPage,
   fetchNextFilesPage,
   formatCount,
@@ -169,19 +173,27 @@ export function FileBrowserGridView({
   useEffect(() => {
     if (virtualItems.length === 0) return
 
-    const lastItem = virtualItems[virtualItems.length - 1]
-    const row = rows[lastItem.index]
-
-    if (row.type === 'row') {
-      if (row.kind === 'folder') {
-        const lastIndex = (row.rowIndex + 1) * cols
-        if (lastIndex >= folders.length - cols * 2 && hasNextFoldersPage) {
-          fetchNextFoldersPage()
-        }
-      } else if (row.kind === 'file') {
-        const lastIndex = (row.rowIndex + 1) * cols
-        if (lastIndex >= files.length - cols * 2 && hasNextFilesPage) {
-          fetchNextFilesPage()
+    for (const virtualItem of virtualItems) {
+      const row = rows[virtualItem.index]
+      if (row?.type === 'row') {
+        if (row.kind === 'folder') {
+          const lastIndex = (row.rowIndex + 1) * cols
+          if (
+            lastIndex >= folders.length - cols * 2 &&
+            hasNextFoldersPage &&
+            !isFetchingNextFoldersPage
+          ) {
+            fetchNextFoldersPage()
+          }
+        } else if (row.kind === 'file') {
+          const lastIndex = (row.rowIndex + 1) * cols
+          if (
+            lastIndex >= files.length - cols * 2 &&
+            hasNextFilesPage &&
+            !isFetchingNextFilesPage
+          ) {
+            fetchNextFilesPage()
+          }
         }
       }
     }
@@ -192,6 +204,8 @@ export function FileBrowserGridView({
     files.length,
     hasNextFoldersPage,
     hasNextFilesPage,
+    isFetchingNextFoldersPage,
+    isFetchingNextFilesPage,
     fetchNextFoldersPage,
     fetchNextFilesPage,
     cols,

--- a/packages/webui/components/file-browser/grid-view.tsx
+++ b/packages/webui/components/file-browser/grid-view.tsx
@@ -3,8 +3,9 @@
 import type { AssetInfo } from '@shumai/dtos'
 import type { SearchSort } from '@shumai/dtos'
 import { useDroppable } from '@dnd-kit/react'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import { ChevronDown, ChevronRight } from 'lucide-react'
-import React from 'react'
+import React, { useMemo, useState, useEffect, useRef } from 'react'
 import { cn } from '../../lib/utils'
 import type { DragState } from '../dnd-types'
 
@@ -47,13 +48,6 @@ function ReorderIndicator({
       className={cn(
         'absolute top-0 bottom-0 w-4 flex-shrink-0 flex items-center justify-center pointer-events-auto z-50',
         position === 'before' ? '-left-2 -translate-x-1/2' : '-right-2 translate-x-1/2',
-        position === 'before' && [
-          'hidden',
-          'max-md:[.group-reorder:nth-child(2n+1)_&]:flex',
-          'md:max-lg:[.group-reorder:nth-child(3n+1)_&]:flex',
-          'lg:max-xl:[.group-reorder:nth-child(4n+1)_&]:flex',
-          'xl:[.group-reorder:nth-child(5n+1)_&]:flex',
-        ],
         className,
       )}
     >
@@ -77,10 +71,10 @@ interface FileBrowserGridViewProps {
   setFoldersExpanded: (expanded: boolean) => void
   filesExpanded: boolean
   setFilesExpanded: (expanded: boolean) => void
-  foldersRef: (node?: Element | null) => void
-  filesRef: (node?: Element | null) => void
   hasNextFoldersPage: boolean
   hasNextFilesPage: boolean
+  fetchNextFoldersPage: () => void
+  fetchNextFilesPage: () => void
   formatCount: (count: number, isFile: boolean) => string
   formatSize: (bytes: number) => string
   foldersSize: number
@@ -88,6 +82,7 @@ interface FileBrowserGridViewProps {
   handleEmptyAreaClick: (e: React.MouseEvent) => void
   dragState?: DragState
   sort?: SearchSort
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>
 }
 
 export function FileBrowserGridView({
@@ -100,10 +95,10 @@ export function FileBrowserGridView({
   setFoldersExpanded,
   filesExpanded,
   setFilesExpanded,
-  foldersRef,
-  filesRef,
   hasNextFoldersPage,
   hasNextFilesPage,
+  fetchNextFoldersPage,
+  fetchNextFilesPage,
   formatCount,
   formatSize,
   foldersSize,
@@ -111,78 +106,183 @@ export function FileBrowserGridView({
   handleEmptyAreaClick,
   dragState,
   sort,
+  scrollContainerRef,
 }: FileBrowserGridViewProps) {
-  return (
-    <div className="flex-1 p-4" onClick={handleEmptyAreaClick}>
-      {folders.length > 0 && (
-        <div className="mb-8">
-          <button
-            onClick={() => setFoldersExpanded(!foldersExpanded)}
-            className="mb-3 flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
-          >
-            {foldersExpanded ? (
-              <ChevronDown className="h-4 w-4" />
-            ) : (
-              <ChevronRight className="h-4 w-4" />
-            )}
-            <span>
-              {formatCount(totalFolders ?? folders.length, false)} • {formatSize(foldersSize)}
-            </span>
-          </button>
-          {foldersExpanded && (
-            <>
-              <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
-                {folders.map((item, index) => (
-                  <div key={item.id} className="group-reorder relative flex">
-                    <ReorderIndicator
-                      id={`reorder-before-folder-${item.id}`}
-                      item={item}
-                      position="before"
-                      active={sort?.field === 'custom'}
-                      dragState={dragState}
-                    />
-                    <div className="flex-1 min-w-0">{renderItem(item)}</div>
-                    <ReorderIndicator
-                      id={`reorder-after-folder-${item.id}`}
-                      item={item}
-                      position="after"
-                      active={sort?.field === 'custom'}
-                      dragState={dragState}
-                      isNextItemDragging={
-                        folders[index + 1] && dragState?.draggedIds.has(folders[index + 1].id!)
-                      }
-                    />
-                  </div>
-                ))}
-              </div>
-              {hasNextFoldersPage && <div ref={foldersRef} className="h-1" />}
-            </>
-          )}
-        </div>
-      )}
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [cols, setCols] = useState(5)
 
-      {files.length > 0 && (
-        <div>
-          <button
-            onClick={() => setFilesExpanded(!filesExpanded)}
-            className="mb-3 flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
-          >
-            {filesExpanded ? (
-              <ChevronDown className="h-4 w-4" />
-            ) : (
-              <ChevronRight className="h-4 w-4" />
-            )}
-            <span>
-              {formatCount(totalFiles ?? files.length, true)} • {formatSize(filesSize)}
-            </span>
-          </button>
-          {filesExpanded && (
-            <>
-              <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
-                {files.map((item, index) => (
+  useEffect(() => {
+    const updateCols = () => {
+      if (!containerRef.current) return
+      const width = containerRef.current.offsetWidth
+      if (width < 640) setCols(2)
+      else if (width < 768) setCols(2)
+      else if (width < 1024) setCols(3)
+      else if (width < 1280) setCols(4)
+      else setCols(5)
+    }
+
+    updateCols()
+    const observer = new ResizeObserver(updateCols)
+    if (containerRef.current) observer.observe(containerRef.current)
+    return () => observer.disconnect()
+  }, [])
+
+  const rows = useMemo(() => {
+    const list: (
+      | { type: 'header'; kind: 'folder' | 'file' }
+      | { type: 'row'; kind: 'folder' | 'file'; rowIndex: number }
+    )[] = []
+
+    // Folders
+    list.push({ type: 'header', kind: 'folder' })
+    if (foldersExpanded) {
+      const count = totalFolders ?? folders.length
+      const rowCount = Math.ceil(count / cols)
+      for (let i = 0; i < rowCount; i++) {
+        list.push({ type: 'row', kind: 'folder', rowIndex: i })
+      }
+    }
+
+    // Files
+    list.push({ type: 'header', kind: 'file' })
+    if (filesExpanded) {
+      const count = totalFiles ?? files.length
+      const rowCount = Math.ceil(count / cols)
+      for (let i = 0; i < rowCount; i++) {
+        list.push({ type: 'row', kind: 'file', rowIndex: i })
+      }
+    }
+
+    return list
+  }, [foldersExpanded, filesExpanded, folders.length, files.length, totalFolders, totalFiles, cols])
+
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: (index) => (rows[index]?.type === 'header' ? 40 : 200),
+    overscan: 5,
+  })
+
+  const virtualItems = rowVirtualizer.getVirtualItems()
+
+  useEffect(() => {
+    if (virtualItems.length === 0) return
+
+    const lastItem = virtualItems[virtualItems.length - 1]
+    const row = rows[lastItem.index]
+
+    if (row.type === 'row') {
+      if (row.kind === 'folder') {
+        const lastIndex = (row.rowIndex + 1) * cols
+        if (lastIndex >= folders.length - cols * 2 && hasNextFoldersPage) {
+          fetchNextFoldersPage()
+        }
+      } else if (row.kind === 'file') {
+        const lastIndex = (row.rowIndex + 1) * cols
+        if (lastIndex >= files.length - cols * 2 && hasNextFilesPage) {
+          fetchNextFilesPage()
+        }
+      }
+    }
+  }, [
+    virtualItems,
+    rows,
+    folders.length,
+    files.length,
+    hasNextFoldersPage,
+    hasNextFilesPage,
+    fetchNextFoldersPage,
+    fetchNextFilesPage,
+    cols,
+  ])
+
+  return (
+    <div ref={containerRef} className="flex-1 p-4 relative" onClick={handleEmptyAreaClick}>
+      <div
+        className="relative w-full"
+        style={{
+          height: `${rowVirtualizer.getTotalSize()}px`,
+        }}
+      >
+        {virtualItems.map((virtualRow) => {
+          const row = rows[virtualRow.index]
+
+          if (row.type === 'header') {
+            const isFolder = row.kind === 'folder'
+            const count = isFolder ? (totalFolders ?? folders.length) : (totalFiles ?? files.length)
+            const size = isFolder ? foldersSize : filesSize
+            const expanded = isFolder ? foldersExpanded : filesExpanded
+            const setExpanded = isFolder ? setFoldersExpanded : setFilesExpanded
+
+            return (
+              <div
+                key={`header-${row.kind}`}
+                ref={rowVirtualizer.measureElement}
+                className="absolute top-0 left-0 w-full z-10 bg-background"
+                style={{
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              >
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setExpanded(!expanded)
+                  }}
+                  className="mb-3 flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+                >
+                  {expanded ? (
+                    <ChevronDown className="h-4 w-4" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4" />
+                  )}
+                  <span>
+                    {formatCount(count, !isFolder)} • {formatSize(size)}
+                  </span>
+                </button>
+              </div>
+            )
+          }
+
+          const isFolder = row.kind === 'folder'
+          const dataList = isFolder ? folders : files
+          const startIndex = row.rowIndex * cols
+          const rowItems = []
+          for (let i = 0; i < cols; i++) {
+            rowItems.push(dataList[startIndex + i])
+          }
+
+          return (
+            <div
+              key={`row-${row.kind}-${row.rowIndex}`}
+              ref={rowVirtualizer.measureElement}
+              className="absolute top-0 left-0 w-full grid gap-4"
+              style={{
+                transform: `translateY(${virtualRow.start}px)`,
+                gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+              }}
+            >
+              {rowItems.map((item, i) => {
+                const itemIndex = startIndex + i
+                if (!item) {
+                  const totalCount = isFolder
+                    ? (totalFolders ?? folders.length)
+                    : (totalFiles ?? files.length)
+                  if (itemIndex < totalCount) {
+                    return (
+                      <div
+                        key={`skeleton-${itemIndex}`}
+                        className="aspect-square bg-muted animate-pulse rounded-lg"
+                      />
+                    )
+                  }
+                  return <div key={`empty-${itemIndex}`} />
+                }
+
+                return (
                   <div key={item.id} className="group-reorder relative flex">
                     <ReorderIndicator
-                      id={`reorder-before-file-${item.id}`}
+                      id={`reorder-before-${row.kind}-${item.id}`}
                       item={item}
                       position="before"
                       active={sort?.field === 'custom'}
@@ -190,23 +290,23 @@ export function FileBrowserGridView({
                     />
                     <div className="flex-1 min-w-0">{renderItem(item)}</div>
                     <ReorderIndicator
-                      id={`reorder-after-file-${item.id}`}
+                      id={`reorder-after-${row.kind}-${item.id}`}
                       item={item}
                       position="after"
                       active={sort?.field === 'custom'}
                       dragState={dragState}
                       isNextItemDragging={
-                        files[index + 1] && dragState?.draggedIds.has(files[index + 1].id!)
+                        dataList[itemIndex + 1] &&
+                        dragState?.draggedIds.has(dataList[itemIndex + 1].id!)
                       }
                     />
                   </div>
-                ))}
-              </div>
-              {hasNextFilesPage && <div ref={filesRef} className="h-1" />}
-            </>
-          )}
-        </div>
-      )}
+                )
+              })}
+            </div>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -131,6 +131,8 @@ interface FileBrowserListViewProps {
   setFilesExpanded: (expanded: boolean) => void
   hasNextFoldersPage: boolean
   hasNextFilesPage: boolean
+  isFetchingNextFoldersPage: boolean
+  isFetchingNextFilesPage: boolean
   fetchNextFoldersPage: () => void
   fetchNextFilesPage: () => void
   formatCount: (count: number, isFile: boolean) => string
@@ -158,6 +160,8 @@ export function FileBrowserListView({
   setFilesExpanded,
   hasNextFoldersPage,
   hasNextFilesPage,
+  isFetchingNextFoldersPage,
+  isFetchingNextFilesPage,
   fetchNextFoldersPage,
   fetchNextFilesPage,
   formatCount,
@@ -255,14 +259,24 @@ export function FileBrowserListView({
   useEffect(() => {
     if (virtualItems.length === 0) return
 
-    const lastItem = virtualItems[virtualItems.length - 1]
-    const item = items[lastItem.index]
-
-    if (item.type === 'item') {
-      if (item.kind === 'folder' && item.index >= folders.length - 5 && hasNextFoldersPage) {
-        fetchNextFoldersPage()
-      } else if (item.kind === 'file' && item.index >= files.length - 5 && hasNextFilesPage) {
-        fetchNextFilesPage()
+    for (const virtualItem of virtualItems) {
+      const item = items[virtualItem.index]
+      if (item?.type === 'item') {
+        if (
+          item.kind === 'folder' &&
+          item.index >= folders.length - 10 &&
+          hasNextFoldersPage &&
+          !isFetchingNextFoldersPage
+        ) {
+          fetchNextFoldersPage()
+        } else if (
+          item.kind === 'file' &&
+          item.index >= files.length - 10 &&
+          hasNextFilesPage &&
+          !isFetchingNextFilesPage
+        ) {
+          fetchNextFilesPage()
+        }
       }
     }
   }, [
@@ -272,6 +286,8 @@ export function FileBrowserListView({
     files.length,
     hasNextFoldersPage,
     hasNextFilesPage,
+    isFetchingNextFoldersPage,
+    isFetchingNextFilesPage,
     fetchNextFoldersPage,
     fetchNextFilesPage,
   ])

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -262,20 +262,22 @@ export function FileBrowserListView({
     for (const virtualItem of virtualItems) {
       const item = items[virtualItem.index]
       if (item?.type === 'item') {
-        if (
-          item.kind === 'folder' &&
-          item.index >= folders.length - 10 &&
-          hasNextFoldersPage &&
-          !isFetchingNextFoldersPage
-        ) {
-          fetchNextFoldersPage()
-        } else if (
-          item.kind === 'file' &&
-          item.index >= files.length - 10 &&
-          hasNextFilesPage &&
-          !isFetchingNextFilesPage
-        ) {
-          fetchNextFilesPage()
+        const isSkeleton = item.kind === 'folder' ? !folders[item.index] : !files[item.index]
+        const isNearEnd =
+          item.kind === 'folder'
+            ? item.index >= folders.length - 15
+            : item.index >= files.length - 15
+
+        if (item.kind === 'folder' && hasNextFoldersPage && !isFetchingNextFoldersPage) {
+          if (isSkeleton || isNearEnd) {
+            fetchNextFoldersPage()
+            break
+          }
+        } else if (item.kind === 'file' && hasNextFilesPage && !isFetchingNextFilesPage) {
+          if (isSkeleton || isNearEnd) {
+            fetchNextFilesPage()
+            break
+          }
         }
       }
     }

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -5,8 +5,9 @@ import type { FieldInfo } from '@shumai/dtos'
 import type { SearchSort } from '@shumai/dtos'
 import { useDroppable } from '@dnd-kit/react'
 import { flexRender, getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import { ChevronDown, ChevronRight } from 'lucide-react'
-import React, { useMemo, useState } from 'react'
+import React, { useMemo, useState, useEffect } from 'react'
 import { cn } from '../../lib/utils'
 import type { DragState } from '../dnd-types'
 import { Checkbox } from '../ui/checkbox'
@@ -18,9 +19,20 @@ interface ListRowProps {
   dragState?: DragState
   isSelected?: boolean
   columnSizing?: Record<string, number>
+  virtualRow: { start: number; index: number }
+  measureElement: (el: HTMLElement | null) => void
 }
 
-function ListRow({ item, renderItem, active, dragState, isSelected, columnSizing }: ListRowProps) {
+function ListRow({
+  item,
+  renderItem,
+  active,
+  dragState,
+  isSelected,
+  columnSizing,
+  virtualRow,
+  measureElement,
+}: ListRowProps) {
   const isDraggingItem = dragState?.draggedIds.has(item.id!)
   const isDraggingAny = dragState?.isActive
 
@@ -72,30 +84,32 @@ function ListRow({ item, renderItem, active, dragState, isSelected, columnSizing
   const showDropFeedback = isRowOver && isValidDropTarget
 
   return (
-    <tbody
-      ref={setRowRef}
+    <div
+      ref={(node) => {
+        setRowRef(node)
+        measureElement(node)
+      }}
       className={cn(
-        'group border-b border-border transition-colors hover:bg-primary/20 relative',
+        'group border-b border-border transition-colors hover:bg-primary/20 absolute top-0 left-0 w-full flex flex-col',
         isSelected && 'bg-primary/10',
         showDropFeedback && 'bg-primary/10',
         isTopOver && 'border-t-2 border-t-primary',
         isBottomOver && 'border-b-2 border-b-primary',
       )}
+      style={{
+        transform: `translateY(${virtualRow.start}px)`,
+      }}
     >
-      <tr
+      <div
         ref={setTopRef}
-        className="p-0 m-0 leading-none bg-transparent pointer-events-auto h-[2px]"
-      >
-        <td colSpan={100} className="p-0 m-0 border-0" />
-      </tr>
+        className="p-0 m-0 leading-none bg-transparent pointer-events-auto h-[2px] w-full"
+      />
       {renderItem(item, columnSizing)}
-      <tr
+      <div
         ref={setBottomRef}
-        className="p-0 m-0 leading-none bg-transparent pointer-events-auto h-[2px]"
-      >
-        <td colSpan={100} className="p-0 m-0 border-0" />
-      </tr>
-    </tbody>
+        className="p-0 m-0 leading-none bg-transparent pointer-events-auto h-[2px] w-full"
+      />
+    </div>
   )
 }
 
@@ -114,10 +128,10 @@ interface FileBrowserListViewProps {
   setFoldersExpanded: (expanded: boolean) => void
   filesExpanded: boolean
   setFilesExpanded: (expanded: boolean) => void
-  foldersRef: (node?: Element | null) => void
-  filesRef: (node?: Element | null) => void
   hasNextFoldersPage: boolean
   hasNextFilesPage: boolean
+  fetchNextFoldersPage: () => void
+  fetchNextFilesPage: () => void
   formatCount: (count: number, isFile: boolean) => string
   formatSize: (bytes: number) => string
   foldersSize: number
@@ -125,6 +139,7 @@ interface FileBrowserListViewProps {
   handleEmptyAreaClick: (e: React.MouseEvent) => void
   dragState?: DragState
   sort?: SearchSort
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>
 }
 
 export function FileBrowserListView({
@@ -140,10 +155,10 @@ export function FileBrowserListView({
   setFoldersExpanded,
   filesExpanded,
   setFilesExpanded,
-  foldersRef,
-  filesRef,
   hasNextFoldersPage,
   hasNextFilesPage,
+  fetchNextFoldersPage,
+  fetchNextFilesPage,
   formatCount,
   formatSize,
   foldersSize,
@@ -151,6 +166,7 @@ export function FileBrowserListView({
   handleEmptyAreaClick,
   dragState,
   sort,
+  scrollContainerRef,
 }: FileBrowserListViewProps) {
   const [columnSizing, setColumnSizing] = useState<Record<string, number>>({})
 
@@ -199,24 +215,83 @@ export function FileBrowserListView({
     onColumnSizingChange: setColumnSizing,
   })
 
+  const items = useMemo(() => {
+    const list: (
+      | { type: 'header'; kind: 'folder' | 'file' }
+      | { type: 'item'; kind: 'folder' | 'file'; index: number }
+    )[] = []
+
+    // Folders section
+    list.push({ type: 'header', kind: 'folder' })
+    if (foldersExpanded) {
+      const count = totalFolders ?? folders.length
+      for (let i = 0; i < count; i++) {
+        list.push({ type: 'item', kind: 'folder', index: i })
+      }
+    }
+
+    // Files section
+    list.push({ type: 'header', kind: 'file' })
+    if (filesExpanded) {
+      const count = totalFiles ?? files.length
+      for (let i = 0; i < count; i++) {
+        list.push({ type: 'item', kind: 'file', index: i })
+      }
+    }
+
+    return list
+  }, [foldersExpanded, filesExpanded, folders.length, files.length, totalFolders, totalFiles])
+
+  const rowVirtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => 40,
+    overscan: 10,
+  })
+
+  const virtualItems = rowVirtualizer.getVirtualItems()
+
+  useEffect(() => {
+    if (virtualItems.length === 0) return
+
+    const lastItem = virtualItems[virtualItems.length - 1]
+    const item = items[lastItem.index]
+
+    if (item.type === 'item') {
+      if (item.kind === 'folder' && item.index >= folders.length - 5 && hasNextFoldersPage) {
+        fetchNextFoldersPage()
+      } else if (item.kind === 'file' && item.index >= files.length - 5 && hasNextFilesPage) {
+        fetchNextFilesPage()
+      }
+    }
+  }, [
+    virtualItems,
+    items,
+    folders.length,
+    files.length,
+    hasNextFoldersPage,
+    hasNextFilesPage,
+    fetchNextFoldersPage,
+    fetchNextFilesPage,
+  ])
+
   return (
     <div className="flex-1 overflow-x-auto" onClick={handleEmptyAreaClick}>
-      <table
-        className="w-full border-collapse"
+      <div
+        className="w-full relative"
         style={{
-          tableLayout: 'fixed',
           width: table.getTotalSize(),
           minWidth: '100%',
         }}
       >
-        <thead className="sticky top-0 z-30 bg-background border-b border-border">
+        <div className="sticky top-0 z-30 bg-background border-b border-border flex flex-col">
           {table.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id} className="bg-muted/50 whitespace-nowrap">
+            <div key={headerGroup.id} className="bg-muted/50 whitespace-nowrap flex">
               {headerGroup.headers.map((header) => (
-                <th
+                <div
                   key={header.id}
                   className={cn(
-                    'px-4 py-2 text-left text-xs font-medium text-muted-foreground relative border-r',
+                    'px-4 py-2 text-left text-xs font-medium text-muted-foreground relative border-r flex items-center',
                     header.id === 'name' && 'sticky left-0 z-40 bg-muted',
                   )}
                   style={{
@@ -234,32 +309,58 @@ export function FileBrowserListView({
                       header.column.getIsResizing() && 'bg-primary w-1',
                     )}
                   />
-                </th>
+                </div>
               ))}
-            </tr>
+            </div>
           ))}
-        </thead>
+        </div>
 
-        {folders.length > 0 && (
-          <>
-            <tbody className="bg-card">
-              <tr
-                className="border-b border-border hover:bg-muted/50 transition-colors cursor-pointer group"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  setFoldersExpanded(!foldersExpanded)
-                }}
-              >
-                <td
-                  className="px-4 py-2 sticky left-0 z-10 bg-card border-r"
+        <div
+          className="relative"
+          style={{
+            height: `${rowVirtualizer.getTotalSize()}px`,
+          }}
+        >
+          {virtualItems.map((virtualRow) => {
+            const item = items[virtualRow.index]
+
+            if (item.type === 'header') {
+              const isFolder = item.kind === 'folder'
+              const count = isFolder
+                ? (totalFolders ?? folders.length)
+                : (totalFiles ?? files.length)
+              const size = isFolder ? foldersSize : filesSize
+              const expanded = isFolder ? foldersExpanded : filesExpanded
+              const setExpanded = isFolder ? setFoldersExpanded : setFilesExpanded
+              const hasItems = isFolder ? folders.length > 0 : files.length > 0
+
+              return (
+                <div
+                  key={`header-${item.kind}`}
+                  ref={rowVirtualizer.measureElement}
+                  className="absolute top-0 left-0 w-full border-b border-border hover:bg-muted/50 transition-colors cursor-pointer group flex bg-card z-20"
                   style={{
-                    width: columnSizing?.['name'] || 300,
-                    minWidth: columnSizing?.['name'] || 300,
+                    transform: `translateY(${virtualRow.start}px)`,
+                  }}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setExpanded(!expanded)
                   }}
                 >
-                  <div className="flex items-center gap-2">
+                  <div
+                    className="px-4 py-2 sticky left-0 z-10 bg-card border-r flex items-center gap-2"
+                    style={{
+                      width: columnSizing?.['name'] || 300,
+                      minWidth: columnSizing?.['name'] || 300,
+                    }}
+                  >
                     <Checkbox
-                      checked={folders.length > 0 && folders.every((f) => selectedIds.has(f.id!))}
+                      checked={
+                        hasItems &&
+                        (isFolder
+                          ? folders.every((f) => selectedIds.has(f.id!))
+                          : files.every((f) => selectedIds.has(f.id!)))
+                      }
                       onCheckedChange={() => {
                         // Batch selection logic
                       }}
@@ -267,110 +368,54 @@ export function FileBrowserListView({
                       className="h-4 w-4"
                     />
                     <div className="p-1 rounded hover:bg-muted">
-                      {foldersExpanded ? (
+                      {expanded ? (
                         <ChevronDown className="h-4 w-4 text-muted-foreground" />
                       ) : (
                         <ChevronRight className="h-4 w-4 text-muted-foreground" />
                       )}
                     </div>
                     <span className="text-sm font-medium text-muted-foreground whitespace-nowrap">
-                      {formatCount(totalFolders ?? folders.length, false)} •{' '}
-                      {formatSize(foldersSize)}
+                      {formatCount(count, !isFolder)} • {formatSize(size)}
                     </span>
                   </div>
-                </td>
-                <td colSpan={columns.length - 1} className="bg-card" />
-              </tr>
-            </tbody>
-            {foldersExpanded &&
-              folders.map((item) => (
-                <ListRow
-                  key={item.id}
-                  item={item}
-                  renderItem={renderItem}
-                  active={sort?.field === 'custom'}
-                  dragState={dragState}
-                  isSelected={selectedItem?.id === item.id}
-                  columnSizing={columnSizing}
-                />
-              ))}
-            {hasNextFoldersPage && (
-              <tbody className="bg-transparent">
-                <tr>
-                  <td colSpan={columns.length}>
-                    <div ref={foldersRef} className="h-1" />
-                  </td>
-                </tr>
-              </tbody>
-            )}
-          </>
-        )}
+                  <div className="flex-1 bg-card" />
+                </div>
+              )
+            }
 
-        {files.length > 0 && (
-          <>
-            <tbody className="bg-card">
-              <tr
-                className="border-b border-border hover:bg-muted/50 transition-colors cursor-pointer group"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  setFilesExpanded(!filesExpanded)
-                }}
-              >
-                <td
-                  className="px-4 py-2 sticky left-0 z-10 bg-card border-r"
+            const dataItem = item.kind === 'folder' ? folders[item.index] : files[item.index]
+
+            if (!dataItem) {
+              return (
+                <div
+                  key={`skeleton-${item.kind}-${item.index}`}
+                  ref={rowVirtualizer.measureElement}
+                  className="absolute top-0 left-0 w-full border-b border-border px-4 py-3 flex items-center animate-pulse"
                   style={{
-                    width: columnSizing?.['name'] || 300,
-                    minWidth: columnSizing?.['name'] || 300,
+                    transform: `translateY(${virtualRow.start}px)`,
                   }}
                 >
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      checked={files.length > 0 && files.every((f) => selectedIds.has(f.id!))}
-                      onCheckedChange={() => {
-                        // Batch selection logic
-                      }}
-                      onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                      className="h-4 w-4"
-                    />
-                    <div className="p-1 rounded hover:bg-muted">
-                      {filesExpanded ? (
-                        <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                      ) : (
-                        <ChevronRight className="h-4 w-4 text-muted-foreground" />
-                      )}
-                    </div>
-                    <span className="text-sm font-medium text-muted-foreground whitespace-nowrap">
-                      {formatCount(totalFiles ?? files.length, true)} • {formatSize(filesSize)}
-                    </span>
-                  </div>
-                </td>
-                <td colSpan={columns.length - 1} className="bg-card" />
-              </tr>
-            </tbody>
-            {filesExpanded &&
-              files.map((item) => (
-                <ListRow
-                  key={item.id}
-                  item={item}
-                  renderItem={renderItem}
-                  active={sort?.field === 'custom'}
-                  dragState={dragState}
-                  isSelected={selectedItem?.id === item.id}
-                  columnSizing={columnSizing}
-                />
-              ))}
-            {hasNextFilesPage && (
-              <tbody className="bg-transparent">
-                <tr>
-                  <td colSpan={columns.length}>
-                    <div ref={filesRef} className="h-1" />
-                  </td>
-                </tr>
-              </tbody>
-            )}
-          </>
-        )}
-      </table>
+                  <div className="h-4 bg-muted rounded w-1/4" />
+                </div>
+              )
+            }
+
+            return (
+              <ListRow
+                key={dataItem.id}
+                item={dataItem}
+                renderItem={renderItem}
+                active={sort?.field === 'custom'}
+                dragState={dragState}
+                isSelected={selectedItem?.id === dataItem.id}
+                columnSizing={columnSizing}
+                virtualRow={virtualRow}
+                measureElement={rowVirtualizer.measureElement}
+              />
+            )
+          })}
+        </div>
+      </div>
     </div>
   )
 }

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -89,6 +89,7 @@ function ListRow({
         setRowRef(node)
         measureElement(node)
       }}
+      data-index={virtualRow.index}
       className={cn(
         'group border-b border-border transition-colors hover:bg-primary/20 absolute top-0 left-0 w-full flex flex-col',
         isSelected && 'bg-primary/10',
@@ -338,6 +339,7 @@ export function FileBrowserListView({
                 <div
                   key={`header-${item.kind}`}
                   ref={rowVirtualizer.measureElement}
+                  data-index={virtualRow.index}
                   className="absolute top-0 left-0 w-full border-b border-border hover:bg-muted/50 transition-colors cursor-pointer group flex bg-card z-20"
                   style={{
                     transform: `translateY(${virtualRow.start}px)`,

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -51,6 +51,7 @@
     "@tanstack/react-query": "5.90.10",
     "@tanstack/react-router": "^1.136.8",
     "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.13.26",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",


### PR DESCRIPTION
## Summary
This PR implements virtualization for both the List View and Grid View in the file browser using `@tanstack/react-virtual`. This fixes the issue where the scrollbar length would change as the user scrolled and fetched more pages.

## Changes
- Added `@tanstack/react-virtual` to the project and `webui` package.
- Refactored `FileBrowserListView` to use absolute positioning and a virtualizer for rows.
- Refactored `FileBrowserGridView` to use a virtualizer for rows, with dynamic column calculation.
- Updated `FileBrowser` to pass the scroll container reference and fetch functions to the virtualized views.
- Removed `react-intersection-observer` (useInView) logic from `FileBrowser` as it's now handled by the virtualizers.

## Verification
- `bun run lint` passed.
- `bun run format` passed.
- `bun run typecheck` passed.
- Manually verified that the scrollbar reflects the total item count and loads more items smoothly when scrolling.