### PR TITLE
feat(ui): refine visual styling for cards, sidebars, and theme colors

### DIFF
--- a/packages/webui/components/dual-sidebar.tsx
+++ b/packages/webui/components/dual-sidebar.tsx
@@ -102,7 +102,7 @@ export const DualSidebar: React.FC<DualSidebarProps> = ({ children }) => {
       >
         <div className="absolute bottom-0 w-full h-[70dvh] bg-linear-to-t from-sidebar-primary/10 to-transparent"></div>
         {/* Level 1: Icon Bar */}
-        <nav className="w-16 bg-sidebar border-r border-sidebar-border flex flex-col items-center pb-4 pt-0 space-y-2 flex-shrink-0">
+        <nav className="w-16 bg-card border-r border-sidebar-border flex flex-col items-center pb-4 pt-0 space-y-2 flex-shrink-0">
           <div className="flex-1 w-full flex flex-col items-center space-y-5 pt-1">
             <TooltipProvider>
               {sidebarItems.map((item, index) => (

--- a/packages/webui/components/file-browser/file-card.tsx
+++ b/packages/webui/components/file-browser/file-card.tsx
@@ -1,7 +1,10 @@
-import type { AssetInfo, FieldValueInfo } from '@shumai/dtos'
 import { client } from '@/ui/api/client'
+import type { AssetInfo, FieldValueInfo } from '@shumai/dtos'
 import { useQuery } from '@tanstack/react-query'
 
+import { Badge } from '@/ui/components/ui/badge'
+import { Button } from '@/ui/components/ui/button'
+import { Checkbox } from '@/ui/components/ui/checkbox'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -9,19 +12,16 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/ui/components/ui/dropdown-menu'
+import { EditableText } from '@/ui/components/ui/editable-text'
+import { Skeleton } from '@/ui/components/ui/skeleton'
 import { formatTimeAgo } from '@/ui/lib/time'
+import { cn } from '@/ui/lib/utils'
 import { useDraggable, useDroppable } from '@dnd-kit/react'
 import { Download, Edit, History, MoreHorizontal, Trash2 } from 'lucide-react'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { cn } from '@/ui/lib/utils'
 import type { DragState } from '../dnd-types'
 import FieldRenderer from '../field-renderer'
 import { FilePreview } from './file-preview'
-import { Badge } from '@/ui/components/ui/badge'
-import { Button } from '@/ui/components/ui/button'
-import { Checkbox } from '@/ui/components/ui/checkbox'
-import { EditableText } from '@/ui/components/ui/editable-text'
-import { Skeleton } from '@/ui/components/ui/skeleton'
 
 import { type FieldInfo as MetadataFieldInfo } from '@shumai/dtos'
 
@@ -275,7 +275,7 @@ export function FileCard({
             onBlur={handleRename}
             onKeyDown={handleKeyDown}
             disabled={!isEditing}
-            className="h-auto p-0 text-sm text-foreground"
+            className="h-auto p-0 text-sm text-foreground !bg-transparent"
           />
           <p className="text-sm text-muted-foreground">
             {displayItem.createdAt && formatTimeAgo(displayItem.createdAt)} by{' '}

--- a/packages/webui/components/file-browser/folder-card.tsx
+++ b/packages/webui/components/file-browser/folder-card.tsx
@@ -1,4 +1,3 @@
-import type { AssetInfo, ChildPreview } from '@shumai/dtos'
 import { Checkbox } from '@/ui/components/ui/checkbox'
 import {
   DropdownMenu,
@@ -10,6 +9,7 @@ import {
 import { EditableText } from '@/ui/components/ui/editable-text'
 import { cn } from '@/ui/lib/utils'
 import { useDraggable, useDroppable } from '@dnd-kit/react'
+import type { AssetInfo, ChildPreview } from '@shumai/dtos'
 import { Download, Edit, History, MoreHorizontal, Trash2 } from 'lucide-react'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import type { DragState } from '../dnd-types'
@@ -56,17 +56,19 @@ const FolderPreviewGrid = ({ items }: { items: ChildPreview[] }) => {
 
   // 1 Item
   if (count === 1) {
-    return <div className="w-full h-full bg-muted/50 rounded-sm">{renderItem(safeChildren[0])}</div>
+    return (
+      <div className="w-full h-full bg-foreground/6 rounded-sm">{renderItem(safeChildren[0])}</div>
+    )
   }
 
   // 2 Items
   if (count === 2) {
     return (
       <div className="grid grid-cols-2 gap-0.5 h-full w-full">
-        <div className="overflow-hidden h-full bg-muted/50 rounded-sm">
+        <div className="overflow-hidden h-full bg-foreground/6 rounded-sm">
           {renderItem(safeChildren[0])}
         </div>
-        <div className="overflow-hidden h-full bg-muted/50 rounded-sm">
+        <div className="overflow-hidden h-full bg-foreground/6 rounded-sm">
           {renderItem(safeChildren[1])}
         </div>
       </div>
@@ -76,14 +78,14 @@ const FolderPreviewGrid = ({ items }: { items: ChildPreview[] }) => {
   // 3 Items
   return (
     <div className="grid grid-cols-3 gap-0.5 h-full w-full">
-      <div className="col-span-1 overflow-hidden h-full relative bg-muted/50 rounded-sm col-span-2">
+      <div className="col-span-1 overflow-hidden h-full relative bg-foreground/6 rounded-sm col-span-2">
         <div className="absolute inset-0 w-full h-full">{renderItem(safeChildren[0])}</div>
       </div>
       <div className="col-span-1 grid grid-rows-2 gap-0.5 h-full col-span-1">
-        <div className="overflow-hidden h-full relative bg-muted/50 rounded-sm">
+        <div className="overflow-hidden h-full relative bg-foreground/6 rounded-sm">
           <div className="absolute inset-0 w-full h-full">{renderItem(safeChildren[1])}</div>
         </div>
-        <div className="overflow-hidden h-full relative bg-muted/50 rounded-sm">
+        <div className="overflow-hidden h-full relative bg-foreground/6 rounded-sm">
           <div className="absolute inset-0 w-full h-full">{renderItem(safeChildren[2])}</div>
         </div>
       </div>
@@ -198,14 +200,14 @@ export function FolderCard({
   const tabHeight = 8
   const config = {
     cornerRadius: 4,
-    tabRadius: 0,
+    tabRadius: 5,
     tabSlope: 15,
-    tabBaseWidth: 150,
+    tabBaseWidth: 120,
   }
   const folderPath = useMemo(() => {
     const { cornerRadius: cr, tabRadius: tr, tabSlope: ts, tabBaseWidth: tbw } = config
     const s = 1
-    return `M ${s}, ${tabHeight + s} L ${s}, ${s + tr} A ${tr} ${tr} 0 0 1 ${s + tr} ${s} L ${tbw - ts + s - tr} ${s} Q ${tbw - ts + s} ${s} ${tbw - ts + s + tr} ${s + tr} L ${tbw + s} ${tabHeight + s} L ${width - cr - s} ${tabHeight + s} A ${cr} ${cr} 0 0 1 ${width - s} ${tabHeight + cr + s} L ${width - s} ${height - cr - s} A ${cr} ${cr} 0 0 1 ${width - cr - s} ${height - s} L ${cr + s} ${height - s} A ${cr} ${cr} 0 0 1 ${s} ${height - cr - s} Z`
+    return `M ${s}, ${tabHeight + s} L ${s}, ${s + tr} A ${tr} ${tr} 0 0 1 ${s + tr} ${s} L ${tbw - ts + s - tr} ${s} Q ${tbw - ts + s} ${s} ${tbw - ts + s} ${s} L ${tbw + s} ${tabHeight + s} L ${width - cr - s} ${tabHeight + s} A ${cr} ${cr} 0 0 1 ${width - s} ${tabHeight + cr + s} L ${width - s} ${height - cr - s} A ${cr} ${cr} 0 0 1 ${width - cr - s} ${height - s} L ${cr + s} ${height - s} A ${cr} ${cr} 0 0 1 ${s} ${height - cr - s} Z`
       .replace(/\s+/g, ' ')
       .trim()
   }, [])
@@ -240,14 +242,14 @@ export function FolderCard({
             strokeLinejoin="round"
             strokeWidth={showDropFeedback ? 3 : 1}
             className={cn(
-              'transition-colors duration-200 fill-none group-hover:stroke-primary',
+              'transition-colors duration-200 fill-none group-hover:stroke-primary stroke-foreground/10',
               (isSelected || isChecked || showDropFeedback) && 'stroke-primary',
             )}
           />
         </svg>
       </div>
 
-      <div className="absolute inset-0 -z-10 drop-shadow-sm pointer-events-none">
+      <div className="absolute inset-0 -z-10 pointer-events-none">
         <svg
           width="100%"
           height="100%"
@@ -260,12 +262,14 @@ export function FolderCard({
             vectorEffect="non-scaling-stroke"
             strokeLinejoin="round"
             strokeWidth={showDropFeedback ? 3 : 1}
-            className={cn('transition-colors duration-200 fill-foreground/15')}
+            className={cn(
+              'transition-colors duration-200 fill-foreground/6 dark:fill-foreground/4',
+            )}
           />
         </svg>
       </div>
 
-      <div className="relative w-full flex flex-1 flex-col p-2 mt-5 bg-muted dark:bg-card rounded-sm">
+      <div className="shadow-[0_-4px_6px_rgba(0,0,0,0.08)] relative w-full flex flex-1 flex-col p-2 mt-5 bg-muted dark:bg-muted/50 rounded-sm">
         <div className="relative w-full aspect-video shrink-0 overflow-hidden">
           <div className="absolute top-1 left-1 z-30 transition-all duration-200">
             <Checkbox

--- a/packages/webui/globals.css
+++ b/packages/webui/globals.css
@@ -10,7 +10,7 @@
 :root {
   --background: oklch(1 0 0);
   --foreground: oklch(0.153 0.006 107.1);
-  --card: oklch(1 0 0);
+  --card: oklch(0.988 0.003 106.5);
   --card-foreground: oklch(0.153 0.006 107.1);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.153 0.006 107.1);
@@ -43,9 +43,9 @@
 }
 
 .dark {
-  --background: oklch(0.153 0.006 107.1);
+  --background: oklch(0.175 0.006 107.1);
   --foreground: oklch(0.988 0.003 106.5);
-  --card: oklch(0.228 0.013 107.4);
+  --card: oklch(0.19 0 55.4);
   --card-foreground: oklch(0.988 0.003 106.5);
   --popover: oklch(0.228 0.013 107.4);
   --popover-foreground: oklch(0.988 0.003 106.5);
@@ -53,7 +53,7 @@
   --primary-foreground: oklch(0.98 0.016 73.684);
   --secondary: oklch(0.274 0.006 286.033);
   --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.286 0.016 107.4);
+  --muted: oklch(0.286 0 107.4);
   --muted-foreground: oklch(0.737 0.021 106.9);
   --accent: oklch(0.286 0.016 107.4);
   --accent-foreground: oklch(0.988 0.003 106.5);


### PR DESCRIPTION
## Summary
Refine visual styling across the WebUI, including card backgrounds, sidebar aesthetics, and theme color variables.

## Changes
- Updated `DualSidebar` background to use card colors.
- Improved `FileCard` and `FolderCard` visuals with better shadows, backgrounds, and SVG paths.
- Adjusted `globals.css` theme variables for both light and dark modes to enhance contrast and consistency.
- Cleaned up imports in card components.

## Verification
- Ran `bun run lint`, `bun run format`, `bun run typecheck`, and `bun run test`. All passed simultaneously.

## Notes
These changes were applied manually to improve the overall look and feel of the application.