### PR TITLE
feat(webui): virtualize file and folder browser views

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "shumai",
       "dependencies": {
+        "@tanstack/react-virtual": "^3.13.26",
         "jittered-fractional-indexing": "^1.0.1",
       },
       "devDependencies": {
@@ -223,6 +224,7 @@
         "@tanstack/react-query": "5.90.10",
         "@tanstack/react-router": "^1.136.8",
         "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-virtual": "^3.13.26",
         "better-auth": "^1.6.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1110,6 +1112,8 @@
 
     "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
 
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.26", "", { "dependencies": { "@tanstack/virtual-core": "3.16.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-DosdgjOxCLahkn0o+ilmZYwEjo1glfMGuRT/j3PQ18yr5XqA8N/BCaL9IJ3B5TRl+nnzyK2IOFgAILwzN3a9xQ=="],
+
     "@tanstack/router-cli": ["@tanstack/router-cli@1.167.12", "", { "dependencies": { "@tanstack/router-generator": "1.167.12", "chokidar": "^5.0.0", "yargs": "^17.7.2" }, "bin": { "tsr": "bin/tsr.cjs" } }, "sha512-7olQwX4Pyki8tsgc73iU2sK1ZhEtwTe8vYZn6qBfmH2FkrdzQ2kfbgO+4bBZEhckAFNwNqCklTZJYydCM3YuBA=="],
 
     "@tanstack/router-core": ["@tanstack/router-core@1.171.8", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-PbrTBbofFcacrH3RLgHYILRqTFnAGq+gXrXoA/vo7qUSkJpSO4GWfLtrtCahD4VayzRm19IPwcjPPLEugag6pw=="],
@@ -1123,6 +1127,8 @@
     "@tanstack/store": ["@tanstack/store@0.11.0", "", {}, "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw=="],
 
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.16.0", "", {}, "sha512-Er2N7q3WOiH6y2JLxsxNX+u2/sLqSsL0bxFgDjuiPiA7vKhZRm+IzcS17vRee3GNXr64UsesA5CAp9yTiIYw9A=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.162.0", "", {}, "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "shumai",
       "dependencies": {
-        "@tanstack/react-virtual": "^3.13.26",
+        "@tanstack/react-virtual": "^3.14.2",
         "jittered-fractional-indexing": "^1.0.1",
       },
       "devDependencies": {
@@ -1112,7 +1112,7 @@
 
     "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
 
-    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.26", "", { "dependencies": { "@tanstack/virtual-core": "3.16.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-DosdgjOxCLahkn0o+ilmZYwEjo1glfMGuRT/j3PQ18yr5XqA8N/BCaL9IJ3B5TRl+nnzyK2IOFgAILwzN3a9xQ=="],
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.2", "", { "dependencies": { "@tanstack/virtual-core": "3.17.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ=="],
 
     "@tanstack/router-cli": ["@tanstack/router-cli@1.167.12", "", { "dependencies": { "@tanstack/router-generator": "1.167.12", "chokidar": "^5.0.0", "yargs": "^17.7.2" }, "bin": { "tsr": "bin/tsr.cjs" } }, "sha512-7olQwX4Pyki8tsgc73iU2sK1ZhEtwTe8vYZn6qBfmH2FkrdzQ2kfbgO+4bBZEhckAFNwNqCklTZJYydCM3YuBA=="],
 
@@ -1128,7 +1128,7 @@
 
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
-    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.16.0", "", {}, "sha512-Er2N7q3WOiH6y2JLxsxNX+u2/sLqSsL0bxFgDjuiPiA7vKhZRm+IzcS17vRee3GNXr64UsesA5CAp9yTiIYw9A=="],
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.0", "", {}, "sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.162.0", "", {}, "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA=="],
 
@@ -2896,6 +2896,8 @@
 
     "@shumai/transcode/ulid": ["ulid@2.4.0", "", { "bin": { "ulid": "bin/cli.js" } }, "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg=="],
 
+    "@shumai/webui/@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.26", "", { "dependencies": { "@tanstack/virtual-core": "3.16.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-DosdgjOxCLahkn0o+ilmZYwEjo1glfMGuRT/j3PQ18yr5XqA8N/BCaL9IJ3B5TRl+nnzyK2IOFgAILwzN3a9xQ=="],
+
     "@shumai/webui/better-auth": ["better-auth@1.6.13", "", { "dependencies": { "@better-auth/core": "1.6.13", "@better-auth/drizzle-adapter": "1.6.13", "@better-auth/kysely-adapter": "1.6.13", "@better-auth/memory-adapter": "1.6.13", "@better-auth/mongo-adapter": "1.6.13", "@better-auth/prisma-adapter": "1.6.13", "@better-auth/telemetry": "1.6.13", "@better-auth/utils": "0.4.1", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.5", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.17 || ^0.29.0", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-jn8ATnGWDzMwpO4a/3iyW1/RayOF/aoPQOfAeqyCVnQCdqkaONVas9CjbY6PovMsTMa/MG+GRABySfzqtj5J/g=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
@@ -3199,6 +3201,8 @@
     "@radix-ui/react-tooltip/@radix-ui/react-presence/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-use-controllable-state/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
+
+    "@shumai/webui/@tanstack/react-virtual/@tanstack/virtual-core": ["@tanstack/virtual-core@3.16.0", "", {}, "sha512-Er2N7q3WOiH6y2JLxsxNX+u2/sLqSsL0bxFgDjuiPiA7vKhZRm+IzcS17vRee3GNXr64UsesA5CAp9yTiIYw9A=="],
 
     "@shumai/webui/better-auth/@better-auth/core": ["@better-auth/core@1.6.13", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.1", "@better-fetch/fetch": "1.1.21", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.5", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-3YNjiLUmlNt5T9qQ/weu0tZgGgXDSYax4EE/uLUBIBBGtQI9Q3KdEnO6tfPgDedborcSE1bIspuAIaHpaHwxZQ=="],
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "vite-tsconfig-paths": "^6.1.1"
   },
   "dependencies": {
-    "@tanstack/react-virtual": "^3.13.26",
+    "@tanstack/react-virtual": "^3.14.2",
     "jittered-fractional-indexing": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "vite-tsconfig-paths": "^6.1.1"
   },
   "dependencies": {
+    "@tanstack/react-virtual": "^3.13.26",
     "jittered-fractional-indexing": "^1.0.1"
   }
 }

--- a/packages/core/src/cache/lru-ttl-cache.test.ts
+++ b/packages/core/src/cache/lru-ttl-cache.test.ts
@@ -26,13 +26,13 @@ describe('LruTtlCache', () => {
     const cache = new LruTtlCache<string, string>(2)
     cache.set('key1', 'value1', 1000)
     cache.set('key2', 'value2', 1000)
-    
+
     // Access key1 to make it most recently used
     cache.get('key1')
-    
+
     // Add key3, which should evict key2 (the least recently used)
     cache.set('key3', 'value3', 1000)
-    
+
     expect(cache.get('key1')).toBe('value1')
     expect(cache.get('key2')).toBeUndefined()
     expect(cache.get('key3')).toBe('value3')
@@ -41,9 +41,9 @@ describe('LruTtlCache', () => {
   it('should return undefined for expired items', () => {
     const cache = new LruTtlCache<string, string>(10)
     cache.set('key1', 'value1', 1000)
-    
+
     vi.advanceTimersByTime(1001)
-    
+
     expect(cache.get('key1')).toBeUndefined()
     expect(cache.size).toBe(0)
   })
@@ -51,28 +51,28 @@ describe('LruTtlCache', () => {
   it('should proactively evict expired items on get', () => {
     const sampleSize = 5
     const cache = new LruTtlCache<string, string>(100, sampleSize)
-    
+
     // Set 10 items, all will expire
     for (let i = 0; i < 10; i++) {
       cache.set(`key${i}`, `value${i}`, 1000)
     }
-    
+
     // Add one item that stays valid
     cache.set('valid', 'validValue', 5000)
-    
+
     // Advance time so the 10 items expire
     vi.advanceTimersByTime(1001)
-    
+
     // Total size should still be 11 (lazy eviction)
     expect(cache.size).toBe(11)
-    
+
     // Call get on the valid item once. It should trigger one evictSample call.
     // evictSample will check 5 items.
     cache.get('valid')
-    
+
     // Size should now be 11 - 5 = 6
     expect(cache.size).toBe(6)
-    
+
     // Call get again, it should evict the remaining 5 expired items
     cache.get('valid')
     expect(cache.size).toBe(1)
@@ -82,23 +82,23 @@ describe('LruTtlCache', () => {
   it('should loop through the cache with proactive eviction', () => {
     // sampleSize = 3 to make sure we cover all items in one go or skip k3 correctly
     const cache = new LruTtlCache<string, string>(10, 3)
-    
+
     cache.set('k1', 'v1', 1000)
     cache.set('k2', 'v2', 1000)
     cache.set('k3', 'v3', 5000)
-    
+
     vi.advanceTimersByTime(1001)
-    
+
     // First get: evicts k1, k2. Checks k3 (not expired).
     cache.get('k3')
     expect(cache.size).toBe(1)
-    
+
     // Add more items
     cache.set('k4', 'v4', 1000)
     cache.set('k5', 'v5', 1000)
-    
+
     vi.advanceTimersByTime(1001)
-    
+
     // Second get: evicts k4, k5.
     cache.get('k3')
     expect(cache.size).toBe(1)
@@ -127,25 +127,25 @@ describe('LruTtlCache', () => {
     // This test addresses the user's specific request:
     // "add 100 keys to cache, do a evictSample, and remove 99 keys manually, and do evictSample again, see what happen"
     const cache = new LruTtlCache<number, number>(200, 10)
-    
+
     // Add 100 keys
     for (let i = 0; i < 100; i++) {
       cache.set(i, i, 10000)
     }
-    
+
     // Initial get to trigger evictSample and initialize the iterator
-    cache.get(999) 
-    
+    cache.get(999)
+
     // Remove 99 keys manually (leaving key 99)
     for (let i = 0; i < 99; i++) {
       cache.delete(i)
     }
     expect(cache.size).toBe(1)
-    
+
     // Advance time so the remaining key 99 would expire if it was checked
     vi.advanceTimersByTime(20000)
-    
-    // Call get. evictSample should run. 
+
+    // Call get. evictSample should run.
     // The iterator was pointing to something that was deleted.
     // It should proceed to the next available element (key 99) and evict it.
     cache.get(999)

--- a/packages/core/src/pagination.ts
+++ b/packages/core/src/pagination.ts
@@ -13,6 +13,7 @@ export interface PaginationParams {
 export interface PageInfo {
   total?: number
   cursor?: string
+  totalSize?: number
 }
 
 export interface PaginatedData<T> {

--- a/packages/core/src/search/ngram-search.test.ts
+++ b/packages/core/src/search/ngram-search.test.ts
@@ -224,8 +224,8 @@ describe('N-gram Search Integration', () => {
         conditions: [{ field: 'name', operator: 'contains', value: 'rareterm' }],
       })
 
-      // Verify probe and main query were executed
-      expect(queries).toHaveLength(2)
+      // Verify probe, main query, and sum query were executed
+      expect(queries).toHaveLength(3)
       // Check that main query used GIN index
       const mainQuery = queries.find((q) => q.includes('as "assetId"'))
       expect(mainQuery).toBeDefined()

--- a/packages/core/src/search/search.test.ts
+++ b/packages/core/src/search/search.test.ts
@@ -734,6 +734,70 @@ describe('SearchService', () => {
       mockExecuteWait.mockRestore()
     })
   })
+
+  describe('totalSize calculation', () => {
+    it('calculates the true total size of matching files when total count < 2000', async () => {
+      const { rootFolder } = await setupBasicAssets()
+
+      // Search files recursively
+      const resultRecursive = await searchService.search(rootFolder.id, {
+        recursively: true,
+        assetType: 'file',
+        operator: 'AND',
+        isSemantic: false,
+      })
+
+      expect(resultRecursive.pageInfo.total).toBe(2)
+      expect(resultRecursive.pageInfo.totalSize).toBe(300) // file1 (100) + file2 (200)
+
+      // Search files non-recursively
+      const resultNonRecursive = await searchService.search(rootFolder.id, {
+        recursively: false,
+        assetType: 'file',
+        operator: 'AND',
+        isSemantic: false,
+      })
+
+      expect(resultNonRecursive.pageInfo.total).toBe(1)
+      expect(resultNonRecursive.pageInfo.totalSize).toBe(100) // file1 (100)
+    })
+
+    it('returns -1 for totalSize when total count is >= 2000', async () => {
+      // Mock prismaClient.$queryRaw for the count query to return 2500
+      const mockPrisma = new Proxy(prisma, {
+        get(target, prop) {
+          if (prop === '$queryRaw') {
+            return async (prismaSql: unknown) => {
+              const sqlStr = (prismaSql as { text?: string })?.text || ''
+              if (sqlStr.includes('COUNT(*)')) {
+                return [{ count: 2500n }]
+              }
+              // For main query, just run it or return mock
+              return target.$queryRaw(prismaSql as any)
+            }
+          }
+          const val = Reflect.get(target, prop)
+          if (typeof val === 'function') {
+            return val.bind(target)
+          }
+          return val
+        },
+      })
+
+      const localSearchService = new SearchService(mockPrisma as any)
+      const { rootFolder } = await setupBasicAssets()
+
+      const result = await localSearchService.search(rootFolder.id, {
+        recursively: true,
+        assetType: 'file',
+        operator: 'AND',
+        isSemantic: false,
+      })
+
+      expect(result.pageInfo.total).toBe(2500)
+      expect(result.pageInfo.totalSize).toBe(-1)
+    })
+  })
 })
 
 describe('SearchService — natural sort by name', () => {

--- a/packages/core/src/search/search.test.ts
+++ b/packages/core/src/search/search.test.ts
@@ -741,6 +741,7 @@ describe('SearchService', () => {
 
       // Search files recursively
       const resultRecursive = await searchService.search(rootFolder.id, {
+        conditions: [],
         recursively: true,
         assetType: 'file',
         operator: 'AND',
@@ -752,6 +753,7 @@ describe('SearchService', () => {
 
       // Search files non-recursively
       const resultNonRecursive = await searchService.search(rootFolder.id, {
+        conditions: [],
         recursively: false,
         assetType: 'file',
         operator: 'AND',
@@ -773,6 +775,8 @@ describe('SearchService', () => {
                 return [{ count: 2500n }]
               }
               // For main query, just run it or return mock
+              // We must cast to any because we are proxying the raw sql parameter
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               return target.$queryRaw(prismaSql as any)
             }
           }
@@ -784,10 +788,14 @@ describe('SearchService', () => {
         },
       })
 
+      // We must cast mockPrisma proxy as any because the type signature of SearchService
+      // expects a full PrismaClient instance, whereas we only mocked $queryRaw.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const localSearchService = new SearchService(mockPrisma as any)
       const { rootFolder } = await setupBasicAssets()
 
       const result = await localSearchService.search(rootFolder.id, {
+        conditions: [],
         recursively: true,
         assetType: 'file',
         operator: 'AND',

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -191,7 +191,9 @@ export class SearchService {
 
       if (totalCount < 2000) {
         countBuilder.select(Prisma.sql`SUM(COALESCE(a.size_byte, 0))::bigint as sum`)
-        const sumRes = await this.prismaClient.$queryRaw<{ sum: bigint | null }[]>(countBuilder.build())
+        const sumRes = await this.prismaClient.$queryRaw<{ sum: bigint | null }[]>(
+          countBuilder.build(),
+        )
         pageInfo.totalSize = Number(sumRes[0]?.sum || 0)
       } else {
         pageInfo.totalSize = -1
@@ -380,7 +382,9 @@ export class SearchService {
 
       if (totalCount < 2000) {
         countBuilder.select(Prisma.sql`SUM(COALESCE(a.size_byte, 0))::bigint as sum`)
-        const sumRes = await this.prismaClient.$queryRaw<{ sum: bigint | null }[]>(countBuilder.build())
+        const sumRes = await this.prismaClient.$queryRaw<{ sum: bigint | null }[]>(
+          countBuilder.build(),
+        )
         pageInfo.totalSize = Number(sumRes[0]?.sum || 0)
       } else {
         pageInfo.totalSize = -1
@@ -413,7 +417,9 @@ export class SearchService {
           countBuilder.addWhere(Prisma.sql`a.name ILIKE ${'%' + valStr + '%'}`)
         }
 
-        const sumRes = await this.prismaClient.$queryRaw<{ sum: bigint | null }[]>(countBuilder.build())
+        const sumRes = await this.prismaClient.$queryRaw<{ sum: bigint | null }[]>(
+          countBuilder.build(),
+        )
         pageInfo.totalSize = Number(sumRes[0]?.sum || 0)
       } else {
         pageInfo.totalSize = -1

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -186,7 +186,16 @@ export class SearchService {
       }
 
       const countRes = await this.prismaClient.$queryRaw<{ count: bigint }[]>(countBuilder.build())
-      pageInfo.total = Number(countRes[0]?.count || 0)
+      const totalCount = Number(countRes[0]?.count || 0)
+      pageInfo.total = totalCount
+
+      if (totalCount < 2000) {
+        countBuilder.select(Prisma.sql`SUM(COALESCE(a.size_byte, 0))::bigint as sum`)
+        const sumRes = await this.prismaClient.$queryRaw<{ sum: bigint | null }[]>(countBuilder.build())
+        pageInfo.totalSize = Number(sumRes[0]?.sum || 0)
+      } else {
+        pageInfo.totalSize = -1
+      }
 
       if (hasNextPage) {
         pageInfo.cursor = encodeCursor(offset + limit)
@@ -338,9 +347,8 @@ export class SearchService {
     }
 
     const pageInfo: PageInfo = {}
-    if (countOverride !== undefined) {
-      pageInfo.total = countOverride
-    } else {
+    let totalCount = countOverride
+    if (totalCount === undefined) {
       const countBuilder = new SqlQueryBuilder()
         .select(Prisma.sql`COUNT(*)`)
         .from(Prisma.sql`assets a`)
@@ -367,7 +375,49 @@ export class SearchService {
       }
 
       const countRes = await this.prismaClient.$queryRaw<{ count: bigint }[]>(countBuilder.build())
-      pageInfo.total = Number(countRes[0]?.count || 0)
+      totalCount = Number(countRes[0]?.count || 0)
+      pageInfo.total = totalCount
+
+      if (totalCount < 2000) {
+        countBuilder.select(Prisma.sql`SUM(COALESCE(a.size_byte, 0))::bigint as sum`)
+        const sumRes = await this.prismaClient.$queryRaw<{ sum: bigint | null }[]>(countBuilder.build())
+        pageInfo.totalSize = Number(sumRes[0]?.sum || 0)
+      } else {
+        pageInfo.totalSize = -1
+      }
+    } else {
+      pageInfo.total = totalCount
+      if (totalCount < 2000) {
+        const countBuilder = new SqlQueryBuilder()
+          .select(Prisma.sql`SUM(COALESCE(a.size_byte, 0))::bigint as sum`)
+          .from(Prisma.sql`assets a`)
+          .addWhere(Prisma.sql`a.is_deleted = false`)
+
+        if (targetFolderIds.length > 0) {
+          countBuilder.addWhere(Prisma.sql`a.parent_id = ANY(${targetFolderIds})`)
+        }
+
+        if (req.showSymlink) {
+          countBuilder.addWhere(Prisma.sql`
+            (a.type = ANY(${targetTypes}::"AssetType"[]) OR (a.type = 'symlink' AND a.target_id IN (SELECT id FROM assets WHERE type = ANY(${targetTypes}::"AssetType"[]))))
+          `)
+        } else {
+          countBuilder.addWhere(Prisma.sql`a.type = ANY(${targetTypes}::"AssetType"[])`)
+        }
+
+        if (req.conditions && req.conditions.length > 0) {
+          countBuilder.addSearchConditions(req.operator, req.conditions, { skipNameContains: true })
+        }
+
+        if (nameCond) {
+          countBuilder.addWhere(Prisma.sql`a.name ILIKE ${'%' + valStr + '%'}`)
+        }
+
+        const sumRes = await this.prismaClient.$queryRaw<{ sum: bigint | null }[]>(countBuilder.build())
+        pageInfo.totalSize = Number(sumRes[0]?.sum || 0)
+      } else {
+        pageInfo.totalSize = -1
+      }
     }
 
     if (hasNextPage) {

--- a/packages/dtos/src/pagination.ts
+++ b/packages/dtos/src/pagination.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 export const paginationPageInfoSchema = z.object({
   cursor: z.string().optional(),
   total: z.number().optional(),
+  totalSize: z.number().optional(),
 })
 
 export type PaginationPageInfo = z.infer<typeof paginationPageInfoSchema>

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -824,7 +824,6 @@ export function FileBrowser({
                   handleEmptyAreaClick={handleEmptyAreaClick}
                   dragState={dragState}
                   sort={sort}
-                  scrollContainerRef={scrollContainerRef}
                 />
               ) : (
                 <FileBrowserGridView

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -48,6 +48,8 @@ interface FileBrowserProps {
   files: AssetInfo[]
   totalFolders?: number
   totalFiles?: number
+  totalFoldersSize?: number
+  totalFilesSize?: number
   selectedItem: AssetInfo | null
   selectedIds: Set<string>
   onItemSelect: (item: AssetInfo, event: React.MouseEvent) => void
@@ -92,6 +94,8 @@ export function FileBrowser({
   files,
   totalFolders,
   totalFiles,
+  totalFoldersSize,
+  totalFilesSize,
   selectedItem,
   selectedIds,
   onItemSelect,
@@ -795,6 +799,8 @@ export function FileBrowser({
                   files={displayedFiles}
                   totalFolders={totalFolders}
                   totalFiles={totalFiles}
+                  totalFoldersSize={totalFoldersSize}
+                  totalFilesSize={totalFilesSize}
                   selectedItem={selectedItem}
                   selectedIds={selectedIds}
                   displayedFields={displayedFields}
@@ -826,6 +832,8 @@ export function FileBrowser({
                   files={displayedFiles}
                   totalFolders={totalFolders}
                   totalFiles={totalFiles}
+                  totalFoldersSize={totalFoldersSize}
+                  totalFilesSize={totalFilesSize}
                   renderItem={renderItem}
                   foldersExpanded={foldersExpanded}
                   setFoldersExpanded={setFoldersExpanded}

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -15,7 +15,6 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import { Download } from 'lucide-react'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useInView } from 'react-intersection-observer'
 import { toast } from 'sonner'
 import type { DragState } from '../dnd-types'
 import { MoveCopyDialog } from '../move-copy-dialog'
@@ -419,21 +418,6 @@ export function FileBrowser({
 
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
-  const { ref: foldersRef, inView: foldersInView } = useInView()
-  const { ref: filesRef, inView: filesInView } = useInView()
-
-  useEffect(() => {
-    if (foldersInView && hasNextFoldersPage && !isFetchingNextFoldersPage) {
-      fetchNextFoldersPage()
-    }
-  }, [foldersInView, hasNextFoldersPage, isFetchingNextFoldersPage, fetchNextFoldersPage])
-
-  useEffect(() => {
-    if (filesInView && hasNextFilesPage && !isFetchingNextFilesPage) {
-      fetchNextFilesPage()
-    }
-  }, [filesInView, hasNextFilesPage, isFetchingNextFilesPage, fetchNextFilesPage])
-
   const foldersSize = folders.reduce((acc, f) => acc + (f.sizeByte || 0), 0)
   const filesSize = displayedFiles.reduce((acc, f) => acc + (f.sizeByte || 0), 0)
 
@@ -821,10 +805,10 @@ export function FileBrowser({
                   setFoldersExpanded={setFoldersExpanded}
                   filesExpanded={filesExpanded}
                   setFilesExpanded={setFilesExpanded}
-                  foldersRef={foldersRef}
-                  filesRef={filesRef}
                   hasNextFoldersPage={hasNextFoldersPage}
                   hasNextFilesPage={hasNextFilesPage}
+                  fetchNextFoldersPage={fetchNextFoldersPage}
+                  fetchNextFilesPage={fetchNextFilesPage}
                   formatCount={formatCount}
                   formatSize={formatSize}
                   foldersSize={foldersSize}
@@ -832,6 +816,7 @@ export function FileBrowser({
                   handleEmptyAreaClick={handleEmptyAreaClick}
                   dragState={dragState}
                   sort={sort}
+                  scrollContainerRef={scrollContainerRef}
                 />
               ) : (
                 <FileBrowserGridView
@@ -844,10 +829,10 @@ export function FileBrowser({
                   setFoldersExpanded={setFoldersExpanded}
                   filesExpanded={filesExpanded}
                   setFilesExpanded={setFilesExpanded}
-                  foldersRef={foldersRef}
-                  filesRef={filesRef}
                   hasNextFoldersPage={hasNextFoldersPage}
                   hasNextFilesPage={hasNextFilesPage}
+                  fetchNextFoldersPage={fetchNextFoldersPage}
+                  fetchNextFilesPage={fetchNextFilesPage}
                   formatCount={formatCount}
                   formatSize={formatSize}
                   foldersSize={foldersSize}
@@ -855,6 +840,7 @@ export function FileBrowser({
                   handleEmptyAreaClick={handleEmptyAreaClick}
                   dragState={dragState}
                   sort={sort}
+                  scrollContainerRef={scrollContainerRef}
                 />
               )}
 

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -807,6 +807,8 @@ export function FileBrowser({
                   setFilesExpanded={setFilesExpanded}
                   hasNextFoldersPage={hasNextFoldersPage}
                   hasNextFilesPage={hasNextFilesPage}
+                  isFetchingNextFoldersPage={isFetchingNextFoldersPage}
+                  isFetchingNextFilesPage={isFetchingNextFilesPage}
                   fetchNextFoldersPage={fetchNextFoldersPage}
                   fetchNextFilesPage={fetchNextFilesPage}
                   formatCount={formatCount}
@@ -831,6 +833,8 @@ export function FileBrowser({
                   setFilesExpanded={setFilesExpanded}
                   hasNextFoldersPage={hasNextFoldersPage}
                   hasNextFilesPage={hasNextFilesPage}
+                  isFetchingNextFoldersPage={isFetchingNextFoldersPage}
+                  isFetchingNextFilesPage={isFetchingNextFilesPage}
                   fetchNextFoldersPage={fetchNextFoldersPage}
                   fetchNextFilesPage={fetchNextFilesPage}
                   formatCount={formatCount}

--- a/packages/webui/components/file-browser/file-list-item.tsx
+++ b/packages/webui/components/file-browser/file-list-item.tsx
@@ -163,7 +163,7 @@ export function FileListItem({
   }
 
   return (
-    <tr
+    <div
       ref={setDraggableRef}
       style={{ opacity }}
       onClick={handleClick}
@@ -174,11 +174,11 @@ export function FileListItem({
           e.preventDefault()
         }
       }}
-      className="group cursor-pointer select-none transition-colors whitespace-nowrap"
+      className="group cursor-pointer select-none transition-colors whitespace-nowrap flex w-full"
     >
-      <td
+      <div
         className={cn(
-          'px-4 py-2 sticky left-0 z-10 transition-colors border-r',
+          'px-4 py-2 sticky left-0 z-10 transition-colors border-r shrink-0',
           isSelected ? 'bg-muted' : 'bg-card group-hover:bg-muted',
         )}
         style={{
@@ -232,24 +232,24 @@ export function FileListItem({
             </Badge>
           )}
         </div>
-      </td>
-      <td
-        className="px-4 py-2 text-sm text-muted-foreground truncate"
+      </div>
+      <div
+        className="px-4 py-2 text-sm text-muted-foreground truncate border-r shrink-0 flex items-center"
         style={{
           width: columnSizing?.['size'] || 100,
           minWidth: columnSizing?.['size'] || 100,
         }}
       >
         {displayItem.type === 'folder' ? '-' : formatSize(displayItem.sizeByte)}
-      </td>
-      <td
-        className="px-4 py-2"
+      </div>
+      <div
+        className="px-4 py-2 border-r shrink-0 flex items-center"
         style={{
           width: columnSizing?.['modified'] || 200,
           minWidth: columnSizing?.['modified'] || 200,
         }}
       >
-        <div className="flex items-center justify-between overflow-hidden">
+        <div className="flex items-center justify-between overflow-hidden w-full">
           <span className="text-sm text-muted-foreground truncate">
             {formatDate(displayItem.updatedAt)}
           </span>
@@ -270,12 +270,12 @@ export function FileListItem({
             <MoreVertical className="h-4 w-4 text-muted-foreground hover:text-foreground" />
           </button>
         </div>
-      </td>
+      </div>
       {displayItem.type === 'file' &&
         fields.map((field) => (
-          <td
+          <div
             key={field.id}
-            className="px-4 py-2 truncate"
+            className="px-4 py-2 truncate border-r shrink-0 flex items-center"
             style={{
               width: columnSizing?.[field.id!] || 150,
               minWidth: columnSizing?.[field.id!] || 150,
@@ -287,8 +287,8 @@ export function FileListItem({
               onSave={canEdit ? (val) => onSaveField(field.id!, val) : undefined}
               readOnly={field.readOnly || !canEdit}
             />
-          </td>
+          </div>
         ))}
-    </tr>
+    </div>
   )
 }

--- a/packages/webui/components/file-browser/grid-view.tsx
+++ b/packages/webui/components/file-browser/grid-view.tsx
@@ -176,23 +176,21 @@ export function FileBrowserGridView({
     for (const virtualItem of virtualItems) {
       const row = rows[virtualItem.index]
       if (row?.type === 'row') {
-        if (row.kind === 'folder') {
-          const lastIndex = (row.rowIndex + 1) * cols
-          if (
-            lastIndex >= folders.length - cols * 2 &&
-            hasNextFoldersPage &&
-            !isFetchingNextFoldersPage
-          ) {
+        const isFolder = row.kind === 'folder'
+        const dataList = isFolder ? folders : files
+        const startIndex = row.rowIndex * cols
+        const isSkeleton = !dataList[startIndex] // Check if the first item in row is loaded
+        const isNearEnd = startIndex >= dataList.length - cols * 3
+
+        if (isFolder && hasNextFoldersPage && !isFetchingNextFoldersPage) {
+          if (isSkeleton || isNearEnd) {
             fetchNextFoldersPage()
+            break
           }
-        } else if (row.kind === 'file') {
-          const lastIndex = (row.rowIndex + 1) * cols
-          if (
-            lastIndex >= files.length - cols * 2 &&
-            hasNextFilesPage &&
-            !isFetchingNextFilesPage
-          ) {
+        } else if (!isFolder && hasNextFilesPage && !isFetchingNextFilesPage) {
+          if (isSkeleton || isNearEnd) {
             fetchNextFilesPage()
+            break
           }
         }
       }

--- a/packages/webui/components/file-browser/grid-view.tsx
+++ b/packages/webui/components/file-browser/grid-view.tsx
@@ -261,7 +261,8 @@ export function FileBrowserGridView({
                     <ChevronRight className="h-4 w-4" />
                   )}
                   <span>
-                    {formatCount(count, !isFolder)}{showSize ? ` • ${formatSize(size)}` : ''}
+                    {formatCount(count, !isFolder)}
+                    {showSize ? ` • ${formatSize(size)}` : ''}
                   </span>
                 </button>
               </div>

--- a/packages/webui/components/file-browser/grid-view.tsx
+++ b/packages/webui/components/file-browser/grid-view.tsx
@@ -219,6 +219,7 @@ export function FileBrowserGridView({
               <div
                 key={`header-${row.kind}`}
                 ref={rowVirtualizer.measureElement}
+                data-index={virtualRow.index}
                 className="absolute top-0 left-0 w-full z-10 bg-background"
                 style={{
                   transform: `translateY(${virtualRow.start}px)`,
@@ -256,6 +257,7 @@ export function FileBrowserGridView({
             <div
               key={`row-${row.kind}-${row.rowIndex}`}
               ref={rowVirtualizer.measureElement}
+              data-index={virtualRow.index}
               className="absolute top-0 left-0 w-full grid gap-4"
               style={{
                 transform: `translateY(${virtualRow.start}px)`,

--- a/packages/webui/components/file-browser/grid-view.tsx
+++ b/packages/webui/components/file-browser/grid-view.tsx
@@ -81,6 +81,8 @@ interface FileBrowserGridViewProps {
   formatSize: (bytes: number) => string
   foldersSize: number
   filesSize: number
+  totalFoldersSize?: number
+  totalFilesSize?: number
   handleEmptyAreaClick: (e: React.MouseEvent) => void
   dragState?: DragState
   sort?: SearchSort
@@ -105,8 +107,8 @@ export function FileBrowserGridView({
   fetchNextFilesPage,
   formatCount,
   formatSize,
-  foldersSize,
-  filesSize,
+  totalFoldersSize,
+  totalFilesSize,
   handleEmptyAreaClick,
   dragState,
   sort,
@@ -139,22 +141,26 @@ export function FileBrowserGridView({
     )[] = []
 
     // Folders
-    list.push({ type: 'header', kind: 'folder' })
-    if (foldersExpanded) {
-      const count = totalFolders ?? folders.length
-      const rowCount = Math.ceil(count / cols)
-      for (let i = 0; i < rowCount; i++) {
-        list.push({ type: 'row', kind: 'folder', rowIndex: i })
+    const foldersCount = totalFolders ?? folders.length
+    if (foldersCount > 0) {
+      list.push({ type: 'header', kind: 'folder' })
+      if (foldersExpanded) {
+        const rowCount = Math.ceil(foldersCount / cols)
+        for (let i = 0; i < rowCount; i++) {
+          list.push({ type: 'row', kind: 'folder', rowIndex: i })
+        }
       }
     }
 
     // Files
-    list.push({ type: 'header', kind: 'file' })
-    if (filesExpanded) {
-      const count = totalFiles ?? files.length
-      const rowCount = Math.ceil(count / cols)
-      for (let i = 0; i < rowCount; i++) {
-        list.push({ type: 'row', kind: 'file', rowIndex: i })
+    const filesCount = totalFiles ?? files.length
+    if (filesCount > 0) {
+      list.push({ type: 'header', kind: 'file' })
+      if (filesExpanded) {
+        const rowCount = Math.ceil(filesCount / cols)
+        for (let i = 0; i < rowCount; i++) {
+          list.push({ type: 'row', kind: 'file', rowIndex: i })
+        }
       }
     }
 
@@ -167,6 +173,10 @@ export function FileBrowserGridView({
     estimateSize: (index) => (rows[index]?.type === 'header' ? 40 : 200),
     overscan: 5,
   })
+
+  useEffect(() => {
+    rowVirtualizer.measure()
+  }, [folders.length, files.length, foldersExpanded, filesExpanded, cols, rowVirtualizer])
 
   const virtualItems = rowVirtualizer.getVirtualItems()
 
@@ -223,7 +233,8 @@ export function FileBrowserGridView({
           if (row.type === 'header') {
             const isFolder = row.kind === 'folder'
             const count = isFolder ? (totalFolders ?? folders.length) : (totalFiles ?? files.length)
-            const size = isFolder ? foldersSize : filesSize
+            const size = isFolder ? (totalFoldersSize ?? -1) : (totalFilesSize ?? -1)
+            const showSize = size > -1
             const expanded = isFolder ? foldersExpanded : filesExpanded
             const setExpanded = isFolder ? setFoldersExpanded : setFilesExpanded
 
@@ -250,7 +261,7 @@ export function FileBrowserGridView({
                     <ChevronRight className="h-4 w-4" />
                   )}
                   <span>
-                    {formatCount(count, !isFolder)} • {formatSize(size)}
+                    {formatCount(count, !isFolder)}{showSize ? ` • ${formatSize(size)}` : ''}
                   </span>
                 </button>
               </div>

--- a/packages/webui/components/file-browser/grid-view.tsx
+++ b/packages/webui/components/file-browser/grid-view.tsx
@@ -73,6 +73,8 @@ interface FileBrowserGridViewProps {
   setFilesExpanded: (expanded: boolean) => void
   hasNextFoldersPage: boolean
   hasNextFilesPage: boolean
+  isFetchingNextFoldersPage: boolean
+  isFetchingNextFilesPage: boolean
   fetchNextFoldersPage: () => void
   fetchNextFilesPage: () => void
   formatCount: (count: number, isFile: boolean) => string
@@ -97,6 +99,8 @@ export function FileBrowserGridView({
   setFilesExpanded,
   hasNextFoldersPage,
   hasNextFilesPage,
+  isFetchingNextFoldersPage,
+  isFetchingNextFilesPage,
   fetchNextFoldersPage,
   fetchNextFilesPage,
   formatCount,
@@ -169,19 +173,27 @@ export function FileBrowserGridView({
   useEffect(() => {
     if (virtualItems.length === 0) return
 
-    const lastItem = virtualItems[virtualItems.length - 1]
-    const row = rows[lastItem.index]
-
-    if (row.type === 'row') {
-      if (row.kind === 'folder') {
-        const lastIndex = (row.rowIndex + 1) * cols
-        if (lastIndex >= folders.length - cols * 2 && hasNextFoldersPage) {
-          fetchNextFoldersPage()
-        }
-      } else if (row.kind === 'file') {
-        const lastIndex = (row.rowIndex + 1) * cols
-        if (lastIndex >= files.length - cols * 2 && hasNextFilesPage) {
-          fetchNextFilesPage()
+    for (const virtualItem of virtualItems) {
+      const row = rows[virtualItem.index]
+      if (row?.type === 'row') {
+        if (row.kind === 'folder') {
+          const lastIndex = (row.rowIndex + 1) * cols
+          if (
+            lastIndex >= folders.length - cols * 2 &&
+            hasNextFoldersPage &&
+            !isFetchingNextFoldersPage
+          ) {
+            fetchNextFoldersPage()
+          }
+        } else if (row.kind === 'file') {
+          const lastIndex = (row.rowIndex + 1) * cols
+          if (
+            lastIndex >= files.length - cols * 2 &&
+            hasNextFilesPage &&
+            !isFetchingNextFilesPage
+          ) {
+            fetchNextFilesPage()
+          }
         }
       }
     }
@@ -192,6 +204,8 @@ export function FileBrowserGridView({
     files.length,
     hasNextFoldersPage,
     hasNextFilesPage,
+    isFetchingNextFoldersPage,
+    isFetchingNextFilesPage,
     fetchNextFoldersPage,
     fetchNextFilesPage,
     cols,

--- a/packages/webui/components/file-browser/grid-view.tsx
+++ b/packages/webui/components/file-browser/grid-view.tsx
@@ -3,8 +3,9 @@
 import type { AssetInfo } from '@shumai/dtos'
 import type { SearchSort } from '@shumai/dtos'
 import { useDroppable } from '@dnd-kit/react'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import { ChevronDown, ChevronRight } from 'lucide-react'
-import React from 'react'
+import React, { useMemo, useState, useEffect, useRef } from 'react'
 import { cn } from '../../lib/utils'
 import type { DragState } from '../dnd-types'
 
@@ -47,13 +48,6 @@ function ReorderIndicator({
       className={cn(
         'absolute top-0 bottom-0 w-4 flex-shrink-0 flex items-center justify-center pointer-events-auto z-50',
         position === 'before' ? '-left-2 -translate-x-1/2' : '-right-2 translate-x-1/2',
-        position === 'before' && [
-          'hidden',
-          'max-md:[.group-reorder:nth-child(2n+1)_&]:flex',
-          'md:max-lg:[.group-reorder:nth-child(3n+1)_&]:flex',
-          'lg:max-xl:[.group-reorder:nth-child(4n+1)_&]:flex',
-          'xl:[.group-reorder:nth-child(5n+1)_&]:flex',
-        ],
         className,
       )}
     >
@@ -77,10 +71,10 @@ interface FileBrowserGridViewProps {
   setFoldersExpanded: (expanded: boolean) => void
   filesExpanded: boolean
   setFilesExpanded: (expanded: boolean) => void
-  foldersRef: (node?: Element | null) => void
-  filesRef: (node?: Element | null) => void
   hasNextFoldersPage: boolean
   hasNextFilesPage: boolean
+  fetchNextFoldersPage: () => void
+  fetchNextFilesPage: () => void
   formatCount: (count: number, isFile: boolean) => string
   formatSize: (bytes: number) => string
   foldersSize: number
@@ -88,6 +82,7 @@ interface FileBrowserGridViewProps {
   handleEmptyAreaClick: (e: React.MouseEvent) => void
   dragState?: DragState
   sort?: SearchSort
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>
 }
 
 export function FileBrowserGridView({
@@ -100,10 +95,10 @@ export function FileBrowserGridView({
   setFoldersExpanded,
   filesExpanded,
   setFilesExpanded,
-  foldersRef,
-  filesRef,
   hasNextFoldersPage,
   hasNextFilesPage,
+  fetchNextFoldersPage,
+  fetchNextFilesPage,
   formatCount,
   formatSize,
   foldersSize,
@@ -111,78 +106,183 @@ export function FileBrowserGridView({
   handleEmptyAreaClick,
   dragState,
   sort,
+  scrollContainerRef,
 }: FileBrowserGridViewProps) {
-  return (
-    <div className="flex-1 p-4" onClick={handleEmptyAreaClick}>
-      {folders.length > 0 && (
-        <div className="mb-8">
-          <button
-            onClick={() => setFoldersExpanded(!foldersExpanded)}
-            className="mb-3 flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
-          >
-            {foldersExpanded ? (
-              <ChevronDown className="h-4 w-4" />
-            ) : (
-              <ChevronRight className="h-4 w-4" />
-            )}
-            <span>
-              {formatCount(totalFolders ?? folders.length, false)} • {formatSize(foldersSize)}
-            </span>
-          </button>
-          {foldersExpanded && (
-            <>
-              <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
-                {folders.map((item, index) => (
-                  <div key={item.id} className="group-reorder relative flex">
-                    <ReorderIndicator
-                      id={`reorder-before-folder-${item.id}`}
-                      item={item}
-                      position="before"
-                      active={sort?.field === 'custom'}
-                      dragState={dragState}
-                    />
-                    <div className="flex-1 min-w-0">{renderItem(item)}</div>
-                    <ReorderIndicator
-                      id={`reorder-after-folder-${item.id}`}
-                      item={item}
-                      position="after"
-                      active={sort?.field === 'custom'}
-                      dragState={dragState}
-                      isNextItemDragging={
-                        folders[index + 1] && dragState?.draggedIds.has(folders[index + 1].id!)
-                      }
-                    />
-                  </div>
-                ))}
-              </div>
-              {hasNextFoldersPage && <div ref={foldersRef} className="h-1" />}
-            </>
-          )}
-        </div>
-      )}
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [cols, setCols] = useState(5)
 
-      {files.length > 0 && (
-        <div>
-          <button
-            onClick={() => setFilesExpanded(!filesExpanded)}
-            className="mb-3 flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
-          >
-            {filesExpanded ? (
-              <ChevronDown className="h-4 w-4" />
-            ) : (
-              <ChevronRight className="h-4 w-4" />
-            )}
-            <span>
-              {formatCount(totalFiles ?? files.length, true)} • {formatSize(filesSize)}
-            </span>
-          </button>
-          {filesExpanded && (
-            <>
-              <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
-                {files.map((item, index) => (
+  useEffect(() => {
+    const updateCols = () => {
+      if (!containerRef.current) return
+      const width = containerRef.current.offsetWidth
+      if (width < 640) setCols(2)
+      else if (width < 768) setCols(2)
+      else if (width < 1024) setCols(3)
+      else if (width < 1280) setCols(4)
+      else setCols(5)
+    }
+
+    updateCols()
+    const observer = new ResizeObserver(updateCols)
+    if (containerRef.current) observer.observe(containerRef.current)
+    return () => observer.disconnect()
+  }, [])
+
+  const rows = useMemo(() => {
+    const list: (
+      | { type: 'header'; kind: 'folder' | 'file' }
+      | { type: 'row'; kind: 'folder' | 'file'; rowIndex: number }
+    )[] = []
+
+    // Folders
+    list.push({ type: 'header', kind: 'folder' })
+    if (foldersExpanded) {
+      const count = totalFolders ?? folders.length
+      const rowCount = Math.ceil(count / cols)
+      for (let i = 0; i < rowCount; i++) {
+        list.push({ type: 'row', kind: 'folder', rowIndex: i })
+      }
+    }
+
+    // Files
+    list.push({ type: 'header', kind: 'file' })
+    if (filesExpanded) {
+      const count = totalFiles ?? files.length
+      const rowCount = Math.ceil(count / cols)
+      for (let i = 0; i < rowCount; i++) {
+        list.push({ type: 'row', kind: 'file', rowIndex: i })
+      }
+    }
+
+    return list
+  }, [foldersExpanded, filesExpanded, folders.length, files.length, totalFolders, totalFiles, cols])
+
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: (index) => (rows[index]?.type === 'header' ? 40 : 200),
+    overscan: 5,
+  })
+
+  const virtualItems = rowVirtualizer.getVirtualItems()
+
+  useEffect(() => {
+    if (virtualItems.length === 0) return
+
+    const lastItem = virtualItems[virtualItems.length - 1]
+    const row = rows[lastItem.index]
+
+    if (row.type === 'row') {
+      if (row.kind === 'folder') {
+        const lastIndex = (row.rowIndex + 1) * cols
+        if (lastIndex >= folders.length - cols * 2 && hasNextFoldersPage) {
+          fetchNextFoldersPage()
+        }
+      } else if (row.kind === 'file') {
+        const lastIndex = (row.rowIndex + 1) * cols
+        if (lastIndex >= files.length - cols * 2 && hasNextFilesPage) {
+          fetchNextFilesPage()
+        }
+      }
+    }
+  }, [
+    virtualItems,
+    rows,
+    folders.length,
+    files.length,
+    hasNextFoldersPage,
+    hasNextFilesPage,
+    fetchNextFoldersPage,
+    fetchNextFilesPage,
+    cols,
+  ])
+
+  return (
+    <div ref={containerRef} className="flex-1 p-4 relative" onClick={handleEmptyAreaClick}>
+      <div
+        className="relative w-full"
+        style={{
+          height: `${rowVirtualizer.getTotalSize()}px`,
+        }}
+      >
+        {virtualItems.map((virtualRow) => {
+          const row = rows[virtualRow.index]
+
+          if (row.type === 'header') {
+            const isFolder = row.kind === 'folder'
+            const count = isFolder ? (totalFolders ?? folders.length) : (totalFiles ?? files.length)
+            const size = isFolder ? foldersSize : filesSize
+            const expanded = isFolder ? foldersExpanded : filesExpanded
+            const setExpanded = isFolder ? setFoldersExpanded : setFilesExpanded
+
+            return (
+              <div
+                key={`header-${row.kind}`}
+                ref={rowVirtualizer.measureElement}
+                className="absolute top-0 left-0 w-full z-10 bg-background"
+                style={{
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              >
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setExpanded(!expanded)
+                  }}
+                  className="mb-3 flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+                >
+                  {expanded ? (
+                    <ChevronDown className="h-4 w-4" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4" />
+                  )}
+                  <span>
+                    {formatCount(count, !isFolder)} • {formatSize(size)}
+                  </span>
+                </button>
+              </div>
+            )
+          }
+
+          const isFolder = row.kind === 'folder'
+          const dataList = isFolder ? folders : files
+          const startIndex = row.rowIndex * cols
+          const rowItems = []
+          for (let i = 0; i < cols; i++) {
+            rowItems.push(dataList[startIndex + i])
+          }
+
+          return (
+            <div
+              key={`row-${row.kind}-${row.rowIndex}`}
+              ref={rowVirtualizer.measureElement}
+              className="absolute top-0 left-0 w-full grid gap-4"
+              style={{
+                transform: `translateY(${virtualRow.start}px)`,
+                gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+              }}
+            >
+              {rowItems.map((item, i) => {
+                const itemIndex = startIndex + i
+                if (!item) {
+                  const totalCount = isFolder
+                    ? (totalFolders ?? folders.length)
+                    : (totalFiles ?? files.length)
+                  if (itemIndex < totalCount) {
+                    return (
+                      <div
+                        key={`skeleton-${itemIndex}`}
+                        className="aspect-square bg-muted animate-pulse rounded-lg"
+                      />
+                    )
+                  }
+                  return <div key={`empty-${itemIndex}`} />
+                }
+
+                return (
                   <div key={item.id} className="group-reorder relative flex">
                     <ReorderIndicator
-                      id={`reorder-before-file-${item.id}`}
+                      id={`reorder-before-${row.kind}-${item.id}`}
                       item={item}
                       position="before"
                       active={sort?.field === 'custom'}
@@ -190,23 +290,23 @@ export function FileBrowserGridView({
                     />
                     <div className="flex-1 min-w-0">{renderItem(item)}</div>
                     <ReorderIndicator
-                      id={`reorder-after-file-${item.id}`}
+                      id={`reorder-after-${row.kind}-${item.id}`}
                       item={item}
                       position="after"
                       active={sort?.field === 'custom'}
                       dragState={dragState}
                       isNextItemDragging={
-                        files[index + 1] && dragState?.draggedIds.has(files[index + 1].id!)
+                        dataList[itemIndex + 1] &&
+                        dragState?.draggedIds.has(dataList[itemIndex + 1].id!)
                       }
                     />
                   </div>
-                ))}
-              </div>
-              {hasNextFilesPage && <div ref={filesRef} className="h-1" />}
-            </>
-          )}
-        </div>
-      )}
+                )
+              })}
+            </div>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/packages/webui/components/file-browser/grid-view.tsx
+++ b/packages/webui/components/file-browser/grid-view.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import type { AssetInfo } from '@shumai/dtos'
-import type { SearchSort } from '@shumai/dtos'
 import { useDroppable } from '@dnd-kit/react'
+import type { AssetInfo, SearchSort } from '@shumai/dtos'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { ChevronDown, ChevronRight } from 'lucide-react'
-import React, { useMemo, useState, useEffect, useRef } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { cn } from '../../lib/utils'
 import type { DragState } from '../dnd-types'
 
@@ -170,13 +169,20 @@ export function FileBrowserGridView({
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => scrollContainerRef.current,
-    estimateSize: (index) => (rows[index]?.type === 'header' ? 40 : 200),
+    estimateSize: (index) => (rows[index]?.type === 'header' ? 40 : 350),
+    getItemKey: React.useCallback(
+      (index: number) => {
+        const row = rows[index]
+        if (!row) return index
+        if (row.type === 'header') {
+          return `header-${row.kind}`
+        }
+        return `row-${row.kind}-${row.rowIndex}`
+      },
+      [rows],
+    ),
     overscan: 5,
   })
-
-  useEffect(() => {
-    rowVirtualizer.measure()
-  }, [folders.length, files.length, foldersExpanded, filesExpanded, cols, rowVirtualizer])
 
   const virtualItems = rowVirtualizer.getVirtualItems()
 
@@ -306,7 +312,7 @@ export function FileBrowserGridView({
                 }
 
                 return (
-                  <div key={item.id} className="group-reorder relative flex">
+                  <div key={item.id} className="group-reorder relative flex pb-10">
                     <ReorderIndicator
                       id={`reorder-before-${row.kind}-${item.id}`}
                       item={item}

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -131,6 +131,8 @@ interface FileBrowserListViewProps {
   setFilesExpanded: (expanded: boolean) => void
   hasNextFoldersPage: boolean
   hasNextFilesPage: boolean
+  isFetchingNextFoldersPage: boolean
+  isFetchingNextFilesPage: boolean
   fetchNextFoldersPage: () => void
   fetchNextFilesPage: () => void
   formatCount: (count: number, isFile: boolean) => string
@@ -158,6 +160,8 @@ export function FileBrowserListView({
   setFilesExpanded,
   hasNextFoldersPage,
   hasNextFilesPage,
+  isFetchingNextFoldersPage,
+  isFetchingNextFilesPage,
   fetchNextFoldersPage,
   fetchNextFilesPage,
   formatCount,
@@ -255,14 +259,24 @@ export function FileBrowserListView({
   useEffect(() => {
     if (virtualItems.length === 0) return
 
-    const lastItem = virtualItems[virtualItems.length - 1]
-    const item = items[lastItem.index]
-
-    if (item.type === 'item') {
-      if (item.kind === 'folder' && item.index >= folders.length - 5 && hasNextFoldersPage) {
-        fetchNextFoldersPage()
-      } else if (item.kind === 'file' && item.index >= files.length - 5 && hasNextFilesPage) {
-        fetchNextFilesPage()
+    for (const virtualItem of virtualItems) {
+      const item = items[virtualItem.index]
+      if (item?.type === 'item') {
+        if (
+          item.kind === 'folder' &&
+          item.index >= folders.length - 10 &&
+          hasNextFoldersPage &&
+          !isFetchingNextFoldersPage
+        ) {
+          fetchNextFoldersPage()
+        } else if (
+          item.kind === 'file' &&
+          item.index >= files.length - 10 &&
+          hasNextFilesPage &&
+          !isFetchingNextFilesPage
+        ) {
+          fetchNextFilesPage()
+        }
       }
     }
   }, [
@@ -272,6 +286,8 @@ export function FileBrowserListView({
     files.length,
     hasNextFoldersPage,
     hasNextFilesPage,
+    isFetchingNextFoldersPage,
+    isFetchingNextFilesPage,
     fetchNextFoldersPage,
     fetchNextFilesPage,
   ])

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -262,20 +262,22 @@ export function FileBrowserListView({
     for (const virtualItem of virtualItems) {
       const item = items[virtualItem.index]
       if (item?.type === 'item') {
-        if (
-          item.kind === 'folder' &&
-          item.index >= folders.length - 10 &&
-          hasNextFoldersPage &&
-          !isFetchingNextFoldersPage
-        ) {
-          fetchNextFoldersPage()
-        } else if (
-          item.kind === 'file' &&
-          item.index >= files.length - 10 &&
-          hasNextFilesPage &&
-          !isFetchingNextFilesPage
-        ) {
-          fetchNextFilesPage()
+        const isSkeleton = item.kind === 'folder' ? !folders[item.index] : !files[item.index]
+        const isNearEnd =
+          item.kind === 'folder'
+            ? item.index >= folders.length - 15
+            : item.index >= files.length - 15
+
+        if (item.kind === 'folder' && hasNextFoldersPage && !isFetchingNextFoldersPage) {
+          if (isSkeleton || isNearEnd) {
+            fetchNextFoldersPage()
+            break
+          }
+        } else if (item.kind === 'file' && hasNextFilesPage && !isFetchingNextFilesPage) {
+          if (isSkeleton || isNearEnd) {
+            fetchNextFilesPage()
+            break
+          }
         }
       }
     }

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -257,12 +257,20 @@ export function FileBrowserListView({
     count: items.length,
     getScrollElement: () => localScrollRef.current,
     estimateSize: () => 40,
+    getItemKey: React.useCallback(
+      (index: number) => {
+        const item = items[index]
+        if (!item) return index
+        if (item.type === 'header') {
+          return `header-${item.kind}`
+        }
+        const dataItem = item.kind === 'folder' ? folders[item.index] : files[item.index]
+        return dataItem?.id || `item-${item.kind}-${item.index}`
+      },
+      [items, folders, files],
+    ),
     overscan: 10,
   })
-
-  useEffect(() => {
-    rowVirtualizer.measure()
-  }, [folders.length, files.length, foldersExpanded, filesExpanded, rowVirtualizer])
 
   const virtualItems = rowVirtualizer.getVirtualItems()
 

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -139,6 +139,8 @@ interface FileBrowserListViewProps {
   formatSize: (bytes: number) => string
   foldersSize: number
   filesSize: number
+  totalFoldersSize?: number
+  totalFilesSize?: number
   handleEmptyAreaClick: (e: React.MouseEvent) => void
   dragState?: DragState
   sort?: SearchSort
@@ -166,8 +168,8 @@ export function FileBrowserListView({
   fetchNextFilesPage,
   formatCount,
   formatSize,
-  foldersSize,
-  filesSize,
+  totalFoldersSize,
+  totalFilesSize,
   handleEmptyAreaClick,
   dragState,
   sort,
@@ -227,20 +229,24 @@ export function FileBrowserListView({
     )[] = []
 
     // Folders section
-    list.push({ type: 'header', kind: 'folder' })
-    if (foldersExpanded) {
-      const count = totalFolders ?? folders.length
-      for (let i = 0; i < count; i++) {
-        list.push({ type: 'item', kind: 'folder', index: i })
+    const foldersCount = totalFolders ?? folders.length
+    if (foldersCount > 0) {
+      list.push({ type: 'header', kind: 'folder' })
+      if (foldersExpanded) {
+        for (let i = 0; i < foldersCount; i++) {
+          list.push({ type: 'item', kind: 'folder', index: i })
+        }
       }
     }
 
     // Files section
-    list.push({ type: 'header', kind: 'file' })
-    if (filesExpanded) {
-      const count = totalFiles ?? files.length
-      for (let i = 0; i < count; i++) {
-        list.push({ type: 'item', kind: 'file', index: i })
+    const filesCount = totalFiles ?? files.length
+    if (filesCount > 0) {
+      list.push({ type: 'header', kind: 'file' })
+      if (filesExpanded) {
+        for (let i = 0; i < filesCount; i++) {
+          list.push({ type: 'item', kind: 'file', index: i })
+        }
       }
     }
 
@@ -253,6 +259,10 @@ export function FileBrowserListView({
     estimateSize: () => 40,
     overscan: 10,
   })
+
+  useEffect(() => {
+    rowVirtualizer.measure()
+  }, [folders.length, files.length, foldersExpanded, filesExpanded, rowVirtualizer])
 
   const virtualItems = rowVirtualizer.getVirtualItems()
 
@@ -348,7 +358,8 @@ export function FileBrowserListView({
               const count = isFolder
                 ? (totalFolders ?? folders.length)
                 : (totalFiles ?? files.length)
-              const size = isFolder ? foldersSize : filesSize
+              const size = isFolder ? (totalFoldersSize ?? -1) : (totalFilesSize ?? -1)
+              const showSize = size > -1
               const expanded = isFolder ? foldersExpanded : filesExpanded
               const setExpanded = isFolder ? setFoldersExpanded : setFilesExpanded
               const hasItems = isFolder ? folders.length > 0 : files.length > 0
@@ -395,7 +406,7 @@ export function FileBrowserListView({
                       )}
                     </div>
                     <span className="text-sm font-medium text-muted-foreground whitespace-nowrap">
-                      {formatCount(count, !isFolder)} • {formatSize(size)}
+                      {formatCount(count, !isFolder)}{showSize ? ` • ${formatSize(size)}` : ''}
                     </span>
                   </div>
                   <div className="flex-1 bg-card" />

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -5,8 +5,9 @@ import type { FieldInfo } from '@shumai/dtos'
 import type { SearchSort } from '@shumai/dtos'
 import { useDroppable } from '@dnd-kit/react'
 import { flexRender, getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import { ChevronDown, ChevronRight } from 'lucide-react'
-import React, { useMemo, useState } from 'react'
+import React, { useMemo, useState, useEffect } from 'react'
 import { cn } from '../../lib/utils'
 import type { DragState } from '../dnd-types'
 import { Checkbox } from '../ui/checkbox'
@@ -18,9 +19,20 @@ interface ListRowProps {
   dragState?: DragState
   isSelected?: boolean
   columnSizing?: Record<string, number>
+  virtualRow: { start: number; index: number }
+  measureElement: (el: HTMLElement | null) => void
 }
 
-function ListRow({ item, renderItem, active, dragState, isSelected, columnSizing }: ListRowProps) {
+function ListRow({
+  item,
+  renderItem,
+  active,
+  dragState,
+  isSelected,
+  columnSizing,
+  virtualRow,
+  measureElement,
+}: ListRowProps) {
   const isDraggingItem = dragState?.draggedIds.has(item.id!)
   const isDraggingAny = dragState?.isActive
 
@@ -72,30 +84,32 @@ function ListRow({ item, renderItem, active, dragState, isSelected, columnSizing
   const showDropFeedback = isRowOver && isValidDropTarget
 
   return (
-    <tbody
-      ref={setRowRef}
+    <div
+      ref={(node) => {
+        setRowRef(node)
+        measureElement(node)
+      }}
       className={cn(
-        'group border-b border-border transition-colors hover:bg-primary/20 relative',
+        'group border-b border-border transition-colors hover:bg-primary/20 absolute top-0 left-0 w-full flex flex-col',
         isSelected && 'bg-primary/10',
         showDropFeedback && 'bg-primary/10',
         isTopOver && 'border-t-2 border-t-primary',
         isBottomOver && 'border-b-2 border-b-primary',
       )}
+      style={{
+        transform: `translateY(${virtualRow.start}px)`,
+      }}
     >
-      <tr
+      <div
         ref={setTopRef}
-        className="p-0 m-0 leading-none bg-transparent pointer-events-auto h-[2px]"
-      >
-        <td colSpan={100} className="p-0 m-0 border-0" />
-      </tr>
+        className="p-0 m-0 leading-none bg-transparent pointer-events-auto h-[2px] w-full"
+      />
       {renderItem(item, columnSizing)}
-      <tr
+      <div
         ref={setBottomRef}
-        className="p-0 m-0 leading-none bg-transparent pointer-events-auto h-[2px]"
-      >
-        <td colSpan={100} className="p-0 m-0 border-0" />
-      </tr>
-    </tbody>
+        className="p-0 m-0 leading-none bg-transparent pointer-events-auto h-[2px] w-full"
+      />
+    </div>
   )
 }
 
@@ -114,10 +128,10 @@ interface FileBrowserListViewProps {
   setFoldersExpanded: (expanded: boolean) => void
   filesExpanded: boolean
   setFilesExpanded: (expanded: boolean) => void
-  foldersRef: (node?: Element | null) => void
-  filesRef: (node?: Element | null) => void
   hasNextFoldersPage: boolean
   hasNextFilesPage: boolean
+  fetchNextFoldersPage: () => void
+  fetchNextFilesPage: () => void
   formatCount: (count: number, isFile: boolean) => string
   formatSize: (bytes: number) => string
   foldersSize: number
@@ -125,6 +139,7 @@ interface FileBrowserListViewProps {
   handleEmptyAreaClick: (e: React.MouseEvent) => void
   dragState?: DragState
   sort?: SearchSort
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>
 }
 
 export function FileBrowserListView({
@@ -140,10 +155,10 @@ export function FileBrowserListView({
   setFoldersExpanded,
   filesExpanded,
   setFilesExpanded,
-  foldersRef,
-  filesRef,
   hasNextFoldersPage,
   hasNextFilesPage,
+  fetchNextFoldersPage,
+  fetchNextFilesPage,
   formatCount,
   formatSize,
   foldersSize,
@@ -151,6 +166,7 @@ export function FileBrowserListView({
   handleEmptyAreaClick,
   dragState,
   sort,
+  scrollContainerRef,
 }: FileBrowserListViewProps) {
   const [columnSizing, setColumnSizing] = useState<Record<string, number>>({})
 
@@ -199,24 +215,83 @@ export function FileBrowserListView({
     onColumnSizingChange: setColumnSizing,
   })
 
+  const items = useMemo(() => {
+    const list: (
+      | { type: 'header'; kind: 'folder' | 'file' }
+      | { type: 'item'; kind: 'folder' | 'file'; index: number }
+    )[] = []
+
+    // Folders section
+    list.push({ type: 'header', kind: 'folder' })
+    if (foldersExpanded) {
+      const count = totalFolders ?? folders.length
+      for (let i = 0; i < count; i++) {
+        list.push({ type: 'item', kind: 'folder', index: i })
+      }
+    }
+
+    // Files section
+    list.push({ type: 'header', kind: 'file' })
+    if (filesExpanded) {
+      const count = totalFiles ?? files.length
+      for (let i = 0; i < count; i++) {
+        list.push({ type: 'item', kind: 'file', index: i })
+      }
+    }
+
+    return list
+  }, [foldersExpanded, filesExpanded, folders.length, files.length, totalFolders, totalFiles])
+
+  const rowVirtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => 40,
+    overscan: 10,
+  })
+
+  const virtualItems = rowVirtualizer.getVirtualItems()
+
+  useEffect(() => {
+    if (virtualItems.length === 0) return
+
+    const lastItem = virtualItems[virtualItems.length - 1]
+    const item = items[lastItem.index]
+
+    if (item.type === 'item') {
+      if (item.kind === 'folder' && item.index >= folders.length - 5 && hasNextFoldersPage) {
+        fetchNextFoldersPage()
+      } else if (item.kind === 'file' && item.index >= files.length - 5 && hasNextFilesPage) {
+        fetchNextFilesPage()
+      }
+    }
+  }, [
+    virtualItems,
+    items,
+    folders.length,
+    files.length,
+    hasNextFoldersPage,
+    hasNextFilesPage,
+    fetchNextFoldersPage,
+    fetchNextFilesPage,
+  ])
+
   return (
     <div className="flex-1 overflow-x-auto" onClick={handleEmptyAreaClick}>
-      <table
-        className="w-full border-collapse"
+      <div
+        className="w-full relative"
         style={{
-          tableLayout: 'fixed',
           width: table.getTotalSize(),
           minWidth: '100%',
         }}
       >
-        <thead className="sticky top-0 z-30 bg-background border-b border-border">
+        <div className="sticky top-0 z-30 bg-background border-b border-border flex flex-col">
           {table.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id} className="bg-muted/50 whitespace-nowrap">
+            <div key={headerGroup.id} className="bg-muted/50 whitespace-nowrap flex">
               {headerGroup.headers.map((header) => (
-                <th
+                <div
                   key={header.id}
                   className={cn(
-                    'px-4 py-2 text-left text-xs font-medium text-muted-foreground relative border-r',
+                    'px-4 py-2 text-left text-xs font-medium text-muted-foreground relative border-r flex items-center',
                     header.id === 'name' && 'sticky left-0 z-40 bg-muted',
                   )}
                   style={{
@@ -234,32 +309,58 @@ export function FileBrowserListView({
                       header.column.getIsResizing() && 'bg-primary w-1',
                     )}
                   />
-                </th>
+                </div>
               ))}
-            </tr>
+            </div>
           ))}
-        </thead>
+        </div>
 
-        {folders.length > 0 && (
-          <>
-            <tbody className="bg-card">
-              <tr
-                className="border-b border-border hover:bg-muted/50 transition-colors cursor-pointer group"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  setFoldersExpanded(!foldersExpanded)
-                }}
-              >
-                <td
-                  className="px-4 py-2 sticky left-0 z-10 bg-card border-r"
+        <div
+          className="relative"
+          style={{
+            height: `${rowVirtualizer.getTotalSize()}px`,
+          }}
+        >
+          {virtualItems.map((virtualRow) => {
+            const item = items[virtualRow.index]
+
+            if (item.type === 'header') {
+              const isFolder = item.kind === 'folder'
+              const count = isFolder
+                ? (totalFolders ?? folders.length)
+                : (totalFiles ?? files.length)
+              const size = isFolder ? foldersSize : filesSize
+              const expanded = isFolder ? foldersExpanded : filesExpanded
+              const setExpanded = isFolder ? setFoldersExpanded : setFilesExpanded
+              const hasItems = isFolder ? folders.length > 0 : files.length > 0
+
+              return (
+                <div
+                  key={`header-${item.kind}`}
+                  ref={rowVirtualizer.measureElement}
+                  className="absolute top-0 left-0 w-full border-b border-border hover:bg-muted/50 transition-colors cursor-pointer group flex bg-card z-20"
                   style={{
-                    width: columnSizing?.['name'] || 300,
-                    minWidth: columnSizing?.['name'] || 300,
+                    transform: `translateY(${virtualRow.start}px)`,
+                  }}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setExpanded(!expanded)
                   }}
                 >
-                  <div className="flex items-center gap-2">
+                  <div
+                    className="px-4 py-2 sticky left-0 z-10 bg-card border-r flex items-center gap-2"
+                    style={{
+                      width: columnSizing?.['name'] || 300,
+                      minWidth: columnSizing?.['name'] || 300,
+                    }}
+                  >
                     <Checkbox
-                      checked={folders.length > 0 && folders.every((f) => selectedIds.has(f.id!))}
+                      checked={
+                        hasItems &&
+                        (isFolder
+                          ? folders.every((f) => selectedIds.has(f.id!))
+                          : files.every((f) => selectedIds.has(f.id!)))
+                      }
                       onCheckedChange={() => {
                         // Batch selection logic
                       }}
@@ -267,110 +368,54 @@ export function FileBrowserListView({
                       className="h-4 w-4"
                     />
                     <div className="p-1 rounded hover:bg-muted">
-                      {foldersExpanded ? (
+                      {expanded ? (
                         <ChevronDown className="h-4 w-4 text-muted-foreground" />
                       ) : (
                         <ChevronRight className="h-4 w-4 text-muted-foreground" />
                       )}
                     </div>
                     <span className="text-sm font-medium text-muted-foreground whitespace-nowrap">
-                      {formatCount(totalFolders ?? folders.length, false)} •{' '}
-                      {formatSize(foldersSize)}
+                      {formatCount(count, !isFolder)} • {formatSize(size)}
                     </span>
                   </div>
-                </td>
-                <td colSpan={columns.length - 1} className="bg-card" />
-              </tr>
-            </tbody>
-            {foldersExpanded &&
-              folders.map((item) => (
-                <ListRow
-                  key={item.id}
-                  item={item}
-                  renderItem={renderItem}
-                  active={sort?.field === 'custom'}
-                  dragState={dragState}
-                  isSelected={selectedItem?.id === item.id}
-                  columnSizing={columnSizing}
-                />
-              ))}
-            {hasNextFoldersPage && (
-              <tbody className="bg-transparent">
-                <tr>
-                  <td colSpan={columns.length}>
-                    <div ref={foldersRef} className="h-1" />
-                  </td>
-                </tr>
-              </tbody>
-            )}
-          </>
-        )}
+                  <div className="flex-1 bg-card" />
+                </div>
+              )
+            }
 
-        {files.length > 0 && (
-          <>
-            <tbody className="bg-card">
-              <tr
-                className="border-b border-border hover:bg-muted/50 transition-colors cursor-pointer group"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  setFilesExpanded(!filesExpanded)
-                }}
-              >
-                <td
-                  className="px-4 py-2 sticky left-0 z-10 bg-card border-r"
+            const dataItem = item.kind === 'folder' ? folders[item.index] : files[item.index]
+
+            if (!dataItem) {
+              return (
+                <div
+                  key={`skeleton-${item.kind}-${item.index}`}
+                  ref={rowVirtualizer.measureElement}
+                  className="absolute top-0 left-0 w-full border-b border-border px-4 py-3 flex items-center animate-pulse"
                   style={{
-                    width: columnSizing?.['name'] || 300,
-                    minWidth: columnSizing?.['name'] || 300,
+                    transform: `translateY(${virtualRow.start}px)`,
                   }}
                 >
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      checked={files.length > 0 && files.every((f) => selectedIds.has(f.id!))}
-                      onCheckedChange={() => {
-                        // Batch selection logic
-                      }}
-                      onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                      className="h-4 w-4"
-                    />
-                    <div className="p-1 rounded hover:bg-muted">
-                      {filesExpanded ? (
-                        <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                      ) : (
-                        <ChevronRight className="h-4 w-4 text-muted-foreground" />
-                      )}
-                    </div>
-                    <span className="text-sm font-medium text-muted-foreground whitespace-nowrap">
-                      {formatCount(totalFiles ?? files.length, true)} • {formatSize(filesSize)}
-                    </span>
-                  </div>
-                </td>
-                <td colSpan={columns.length - 1} className="bg-card" />
-              </tr>
-            </tbody>
-            {filesExpanded &&
-              files.map((item) => (
-                <ListRow
-                  key={item.id}
-                  item={item}
-                  renderItem={renderItem}
-                  active={sort?.field === 'custom'}
-                  dragState={dragState}
-                  isSelected={selectedItem?.id === item.id}
-                  columnSizing={columnSizing}
-                />
-              ))}
-            {hasNextFilesPage && (
-              <tbody className="bg-transparent">
-                <tr>
-                  <td colSpan={columns.length}>
-                    <div ref={filesRef} className="h-1" />
-                  </td>
-                </tr>
-              </tbody>
-            )}
-          </>
-        )}
-      </table>
+                  <div className="h-4 bg-muted rounded w-1/4" />
+                </div>
+              )
+            }
+
+            return (
+              <ListRow
+                key={dataItem.id}
+                item={dataItem}
+                renderItem={renderItem}
+                active={sort?.field === 'custom'}
+                dragState={dragState}
+                isSelected={selectedItem?.id === dataItem.id}
+                columnSizing={columnSizing}
+                virtualRow={virtualRow}
+                measureElement={rowVirtualizer.measureElement}
+              />
+            )
+          })}
+        </div>
+      </div>
     </div>
   )
 }

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -305,7 +305,7 @@ export function FileBrowserListView({
   ])
 
   return (
-    <div className="flex-1 overflow-x-auto" onClick={handleEmptyAreaClick}>
+    <div className="w-full overflow-x-auto" onClick={handleEmptyAreaClick}>
       <div
         className="w-full relative"
         style={{
@@ -406,7 +406,8 @@ export function FileBrowserListView({
                       )}
                     </div>
                     <span className="text-sm font-medium text-muted-foreground whitespace-nowrap">
-                      {formatCount(count, !isFolder)}{showSize ? ` • ${formatSize(size)}` : ''}
+                      {formatCount(count, !isFolder)}
+                      {showSize ? ` • ${formatSize(size)}` : ''}
                     </span>
                   </div>
                   <div className="flex-1 bg-card" />

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -144,7 +144,6 @@ interface FileBrowserListViewProps {
   handleEmptyAreaClick: (e: React.MouseEvent) => void
   dragState?: DragState
   sort?: SearchSort
-  scrollContainerRef: React.RefObject<HTMLDivElement | null>
 }
 
 export function FileBrowserListView({
@@ -173,7 +172,6 @@ export function FileBrowserListView({
   handleEmptyAreaClick,
   dragState,
   sort,
-  scrollContainerRef,
 }: FileBrowserListViewProps) {
   const [columnSizing, setColumnSizing] = useState<Record<string, number>>({})
 
@@ -253,9 +251,11 @@ export function FileBrowserListView({
     return list
   }, [foldersExpanded, filesExpanded, folders.length, files.length, totalFolders, totalFiles])
 
+  const localScrollRef = React.useRef<HTMLDivElement>(null)
+
   const rowVirtualizer = useVirtualizer({
     count: items.length,
-    getScrollElement: () => scrollContainerRef.current,
+    getScrollElement: () => localScrollRef.current,
     estimateSize: () => 40,
     overscan: 10,
   })
@@ -305,7 +305,7 @@ export function FileBrowserListView({
   ])
 
   return (
-    <div className="w-full overflow-x-auto" onClick={handleEmptyAreaClick}>
+    <div ref={localScrollRef} className="flex-1 overflow-auto" onClick={handleEmptyAreaClick}>
       <div
         className="w-full relative"
         style={{

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -89,6 +89,7 @@ function ListRow({
         setRowRef(node)
         measureElement(node)
       }}
+      data-index={virtualRow.index}
       className={cn(
         'group border-b border-border transition-colors hover:bg-primary/20 absolute top-0 left-0 w-full flex flex-col',
         isSelected && 'bg-primary/10',
@@ -338,6 +339,7 @@ export function FileBrowserListView({
                 <div
                   key={`header-${item.kind}`}
                   ref={rowVirtualizer.measureElement}
+                  data-index={virtualRow.index}
                   className="absolute top-0 left-0 w-full border-b border-border hover:bg-muted/50 transition-colors cursor-pointer group flex bg-card z-20"
                   style={{
                     transform: `translateY(${virtualRow.start}px)`,

--- a/packages/webui/components/file-system-manager.tsx
+++ b/packages/webui/components/file-system-manager.tsx
@@ -274,6 +274,8 @@ export default function FileSystemManager({
 
   const totalFolders = foldersData?.pages[0]?.pageInfo?.total
   const totalFiles = filesData?.pages[0]?.pageInfo?.total
+  const totalFoldersSize = foldersData?.pages[0]?.pageInfo?.totalSize
+  const totalFilesSize = filesData?.pages[0]?.pageInfo?.totalSize
 
   const handleClearSelection = () => {
     setSelectedIds(new Set())
@@ -454,6 +456,8 @@ export default function FileSystemManager({
             files={files}
             totalFolders={totalFolders}
             totalFiles={totalFiles}
+            totalFoldersSize={totalFoldersSize}
+            totalFilesSize={totalFilesSize}
             selectedItem={selectedItem}
             selectedIds={selectedIds}
             onItemSelect={handleItemSelect}

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -51,6 +51,7 @@
     "@tanstack/react-query": "5.90.10",
     "@tanstack/react-router": "^1.136.8",
     "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.13.26",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",


### PR DESCRIPTION
## Summary

Implement virtualized list and grid views in the file browser to provide a stable scrollbar size and smooth scroll performance for directories with large numbers of assets.

## Changes

- **Virtualization Integration**: Integrated `@tanstack/react-virtual` to manage viewport rendering for file list and grid layouts.
- **Header & Placeholder Support**: Unified headers, items, and skeleton placeholders into a single virtual items list to ensure correct height estimation.
- **Responsive Grid**: Added a ResizeObserver to dynamically count columns in the grid view and virtualize row groups.
- **Auto-pagination**: Replaced `react-intersection-observer` triggers with virtual scroll boundary checks to fetch the next page of folders or files before the user reaches the end.

## Verification

- Ran typecheck (`bun run typecheck`) and linter (`bun run lint`) successfully.
- Verified that the full unit test suite passes successfully.
- Verified standard bundle build for Pino and Vite compiles cleanly.