### PR TITLE
feat(team): add member scope labels and visibility filtering

### DIFF
--- a/packages/api/src/api/team.test.ts
+++ b/packages/api/src/api/team.test.ts
@@ -175,7 +175,11 @@ describe('team api', () => {
         permission: Permission.Read,
       }),
     )
-    expect(mockGetTeamMembers).toHaveBeenCalledWith({ teamId: 't1', includeAgents: false })
+    expect(mockGetTeamMembers).toHaveBeenCalledWith({
+      teamId: 't1',
+      userId: 'user1',
+      includeAgents: false,
+    })
   })
 
   it('GET /teams/:teamId/settings returns settings', async () => {

--- a/packages/api/src/api/team.ts
+++ b/packages/api/src/api/team.ts
@@ -108,6 +108,7 @@ const route = new Hono<{ Variables: { user: User } }>()
 
     const members = await teamService.getTeamMembers({
       teamId,
+      userId: user.id,
       includeAgents: includeAgents,
     })
 

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -225,6 +225,7 @@ export class ProjectService {
           name: pm.teamMember.user.name,
           role: pm.role,
           image: await getAvatarUrl(pm.teamMember.user.image),
+          scope: pm.teamMember.scope,
         })),
     )
   }

--- a/packages/core/src/team/team.test.ts
+++ b/packages/core/src/team/team.test.ts
@@ -127,6 +127,7 @@ describe('TeamService', () => {
 
     const members = await teamService.getTeamMembers({
       teamId: team.id,
+      userId: user1.id,
     })
 
     expect(members).toHaveLength(2)
@@ -169,6 +170,7 @@ describe('TeamService', () => {
     // Should hide bots by default
     const members = await teamService.getTeamMembers({
       teamId: team.id,
+      userId: user.id,
     })
     expect(members).toHaveLength(1)
     expect(members[0].id).toBe(user.id)
@@ -176,9 +178,71 @@ describe('TeamService', () => {
     // Should include bots if requested
     const allMembers = await teamService.getTeamMembers({
       teamId: team.id,
+      userId: user.id,
       includeAgents: true,
     })
     expect(allMembers).toHaveLength(2)
+  })
+
+  it('should filter members for project-scoped members', async () => {
+    const owner = await prisma.user.create({
+      data: { name: 'Owner', email: `owner-${Date.now()}@example.com`, password: 'pw' },
+    })
+    const team = await teamService.createTeam(owner, { name: 'Test Team' })
+
+    const teamMember = await prisma.user.create({
+      data: { name: 'Team Member', email: `tm-${Date.now()}@example.com`, password: 'pw' },
+    })
+    await teamService.joinTeam({ teamId: team.id, userId: teamMember.id })
+
+    const projectMember1 = await prisma.user.create({
+      data: { name: 'Proj Member 1', email: `pm1-${Date.now()}@example.com`, password: 'pw' },
+    })
+    const tm1 = await prisma.teamMember.create({
+      data: { teamId: team.id, userId: projectMember1.id, scope: 'project', role: 'editor' },
+    })
+
+    const projectMember2 = await prisma.user.create({
+      data: { name: 'Proj Member 2', email: `pm2-${Date.now()}@example.com`, password: 'pw' },
+    })
+    const tm2 = await prisma.teamMember.create({
+      data: { teamId: team.id, userId: projectMember2.id, scope: 'project', role: 'editor' },
+    })
+
+    const project = await prisma.project.create({
+      data: { name: 'Shared Project', teamId: team.id },
+    })
+
+    await prisma.projectMember.createMany({
+      data: [
+        { projectId: project.id, teamMemberId: tm1.id, role: 'editor' },
+        { projectId: project.id, teamMemberId: tm2.id, role: 'editor' },
+      ],
+    })
+
+    const projectMember3 = await prisma.user.create({
+      data: { name: 'Proj Member 3', email: `pm3-${Date.now()}@example.com`, password: 'pw' },
+    })
+    await prisma.teamMember.create({
+      data: { teamId: team.id, userId: projectMember3.id, scope: 'project', role: 'editor' },
+    })
+
+    // Owner (team scope) should see everyone (4 users)
+    const ownerView = await teamService.getTeamMembers({ teamId: team.id, userId: owner.id })
+    expect(ownerView).toHaveLength(5) // Owner, Team Member, PM1, PM2, PM3
+
+    // PM1 (project scope) should see: Owner, Team Member, PM2 (shares project), but NOT PM3
+    const pm1View = await teamService.getTeamMembers({ teamId: team.id, userId: projectMember1.id })
+    const pm1ViewIds = pm1View.map((m) => m.id)
+    expect(pm1View).toHaveLength(4)
+    expect(pm1ViewIds).toContain(owner.id)
+    expect(pm1ViewIds).toContain(teamMember.id)
+    expect(pm1ViewIds).toContain(projectMember2.id)
+    expect(pm1ViewIds).not.toContain(projectMember3.id)
+
+    // Check scopes are returned
+    expect(pm1View.find((m) => m.id === owner.id)?.scope).toBe('team')
+    expect(pm1View.find((m) => m.id === projectMember2.id)?.scope).toBe('project')
   })
 
   it('should get and update settings', async () => {

--- a/packages/core/src/team/team.ts
+++ b/packages/core/src/team/team.ts
@@ -174,6 +174,19 @@ export class TeamService {
   }
 
   async getTeamMembers(req: ServiceGetTeamMembersRequest): Promise<UserInfo[]> {
+    const requester = await prisma.teamMember.findUnique({
+      where: {
+        teamIdUserId: {
+          teamId: req.teamId,
+          userId: req.userId,
+        },
+      },
+    })
+
+    if (!requester) {
+      throw new HTTPException(403, { message: 'Requester is not a team member' })
+    }
+
     const members = await prisma.teamMember.findMany({
       where: {
         teamId: req.teamId,
@@ -194,17 +207,39 @@ export class TeamService {
             }
           : { user: { type: { not: 'agent' } } }),
       },
-      include: { user: true },
+      include: {
+        user: true,
+        projectMembers: true,
+      },
     })
 
+    let filteredMembers = members
+
+    if (requester.scope === 'project') {
+      const requesterProjectIds = await prisma.projectMember
+        .findMany({
+          where: { teamMemberId: requester.id },
+          select: { projectId: true },
+        })
+        .then((pms) => pms.map((pm) => pm.projectId))
+
+      filteredMembers = members.filter((m) => {
+        // Team-scoped members are always visible
+        if (m.scope === 'team') return true
+        // Project-scoped members are visible if they share a project
+        return m.projectMembers.some((pm) => requesterProjectIds.includes(pm.projectId))
+      })
+    }
+
     return Promise.all(
-      members.map(async (m) => ({
+      filteredMembers.map(async (m) => ({
         id: m.user.id,
         name: m.user.name,
         email: undefined,
         role: m.role,
         type: m.user.type || undefined,
         image: await getAvatarUrl(m.user.image),
+        scope: m.scope,
       })),
     )
   }

--- a/packages/dtos/src/project.ts
+++ b/packages/dtos/src/project.ts
@@ -48,6 +48,7 @@ export const projectUserInfoSchema = z.object({
   name: z.string(),
   role: z.enum(['owner', 'editor', 'reviewer', 'bot', 'unknown']),
   image: z.string().optional(),
+  scope: z.enum(['team', 'project']).optional(),
 })
 export type ProjectUserInfo = z.infer<typeof projectUserInfoSchema>
 

--- a/packages/dtos/src/team.ts
+++ b/packages/dtos/src/team.ts
@@ -52,6 +52,7 @@ export const userInfoSchema = z.object({
   email: z.string().optional(),
   type: z.enum(['human', 'agent']).optional(),
   image: z.string().optional(),
+  scope: z.enum(['team', 'project']).optional(),
 })
 export type UserInfo = z.infer<typeof userInfoSchema>
 
@@ -112,6 +113,7 @@ export interface ServiceGetMeRequest {
 
 export interface ServiceGetTeamMembersRequest {
   teamId: string
+  userId: string
   includeAgents?: boolean
 }
 

--- a/packages/webui/components/members-dialog.tsx
+++ b/packages/webui/components/members-dialog.tsx
@@ -28,6 +28,7 @@ export interface Member {
   name?: string
   role?: string
   image?: string
+  scope?: 'team' | 'project'
 }
 
 interface MembersDialogProps {
@@ -154,7 +155,19 @@ export function MembersDialog({
                   </Avatar>
                   <div className="flex flex-col">
                     <span className="text-sm font-medium">{member.name}</span>
-                    <span className="text-xs text-muted-foreground capitalize">{member.role}</span>
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs text-muted-foreground capitalize">
+                        {member.role}
+                      </span>
+                      {member.scope && (
+                        <>
+                          <span className="text-[10px] text-muted-foreground/50">•</span>
+                          <span className="text-[10px] bg-muted px-1.5 py-0.5 rounded-full font-medium text-muted-foreground uppercase tracking-wider">
+                            {member.scope === 'team' ? 'Team Member' : 'Project Member'}
+                          </span>
+                        </>
+                      )}
+                    </div>
                   </div>
                 </div>
 


### PR DESCRIPTION
## Summary
This PR adds labels to distinguish between team members and project members in the members dialog, and enforces visibility rules for project-scoped members.

## Changes
- Updated `UserInfo` and `ProjectUserInfo` DTOs to include a `scope` field.
- Updated `TeamService.getTeamMembers` to implement visibility filtering: project-scoped members only see team-wide members and project members from projects they share.
- Updated `ProjectService.listProjectMembers` to return member scope.
- Updated the `MembersDialog` UI to display "Team Member" or "Project Member" labels.
- Added a new test case in `TeamService` to verify the visibility filtering logic.

## Verification
- `bun run test` passes (including new test cases).
- `bun run lint`, `bun run format`, and `bun run typecheck` all pass.
- Verified that deleted members can rejoin via invite links by code analysis.

## Notes
- Project-scoped members visibility filtering is now active on the team members list endpoint.