### PR TITLE
feat: show selection size and correctly pluralize type in file browser bottom bar

### DIFF
--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -542,6 +542,10 @@ export function FileBrowser({
   const selectedFiles = Array.from(selectedIds).filter((id) =>
     displayedFiles.find((item) => item.id === id),
   ).length
+  const selectedSize = Array.from(selectedIds).reduce((acc, id) => {
+    const item = folders.find((f) => f.id === id) || displayedFiles.find((f) => f.id === id)
+    return acc + (item?.sizeByte || 0)
+  }, 0)
 
   const handleUploadFilesClick = () => {
     fileInputRef.current?.click()
@@ -879,20 +883,17 @@ export function FileBrowser({
                 <div className="text-sm text-muted-foreground">
                   {selectedFolders > 0 && selectedFiles > 0 && (
                     <span>
-                      {selectedFolders} folder
-                      {selectedFolders !== 1 ? 's' : ''}, {selectedFiles} file
-                      {selectedFiles !== 1 ? 's' : ''} selected
+                      {selectedCount} Item{selectedCount !== 1 ? 's' : ''} selected • {formatSize(selectedSize)}
                     </span>
                   )}
                   {selectedFolders > 0 && selectedFiles === 0 && (
                     <span>
-                      {selectedFolders} folder
-                      {selectedFolders !== 1 ? 's' : ''} selected
+                      {selectedFolders} folder{selectedFolders !== 1 ? 's' : ''} selected • {formatSize(selectedSize)}
                     </span>
                   )}
                   {selectedFolders === 0 && selectedFiles > 0 && (
                     <span>
-                      {selectedFiles} file{selectedFiles !== 1 ? 's' : ''} selected
+                      {selectedFiles} file{selectedFiles !== 1 ? 's' : ''} selected • {formatSize(selectedSize)}
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
Adds total file/folder size to the selection bottom bar in the file browser. Conditionally renders selection text to better reflect what is selected (Items/file(s)/folder(s)).

---
*PR created automatically by Jules for task [8006574181274949502](https://jules.google.com/task/8006574181274949502) started by @Yiling-J*