### PR TITLE
fix(transcode): handle large images and WebP limits

### DIFF
--- a/packages/transcode/src/transcode.test.ts
+++ b/packages/transcode/src/transcode.test.ts
@@ -106,7 +106,7 @@ describe('TranscodeService', () => {
     expect(info.originalHeight).toBe(600)
     expect(info.mimeType).toBe('png')
     expect(info.duration).toBe(0)
-    expect(sharp).toHaveBeenCalledWith('test.png')
+    expect(sharp).toHaveBeenCalledWith('test.png', { limitInputPixels: false })
   })
 
   it('should construct correct ffmpeg arguments for video transcoding', async () => {
@@ -147,9 +147,9 @@ describe('TranscodeService', () => {
     const outputFile = path.join(tempDir, 'output.webp')
     await transcodeService.transcodeImage('input.png', outputFile, 480, 80)
 
-    expect(sharp).toHaveBeenCalledWith('input.png')
+    expect(sharp).toHaveBeenCalledWith('input.png', { limitInputPixels: false })
     const mockSharp = vi.mocked(sharp).mock.results[0].value
-    expect(mockSharp.resize).toHaveBeenCalledWith(480, null, expect.any(Object))
+    expect(mockSharp.resize).toHaveBeenCalledWith(480, 16383, expect.any(Object))
     expect(mockSharp.webp).toHaveBeenCalledWith({ quality: 80 })
     expect(mockSharp.toFile).toHaveBeenCalledWith(outputFile)
   })
@@ -166,7 +166,7 @@ describe('TranscodeService', () => {
     await transcodeService.transcodeImage('http://example.com/image.png', outputFile, 480, 80)
 
     expect(global.fetch).toHaveBeenCalledWith('http://example.com/image.png')
-    expect(sharp).toHaveBeenCalledWith(expect.any(Buffer))
+    expect(sharp).toHaveBeenCalledWith(expect.any(Buffer), { limitInputPixels: false })
   })
 
   it('should support Buffer as input for image transcoding', async () => {
@@ -174,9 +174,9 @@ describe('TranscodeService', () => {
     const outputFile = path.join(tempDir, 'output-buffer.webp')
     await transcodeService.transcodeImage(inputBuffer, outputFile, 480, 80)
 
-    expect(sharp).toHaveBeenCalledWith(inputBuffer)
+    expect(sharp).toHaveBeenCalledWith(inputBuffer, { limitInputPixels: false })
     const mockSharp = vi.mocked(sharp).mock.results[vi.mocked(sharp).mock.results.length - 1].value
-    expect(mockSharp.resize).toHaveBeenCalledWith(480, null, expect.any(Object))
+    expect(mockSharp.resize).toHaveBeenCalledWith(480, 16383, expect.any(Object))
     expect(mockSharp.webp).toHaveBeenCalledWith({ quality: 80 })
     expect(mockSharp.toFile).toHaveBeenCalledWith(outputFile)
   })

--- a/packages/transcode/src/transcode.ts
+++ b/packages/transcode/src/transcode.ts
@@ -237,7 +237,7 @@ export class TranscodeService {
       input = Buffer.from(await resp.arrayBuffer())
     }
 
-    const metadata = await sharp(input).metadata()
+    const metadata = await sharp(input, { limitInputPixels: false }).metadata()
     return {
       originalWidth: metadata.width || 0,
       originalHeight: metadata.height || 0,
@@ -289,17 +289,16 @@ export class TranscodeService {
       input = Buffer.from(await resp.arrayBuffer())
     }
 
-    const sharpInstance = sharp(input)
+    const sharpInstance = sharp(input, { limitInputPixels: false })
 
-    const w = width > 0 ? width : null
-    const h = height && height > 0 ? height : null
+    const WEBP_MAX_DIMENSION = 16383
+    const targetW = width > 0 ? Math.min(width, WEBP_MAX_DIMENSION) : WEBP_MAX_DIMENSION
+    const targetH = height && height > 0 ? Math.min(height, WEBP_MAX_DIMENSION) : WEBP_MAX_DIMENSION
 
-    if (w || h) {
-      sharpInstance.resize(w, h, {
-        withoutEnlargement: true,
-        fit: 'inside',
-      })
-    }
+    sharpInstance.resize(targetW, targetH, {
+      withoutEnlargement: true,
+      fit: 'inside',
+    })
 
     await sharpInstance.webp({ quality }).toFile(outputFile)
   }
@@ -497,14 +496,14 @@ export class TranscodeService {
           params.annotations &&
           params.annotations.length > 0
         ) {
-          const meta = await sharp(localShotPath).metadata()
+          const meta = await sharp(localShotPath, { limitInputPixels: false }).metadata()
           const width = meta.width || 1280
           const height = meta.height || 720
 
           const svgStr = renderAnnotationsToSvg(width, height, params.annotations)
           const tempCompositedPath = path.join(tmpDir, `composite-${outName}`)
 
-          await sharp(localShotPath)
+          await sharp(localShotPath, { limitInputPixels: false })
             .composite([{ input: Buffer.from(svgStr), top: 0, left: 0 }])
             .toFile(tempCompositedPath)
 
@@ -539,7 +538,7 @@ export class TranscodeService {
       await s3Service.downloadToFile(bucket, params.assetKey, imgPath)
 
       // 2. Read dimensions
-      const meta = await sharp(imgPath).metadata()
+      const meta = await sharp(imgPath, { limitInputPixels: false }).metadata()
       const width = meta.width || 1920
       const height = meta.height || 1080
 
@@ -550,8 +549,9 @@ export class TranscodeService {
       const outName = `annotation-${ulid()}.webp`
       const localOutPath = path.join(tmpDir, outName)
 
-      await sharp(imgPath)
+      await sharp(imgPath, { limitInputPixels: false })
         .composite([{ input: Buffer.from(svgStr), top: 0, left: 0 }])
+        .resize(16383, 16383, { fit: 'inside', withoutEnlargement: true })
         .webp({ quality: 90 })
         .toFile(localOutPath)
 


### PR DESCRIPTION
## Summary

This PR fixes two issues related to processing very large images in the transcode service:
1. `Input image exceeds pixel limit`: Fixed by disabling `limitInputPixels` in `sharp`.
2. `Processed image is too large for the WebP format`: Fixed by enforcing WebP's maximum dimension limit (16383x16383) via mandatory resizing.

## Changes

- Disabled `limitInputPixels` in `sharp` across all image processing methods in `TranscodeService`.
- Enforced a 16383px cap for WebP outputs in `transcodeImage` and `overlayAnnotations`.
- Updated unit tests to match the new implementation.

## Verification

- Ran `bun run typecheck`, `bun run lint`, and `bun run format`.
- Ran all tests using `bun run test`, which passed successfully.
