### PR TITLE
refactor(core): fix fileCount and createAssetsRecursively transaction

### DIFF
--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -866,12 +866,6 @@ export async function executeAgentToolActivity(params: ExecuteAgentToolParams): 
         creatorId: userId,
       })
 
-      // Increment fileCount of parent folder
-      await prisma.asset.update({
-        where: { id: parent },
-        data: { fileCount: { increment: 1 } },
-      })
-
       return {
         id: newFolder.id,
         name: newFolder.name,
@@ -930,12 +924,8 @@ export async function executeAgentToolActivity(params: ExecuteAgentToolParams): 
         creatorId: userId,
       })
 
-      // Increment fileCount of parent and update ancestor size
+      // Increment update ancestor size
       await prisma.$transaction(async (tx) => {
-        await tx.asset.update({
-          where: { id: parent },
-          data: { fileCount: { increment: 1 } },
-        })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         await assetService.updateAncestorsSize(tx as any, parent, fileSize)
 
@@ -1026,11 +1016,10 @@ export async function executeAgentToolActivity(params: ExecuteAgentToolParams): 
             where: { id: newFile.id },
             data: { sortIndex: newSortIndex },
           })
-          // Increment stack's fileCount and size
+          // Increment stack's size (fileCount is incremented by createAsset already)
           const updatedStack = await tx.asset.update({
             where: { id: stackId },
             data: {
-              fileCount: { increment: 1 },
               sizeByte: { increment: fileSize },
             },
           })

--- a/packages/core/src/asset/asset.test.ts
+++ b/packages/core/src/asset/asset.test.ts
@@ -559,6 +559,63 @@ describe('AssetService', () => {
     })
   })
 
+  describe('fileCount verification', () => {
+    it('createAsset should increment parent fileCount', async () => {
+      const { user, assets, project } = await setupBasicAssets()
+
+      const parent = assets.folderA
+      const initialCount = parent.fileCount // should be 2 from setup (fileA1, fileA2)
+
+      // Create a new folder inside folderA
+      await assetService.createAsset({
+        name: 'newFolder',
+        type: 'folder',
+        parentId: parent.id,
+        projectId: project.id,
+        creatorId: user.id,
+      })
+
+      const updatedParent = await prisma.asset.findUnique({ where: { id: parent.id } })
+      expect(updatedParent?.fileCount).toBe(initialCount + 1)
+
+      // Create a new file inside folderA
+      await assetService.createAsset({
+        name: 'newFile',
+        type: 'file',
+        parentId: parent.id,
+        projectId: project.id,
+        creatorId: user.id,
+      })
+
+      const updatedParent2 = await prisma.asset.findUnique({ where: { id: parent.id } })
+      expect(updatedParent2?.fileCount).toBe(initialCount + 2)
+    })
+
+    it('reparentAssets should update fileCount when moving folders', async () => {
+      const { user, assets } = await setupBasicAssets()
+
+      const sourceParent = assets.root
+      const targetParent = assets.folderB
+      const folderToMove = assets.folderA
+
+      // folderA is a child of root.
+      // root children: folderA, folderB, fileRoot1. count=3.
+      // folderB children: stackB, fileB2. count=2.
+
+      await assetService.reparentAssets({
+        assetIds: [folderToMove.id],
+        newParentId: targetParent.id,
+        creatorId: user.id,
+      })
+
+      const updatedSourceParent = await prisma.asset.findUnique({ where: { id: sourceParent.id } })
+      expect(updatedSourceParent?.fileCount).toBe(2)
+
+      const updatedTargetParent = await prisma.asset.findUnique({ where: { id: targetParent.id } })
+      expect(updatedTargetParent?.fileCount).toBe(3)
+    })
+  })
+
   it('handles reparenting - Version Stack: dissolve with 1 remaining', async () => {
     const { user, assets } = await setupBasicAssets()
     await assetService.reparentAssets({

--- a/packages/core/src/asset/asset.ts
+++ b/packages/core/src/asset/asset.ts
@@ -172,8 +172,8 @@ export class AssetService {
     }
   }
 
-  async reparentAssets(req: ReparentAssetsRequest): Promise<void> {
-    await this.prismaClient.$transaction(async (tx) => {
+  async reparentAssets(req: ReparentAssetsRequest, tx?: Prisma.TransactionClient): Promise<void> {
+    const runInTx = async (tx: Prisma.TransactionClient) => {
       const newParent = await tx.asset.findUnique({
         where: { id: req.newParentId },
         include: { project: { include: { team: true } } },
@@ -269,7 +269,13 @@ export class AssetService {
       if (oldParent) {
         await this.dissolveStackIfEmpty(tx, oldParent)
       }
-    })
+    }
+
+    if (tx) {
+      await runInTx(tx)
+    } else {
+      await this.prismaClient.$transaction(runInTx)
+    }
   }
 
   async copyAssets(req: CopyAssetsRequest): Promise<void> {
@@ -722,30 +728,41 @@ export class AssetService {
     if (req.contentType) data.mediaType = req.contentType
     if (req.creatorId) data.creator = { connect: { id: req.creatorId } }
 
-    const asset = await this.prismaClient.asset.create({
-      data,
-      include: {
-        creator: true,
-        metadataValues: true,
-        storageKey: true,
-        target: {
-          include: {
-            creator: true,
-            metadataValues: true,
-            storageKey: true,
-            children: {
-              include: { creator: true, metadataValues: true, storageKey: true },
-              take: 3,
-              orderBy: { sortIndex: 'asc' },
+    const asset = await this.prismaClient.$transaction(async (tx) => {
+      const createdAsset = await tx.asset.create({
+        data,
+        include: {
+          creator: true,
+          metadataValues: true,
+          storageKey: true,
+          target: {
+            include: {
+              creator: true,
+              metadataValues: true,
+              storageKey: true,
+              children: {
+                include: { creator: true, metadataValues: true, storageKey: true },
+                take: 3,
+                orderBy: { sortIndex: 'asc' },
+              },
             },
           },
+          children: {
+            include: { creator: true, metadataValues: true, storageKey: true },
+            take: 3,
+            orderBy: { sortIndex: 'asc' },
+          },
         },
-        children: {
-          include: { creator: true, metadataValues: true, storageKey: true },
-          take: 3,
-          orderBy: { sortIndex: 'asc' },
-        },
-      },
+      })
+
+      if (parent) {
+        await tx.asset.update({
+          where: { id: parent.id },
+          data: { fileCount: { increment: 1 } },
+        })
+      }
+
+      return createdAsset
     })
 
     const infos = await this.toAssetInfos([asset])

--- a/packages/core/src/upload/upload.test.ts
+++ b/packages/core/src/upload/upload.test.ts
@@ -93,6 +93,67 @@ describe('UploadService', () => {
     expect(hidden).toBeNull()
   })
 
+  it('should correctly increment fileCount for parent folders when uploading folders', async () => {
+    const req = {
+      parentId: parentId,
+      files: [
+        {
+          name: 'folder1',
+          id: '1',
+          type: 'folder' as const,
+          size: 0,
+          children: [
+            {
+              name: 'folder2',
+              id: '2',
+              type: 'folder' as const,
+              size: 0,
+              children: [],
+            },
+            {
+              name: 'file1.txt',
+              id: '3',
+              type: 'file' as const,
+              size: 100,
+              mediaType: 'text/plain',
+              children: [],
+            },
+          ],
+        },
+      ],
+    }
+
+    await uploadService.createUploadTask(userId, req)
+
+    // parentId folder should have folder1 as a direct child
+    const parent = await prisma.asset.findUnique({ where: { id: parentId } })
+    expect(parent?.fileCount).toBe(1)
+
+    // folder1 should have folder2 and file1.txt as direct children
+    // folder2 is a folder, so it is counted immediately.
+    // file1.txt is a file, so it is counted after confirmFileUpload.
+    const folder1 = await prisma.asset.findFirst({ where: { name: 'folder1' } })
+    expect(folder1?.parentId).toBe(parentId)
+    expect(folder1?.fileCount).toBe(1)
+
+    const folder2 = await prisma.asset.findFirst({ where: { name: 'folder2' } })
+    expect(folder2?.parentId).toBe(folder1?.id)
+    expect(folder2?.fileCount).toBe(0)
+
+    const file1 = await prisma.asset.findFirst({ where: { name: 'file1.txt' } })
+    expect(file1?.parentId).toBe(folder1?.id)
+    expect(file1?.status).toBe(AssetStatus.uploading)
+
+    // Confirm upload for file1.txt
+    const task = await prisma.task.findFirst({ where: { total: 1 } })
+    await uploadService.confirmFileUpload(userId, task!.id, {
+      fileId: file1!.id,
+    })
+
+    const folder1After = await prisma.asset.findUnique({ where: { id: folder1!.id } })
+    expect(folder1After?.fileCount).toBe(2)
+  })
+
   it('should confirm file upload and create transcode tasks for video', async () => {
     const task = await prisma.task.create({
       data: { creatorId: userId, total: 1, uploaded: 0, type: 'upload' },

--- a/packages/core/src/upload/upload.ts
+++ b/packages/core/src/upload/upload.ts
@@ -2,21 +2,21 @@ import { assetService } from '@shumai/core/src/asset/asset'
 import { PaginatedData, PaginationParams, paginateQuery } from '@shumai/core/src/pagination'
 import { s3Service } from '@shumai/core/src/s3/s3'
 import {
-    AssetStatus,
-    AssetType,
-    Prisma,
-    TaskStatus,
-    WorkflowTaskStatus,
-    WorkflowTaskType,
-    prisma,
+  AssetStatus,
+  AssetType,
+  Prisma,
+  TaskStatus,
+  WorkflowTaskStatus,
+  WorkflowTaskType,
+  prisma,
 } from '@shumai/db'
 import {
-    ConfirmFileUploadRequest,
-    CreateUploadTaskRequest,
-    CreateUploadTaskResponse,
-    FileNode,
-    PresignedUrl,
-    TaskInfo,
+  ConfirmFileUploadRequest,
+  CreateUploadTaskRequest,
+  CreateUploadTaskResponse,
+  FileNode,
+  PresignedUrl,
+  TaskInfo,
 } from '@shumai/dtos'
 import { ImageTranscoder, VideoTranscoder } from '@shumai/transcode'
 import { generateKeyBetween } from 'jittered-fractional-indexing'
@@ -67,24 +67,32 @@ export class UploadService {
     const isParentFile = parentAsset.type === AssetType.file
     const targetParentId = isParentFile ? parentAsset.parentId! : parentAsset.id
 
-    const createdAssetIds = await this.createAssetsRecursively(
-      userId,
-      task.id,
-      parentAsset.projectId,
-      targetParentId,
-      req.files,
-      presignedUrls,
-    )
+    await this.prismaClient.$transaction(async (tx) => {
+      const ids = await this.createAssetsRecursively(
+        tx,
+        userId,
+        task.id,
+        parentAsset.projectId!,
+        targetParentId,
+        req.files,
+        presignedUrls,
+      )
 
-    if (isParentFile && createdAssetIds.length > 0) {
-      for (const assetId of createdAssetIds) {
-        await assetService.reparentAssets({
-          assetIds: [assetId],
-          newParentId: parentAsset.id,
-          creatorId: userId,
-        })
+      if (isParentFile && ids.length > 0) {
+        for (const assetId of ids) {
+          await assetService.reparentAssets(
+            {
+              assetIds: [assetId],
+              newParentId: parentAsset.id,
+              creatorId: userId,
+            },
+            tx,
+          )
+        }
       }
-    }
+
+      return ids
+    })
 
     return {
       taskId: task.id,
@@ -93,6 +101,7 @@ export class UploadService {
   }
 
   private async createAssetsRecursively(
+    tx: Prisma.TransactionClient,
     userId: string,
     taskId: string,
     projectId: string,
@@ -100,7 +109,7 @@ export class UploadService {
     files: FileNode[],
     presignedUrls: PresignedUrl[],
   ): Promise<string[]> {
-    const firstFile = await this.prismaClient.asset.findFirst({
+    const firstFile = await tx.asset.findFirst({
       where: { parentId },
       orderBy: { sortIndex: 'asc' },
     })
@@ -119,14 +128,14 @@ export class UploadService {
         key = `files/${ulid()}/raw`
       }
 
-      const newAsset = await this.prismaClient.asset.create({
+      const newAsset = await tx.asset.create({
         data: {
           name: file.name,
           type: assetType,
           storageKey: key ? { create: { key } } : undefined,
           sortIndex: newSortIndex,
           mediaType: file.mediaType,
-          status: AssetStatus.uploading,
+          status: assetType === AssetType.folder ? AssetStatus.uploaded : AssetStatus.uploading,
           sizeByte: file.size,
           creator: userId ? { connect: { id: userId } } : undefined,
           parent: parentId ? { connect: { id: parentId } } : undefined,
@@ -136,8 +145,16 @@ export class UploadService {
       })
       createdIds.push(newAsset.id)
 
+      if (assetType === AssetType.folder && parentId) {
+        await tx.asset.update({
+          where: { id: parentId },
+          data: { fileCount: { increment: 1 } },
+        })
+      }
+
       if (file.children && file.children.length > 0) {
         await this.createAssetsRecursively(
+          tx,
           userId,
           taskId,
           projectId,
@@ -212,9 +229,8 @@ export class UploadService {
           where: { id: asset.parentId },
           data: { fileCount: { increment: 1 } },
         })
-        // The transaction context is compatible with the asset service's requirements
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await assetService.updateAncestorsSize(tx as any, asset.parentId, updatedAsset.sizeByte)
+
+        await assetService.updateAncestorsSize(tx, asset.parentId, updatedAsset.sizeByte)
       }
 
       // Update task


### PR DESCRIPTION
## Summary
This PR fixes the `fileCount` calculation for folders and refactors `createAssetsRecursively` to use Prisma transactions safely.

## Changes
- **`fileCount` Fix**:
    - `fileCount` now correctly represents the count of ALL direct children (both files and folders).
    - Updated `createAsset` (AssetService) to increment parent's `fileCount`.
    - Updated `createAssetsRecursively` (UploadService) to increment parent's `fileCount` for folders immediately.
    - Folders created during upload are now set to `uploaded` status immediately.
- **Transaction Refactoring**:
    - Refactored `createAssetsRecursively` to take a transaction client (`tx`).
    - Wrapped `createUploadTask` logic in a single transaction.
    - Added optional `tx` parameter to `reparentAssets` to allow transactional participation.
    - Removed unnecessary `as any` casts when calling `updateAncestorsSize`.

## Verification
- Added new tests in `asset.test.ts` to verify `fileCount` increments for `createAsset` and `reparentAssets` (moving folders).
- Added new tests in `upload.test.ts` to verify `fileCount` increments for folder uploads and nested structures.
- Verified all tests pass: `bun run test packages/core/src/upload/upload.test.ts packages/core/src/asset/asset.test.ts`.
- Ran full workspace checks: `bun run lint && bun run format && bun run typecheck`.