### PR TITLE
fix(webui): fix list mode pagination and virtualization scroll ref

### DIFF
--- a/packages/core/src/search/search.test.ts
+++ b/packages/core/src/search/search.test.ts
@@ -741,6 +741,7 @@ describe('SearchService', () => {
 
       // Search files recursively
       const resultRecursive = await searchService.search(rootFolder.id, {
+        conditions: [],
         recursively: true,
         assetType: 'file',
         operator: 'AND',
@@ -752,6 +753,7 @@ describe('SearchService', () => {
 
       // Search files non-recursively
       const resultNonRecursive = await searchService.search(rootFolder.id, {
+        conditions: [],
         recursively: false,
         assetType: 'file',
         operator: 'AND',
@@ -773,6 +775,8 @@ describe('SearchService', () => {
                 return [{ count: 2500n }]
               }
               // For main query, just run it or return mock
+              // We must cast to any because we are proxying the raw sql parameter
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               return target.$queryRaw(prismaSql as any)
             }
           }
@@ -784,10 +788,14 @@ describe('SearchService', () => {
         },
       })
 
+      // We must cast mockPrisma proxy as any because the type signature of SearchService
+      // expects a full PrismaClient instance, whereas we only mocked $queryRaw.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const localSearchService = new SearchService(mockPrisma as any)
       const { rootFolder } = await setupBasicAssets()
 
       const result = await localSearchService.search(rootFolder.id, {
+        conditions: [],
         recursively: true,
         assetType: 'file',
         operator: 'AND',

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -191,7 +191,9 @@ export class SearchService {
 
       if (totalCount < 2000) {
         countBuilder.select(Prisma.sql`SUM(COALESCE(a.size_byte, 0))::bigint as sum`)
-        const sumRes = await this.prismaClient.$queryRaw<{ sum: bigint | null }[]>(countBuilder.build())
+        const sumRes = await this.prismaClient.$queryRaw<{ sum: bigint | null }[]>(
+          countBuilder.build(),
+        )
         pageInfo.totalSize = Number(sumRes[0]?.sum || 0)
       } else {
         pageInfo.totalSize = -1
@@ -380,7 +382,9 @@ export class SearchService {
 
       if (totalCount < 2000) {
         countBuilder.select(Prisma.sql`SUM(COALESCE(a.size_byte, 0))::bigint as sum`)
-        const sumRes = await this.prismaClient.$queryRaw<{ sum: bigint | null }[]>(countBuilder.build())
+        const sumRes = await this.prismaClient.$queryRaw<{ sum: bigint | null }[]>(
+          countBuilder.build(),
+        )
         pageInfo.totalSize = Number(sumRes[0]?.sum || 0)
       } else {
         pageInfo.totalSize = -1
@@ -413,7 +417,9 @@ export class SearchService {
           countBuilder.addWhere(Prisma.sql`a.name ILIKE ${'%' + valStr + '%'}`)
         }
 
-        const sumRes = await this.prismaClient.$queryRaw<{ sum: bigint | null }[]>(countBuilder.build())
+        const sumRes = await this.prismaClient.$queryRaw<{ sum: bigint | null }[]>(
+          countBuilder.build(),
+        )
         pageInfo.totalSize = Number(sumRes[0]?.sum || 0)
       } else {
         pageInfo.totalSize = -1

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -824,7 +824,6 @@ export function FileBrowser({
                   handleEmptyAreaClick={handleEmptyAreaClick}
                   dragState={dragState}
                   sort={sort}
-                  scrollContainerRef={scrollContainerRef}
                 />
               ) : (
                 <FileBrowserGridView

--- a/packages/webui/components/file-browser/grid-view.tsx
+++ b/packages/webui/components/file-browser/grid-view.tsx
@@ -261,7 +261,8 @@ export function FileBrowserGridView({
                     <ChevronRight className="h-4 w-4" />
                   )}
                   <span>
-                    {formatCount(count, !isFolder)}{showSize ? ` • ${formatSize(size)}` : ''}
+                    {formatCount(count, !isFolder)}
+                    {showSize ? ` • ${formatSize(size)}` : ''}
                   </span>
                 </button>
               </div>

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -305,7 +305,7 @@ export function FileBrowserListView({
   ])
 
   return (
-    <div className="flex-1 overflow-x-auto" onClick={handleEmptyAreaClick}>
+    <div className="w-full overflow-x-auto" onClick={handleEmptyAreaClick}>
       <div
         className="w-full relative"
         style={{
@@ -406,7 +406,8 @@ export function FileBrowserListView({
                       )}
                     </div>
                     <span className="text-sm font-medium text-muted-foreground whitespace-nowrap">
-                      {formatCount(count, !isFolder)}{showSize ? ` • ${formatSize(size)}` : ''}
+                      {formatCount(count, !isFolder)}
+                      {showSize ? ` • ${formatSize(size)}` : ''}
                     </span>
                   </div>
                   <div className="flex-1 bg-card" />

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -144,7 +144,6 @@ interface FileBrowserListViewProps {
   handleEmptyAreaClick: (e: React.MouseEvent) => void
   dragState?: DragState
   sort?: SearchSort
-  scrollContainerRef: React.RefObject<HTMLDivElement | null>
 }
 
 export function FileBrowserListView({
@@ -173,7 +172,6 @@ export function FileBrowserListView({
   handleEmptyAreaClick,
   dragState,
   sort,
-  scrollContainerRef,
 }: FileBrowserListViewProps) {
   const [columnSizing, setColumnSizing] = useState<Record<string, number>>({})
 
@@ -253,9 +251,11 @@ export function FileBrowserListView({
     return list
   }, [foldersExpanded, filesExpanded, folders.length, files.length, totalFolders, totalFiles])
 
+  const localScrollRef = React.useRef<HTMLDivElement>(null)
+
   const rowVirtualizer = useVirtualizer({
     count: items.length,
-    getScrollElement: () => scrollContainerRef.current,
+    getScrollElement: () => localScrollRef.current,
     estimateSize: () => 40,
     overscan: 10,
   })
@@ -305,7 +305,7 @@ export function FileBrowserListView({
   ])
 
   return (
-    <div className="w-full overflow-x-auto" onClick={handleEmptyAreaClick}>
+    <div ref={localScrollRef} className="flex-1 overflow-auto" onClick={handleEmptyAreaClick}>
       <div
         className="w-full relative"
         style={{


### PR DESCRIPTION
## Summary

Fixes a pagination bug in the file browser list mode where scrolling to the bottom of the list-view did not fetch the next page of results.

## Changes

- Changed `FileBrowserListView` to act as its own scroll container (`overflow-auto`) using a local ref instead of relying on the parent flex container (`scrollContainerRef`). This bypasses the flex overflow min-height restriction where the child `overflow-x-auto` was forced into scrolling internally without sending scroll events to the parent.
- Cleans up and removes the unused `scrollContainerRef` prop from the list-view component and parent file-browser instantiation.
- Fixed TypeScript compile errors in `search.test.ts` by adding the required `conditions` argument in `totalSize` tests, and documented `as any` casts with ESLint disable comments.

## Verification

- Ran `bun run typecheck` - passed.
- Ran `bun run lint` - passed.
- Ran `bun run format` - passed.
- Ran `bun run test` - all 443 unit tests passed successfully.