### PR TITLE
fix(transcode): update WEBP_MAX_DIMENSION to 7680

### DIFF
--- a/packages/transcode/src/transcode.test.ts
+++ b/packages/transcode/src/transcode.test.ts
@@ -149,7 +149,7 @@ describe('TranscodeService', () => {
 
     expect(sharp).toHaveBeenCalledWith('input.png', { limitInputPixels: false })
     const mockSharp = vi.mocked(sharp).mock.results[0].value
-    expect(mockSharp.resize).toHaveBeenCalledWith(480, 16383, expect.any(Object))
+    expect(mockSharp.resize).toHaveBeenCalledWith(480, 7680, expect.any(Object))
     expect(mockSharp.webp).toHaveBeenCalledWith({ quality: 80 })
     expect(mockSharp.toFile).toHaveBeenCalledWith(outputFile)
   })
@@ -176,7 +176,7 @@ describe('TranscodeService', () => {
 
     expect(sharp).toHaveBeenCalledWith(inputBuffer, { limitInputPixels: false })
     const mockSharp = vi.mocked(sharp).mock.results[vi.mocked(sharp).mock.results.length - 1].value
-    expect(mockSharp.resize).toHaveBeenCalledWith(480, 16383, expect.any(Object))
+    expect(mockSharp.resize).toHaveBeenCalledWith(480, 7680, expect.any(Object))
     expect(mockSharp.webp).toHaveBeenCalledWith({ quality: 80 })
     expect(mockSharp.toFile).toHaveBeenCalledWith(outputFile)
   })

--- a/packages/transcode/src/transcode.ts
+++ b/packages/transcode/src/transcode.ts
@@ -1,14 +1,13 @@
-import { prisma } from '@shumai/db'
-import { WorkflowTaskStatus, WorkflowTaskType } from '@shumai/db'
+import { s3Service } from '@shumai/core/src/s3/s3'
+import { prisma, WorkflowTaskStatus, WorkflowTaskType } from '@shumai/db'
 import '@shumai/db/src/prisma-json-types'
 import { execFile } from 'child_process'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import sharp from 'sharp'
-import { promisify } from 'util'
-import { s3Service } from '@shumai/core/src/s3/s3'
 import { ulid } from 'ulid'
+import { promisify } from 'util'
 
 const execFileAsync = promisify(execFile)
 
@@ -291,7 +290,7 @@ export class TranscodeService {
 
     const sharpInstance = sharp(input, { limitInputPixels: false })
 
-    const WEBP_MAX_DIMENSION = 16383
+    const WEBP_MAX_DIMENSION = 7680
     const targetW = width > 0 ? Math.min(width, WEBP_MAX_DIMENSION) : WEBP_MAX_DIMENSION
     const targetH = height && height > 0 ? Math.min(height, WEBP_MAX_DIMENSION) : WEBP_MAX_DIMENSION
 

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -883,17 +883,20 @@ export function FileBrowser({
                 <div className="text-sm text-muted-foreground">
                   {selectedFolders > 0 && selectedFiles > 0 && (
                     <span>
-                      {selectedCount} Item{selectedCount !== 1 ? 's' : ''} selected • {formatSize(selectedSize)}
+                      {selectedCount} Item{selectedCount !== 1 ? 's' : ''} selected •{' '}
+                      {formatSize(selectedSize)}
                     </span>
                   )}
                   {selectedFolders > 0 && selectedFiles === 0 && (
                     <span>
-                      {selectedFolders} folder{selectedFolders !== 1 ? 's' : ''} selected • {formatSize(selectedSize)}
+                      {selectedFolders} folder{selectedFolders !== 1 ? 's' : ''} selected •{' '}
+                      {formatSize(selectedSize)}
                     </span>
                   )}
                   {selectedFolders === 0 && selectedFiles > 0 && (
                     <span>
-                      {selectedFiles} file{selectedFiles !== 1 ? 's' : ''} selected • {formatSize(selectedSize)}
+                      {selectedFiles} file{selectedFiles !== 1 ? 's' : ''} selected •{' '}
+                      {formatSize(selectedSize)}
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
## Summary

Update the `WEBP_MAX_DIMENSION` constant in `TranscodeService` to 7680 and update corresponding tests.

## Changes

- Modified `WEBP_MAX_DIMENSION` from 16383 to 7680 in `packages/transcode/src/transcode.ts`.
- Updated test assertions in `packages/transcode/src/transcode.test.ts` to match the new constant value.

## Verification

- Ran `bun run lint`, `bun run format`, `bun run typecheck`, and `bun run test`.
- All checks passed simultaneously (447 tests passed).

## Notes

The reduction in max dimension ensures better compatibility or performance for WebP transcoding.