### PR TITLE
feat(project): support adding existing team members and prioritize project-specific roles

### DIFF
--- a/packages/api/src/api/project.test.ts
+++ b/packages/api/src/api/project.test.ts
@@ -196,4 +196,54 @@ describe('project api', () => {
     })
     expect(assetService.emptyTrash).toHaveBeenCalledWith('p1')
   })
+
+  it('POST /projects/:projectId/members', async () => {
+    vi.mocked(projectService.addProjectMember).mockResolvedValue(undefined)
+
+    const res = await app.request('/projects/p1/members', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: 'user2', role: 'editor' }),
+    })
+
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({ success: true })
+    expect(authzService.hasPermission).toHaveBeenCalledWith({
+      user: expect.anything(),
+      permission: Permission.Admin,
+      type: ResourceType.Project,
+      id: 'p1',
+    })
+    expect(projectService.addProjectMember).toHaveBeenCalledWith({
+      projectId: 'p1',
+      userId: 'user2',
+      role: 'editor',
+    })
+  })
+
+  it('GET /projects/:projectId/me', async () => {
+    vi.mocked(projectService.getProjectMe).mockResolvedValue({
+      id: 'user1',
+      name: 'Test User',
+      role: 'editor',
+    })
+
+    const res = await app.request('/projects/p1/me')
+
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({
+      id: 'user1',
+      name: 'Test User',
+      role: 'editor',
+    })
+    expect(authzService.hasPermission).toHaveBeenCalledWith({
+      user: expect.anything(),
+      permission: Permission.Read,
+      type: ResourceType.Project,
+      id: 'p1',
+    })
+    expect(projectService.getProjectMe).toHaveBeenCalledWith('p1', 'user1')
+  })
 })

--- a/packages/api/src/api/project.ts
+++ b/packages/api/src/api/project.ts
@@ -320,8 +320,7 @@ const route = new Hono<{ Variables: { user: User } }>()
       await projectService.addProjectMember({
         projectId,
         userId: req.userId,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        role: req.role as any,
+        role: req.role,
       })
 
       return c.json({ success: true })

--- a/packages/api/src/api/project.ts
+++ b/packages/api/src/api/project.ts
@@ -10,6 +10,7 @@ import {
   listProjectsRequestSchema,
   recentlyDeletedRequestSchema,
   updateProjectMemberRoleRequestSchema,
+  addProjectMemberRequestSchema,
 } from '@shumai/dtos'
 import { listMembersQuerySchema } from '@shumai/dtos'
 import type { Prisma } from '@shumai/db'
@@ -300,6 +301,45 @@ const route = new Hono<{ Variables: { user: User } }>()
     await projectService.removeMember(projectId, userId)
 
     return c.json({ success: true })
+  })
+  .post(
+    '/projects/:projectId/members',
+    zValidator('json', addProjectMemberRequestSchema),
+    async (c) => {
+      const user = c.get('user')
+      const projectId = c.req.param('projectId')
+      const req = c.req.valid('json')
+
+      await authzService.hasPermission({
+        user,
+        permission: Permission.Admin,
+        type: ResourceType.Project,
+        id: projectId,
+      })
+
+      await projectService.addProjectMember({
+        projectId,
+        userId: req.userId,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        role: req.role as any,
+      })
+
+      return c.json({ success: true })
+    },
+  )
+  .get('/projects/:projectId/me', async (c) => {
+    const user = c.get('user')
+    const projectId = c.req.param('projectId')
+
+    await authzService.hasPermission({
+      user,
+      permission: Permission.Read,
+      type: ResourceType.Project,
+      id: projectId,
+    })
+
+    const me = await projectService.getProjectMe(projectId, user.id)
+    return c.json(me)
   })
 
 export default route

--- a/packages/core/src/authz/authz.test.ts
+++ b/packages/core/src/authz/authz.test.ts
@@ -397,4 +397,110 @@ describe('AuthzService', () => {
       projectId: project.id,
     })
   })
+
+  describe('New project-precedent authz rules', () => {
+    it('should prioritize project-specific role over team role', async () => {
+      const user = await prisma.user.create({
+        data: { name: 'Matt', email: 'matt@example.com', password: 'pass' },
+      })
+      const team = await prisma.team.create({ data: { name: 'Team Precedence' } })
+      const project = await prisma.project.create({
+        data: { name: 'Project Foo', teamId: team.id },
+      })
+
+      // Matt is a team editor (which would normally give Edit permissions)
+      const tm = await prisma.teamMember.create({
+        data: { teamId: team.id, userId: user.id, role: 'editor', scope: 'team' },
+      })
+
+      // But Matt is specifically added to Project Foo as a reviewer (Read-only)
+      await prisma.projectMember.create({
+        data: { projectId: project.id, teamMemberId: tm.id, role: 'reviewer' },
+      })
+
+      // Check that Matt has Read permission on Project Foo
+      await expect(
+        authzService.hasPermission({
+          type: ResourceType.Project,
+          id: project.id,
+          user,
+          permission: Permission.Read,
+        }),
+      ).resolves.toBeUndefined()
+
+      // Check that Matt is DENIED Edit permission on Project Foo (even though they are team editor)
+      await expect(
+        authzService.hasPermission({
+          type: ResourceType.Project,
+          id: project.id,
+          user,
+          permission: Permission.Edit,
+        }),
+      ).rejects.toThrow()
+    })
+
+    it('should fall back to team role if no project-specific role exists', async () => {
+      const user = await prisma.user.create({
+        data: { name: 'Jane', email: 'jane@example.com', password: 'pass' },
+      })
+      const team = await prisma.team.create({ data: { name: 'Team Fallback' } })
+      const project = await prisma.project.create({
+        data: { name: 'Project Bar', teamId: team.id },
+      })
+
+      // Jane is a team editor (scope: team)
+      await prisma.teamMember.create({
+        data: { teamId: team.id, userId: user.id, role: 'editor', scope: 'team' },
+      })
+
+      // Jane has no project-specific record on Project Bar, should fall back to team role (editor)
+      await expect(
+        authzService.hasPermission({
+          type: ResourceType.Project,
+          id: project.id,
+          user,
+          permission: Permission.Edit,
+        }),
+      ).resolves.toBeUndefined()
+    })
+
+    it('should deny project-scoped user access to projects they are not member of', async () => {
+      const user = await prisma.user.create({
+        data: { name: 'Guest', email: 'guest@example.com', password: 'pass' },
+      })
+      const team = await prisma.team.create({ data: { name: 'Team Guest' } })
+      const projectA = await prisma.project.create({ data: { name: 'Project A', teamId: team.id } })
+      const projectB = await prisma.project.create({ data: { name: 'Project B', teamId: team.id } })
+
+      // Guest is project-scoped
+      const tm = await prisma.teamMember.create({
+        data: { teamId: team.id, userId: user.id, role: 'reviewer', scope: 'project' },
+      })
+
+      // Guest is only added to Project A (as editor)
+      await prisma.projectMember.create({
+        data: { projectId: projectA.id, teamMemberId: tm.id, role: 'editor' },
+      })
+
+      // Guest can access Project A
+      await expect(
+        authzService.hasPermission({
+          type: ResourceType.Project,
+          id: projectA.id,
+          user,
+          permission: Permission.Edit,
+        }),
+      ).resolves.toBeUndefined()
+
+      // Guest CANNOT access Project B (denied)
+      await expect(
+        authzService.hasPermission({
+          type: ResourceType.Project,
+          id: projectB.id,
+          user,
+          permission: Permission.Read,
+        }),
+      ).rejects.toThrow('User has only project scope')
+    })
+  })
 })

--- a/packages/core/src/authz/authz.ts
+++ b/packages/core/src/authz/authz.ts
@@ -50,37 +50,35 @@ export class AuthzService {
 
     if (!member) throw new HTTPException(403, { message: 'User is not a member of the team' })
 
-    // 2. Check Scope
+    // 2. Check Project Membership first if project context is available
+    if (projectId) {
+      const pm = await prisma.projectMember.findUnique({
+        where: {
+          projectIdTeamMemberId: {
+            projectId: projectId,
+            teamMemberId: member.id,
+          },
+        },
+      })
+      if (pm) {
+        return this.checkRole(pm.role, req.permission)
+      }
+    }
+
+    // 3. Fall back to Team scope checks
     if (member.scope === 'team') {
       return this.checkRole(member.role, req.permission)
     }
 
-    // 3. Scope is Project
+    // 4. Scope is Project, and no project-level record exists (or no project context was provided)
     if (!projectId) {
       // User has project scope but no project context provided (e.g. Team-level resource)
-      // If it's a team-level resource, project-scoped users shouldn't have access except for Read maybe?
-      // But usually team resources like Skills/Providers are managed by Team Owners/Editors.
-      // For now, let's keep the logic: project-scoped users can't access team-level resources unless it's Read (like ListProjects).
+      // If it's a team-level resource, project-scoped users can access Read (like ListProjects).
       if (req.permission === Permission.Read) {
         return
       }
-      throw new HTTPException(403, { message: 'User has only project scope' })
     }
-
-    // Check Project Membership
-    const pm = await prisma.projectMember.findUnique({
-      where: {
-        projectIdTeamMemberId: {
-          projectId: projectId,
-          teamMemberId: member.id,
-        },
-      },
-    })
-
-    if (!pm)
-      throw new HTTPException(403, { message: `User is not a member of project ${projectId}` })
-
-    return this.checkRole(pm.role, req.permission)
+    throw new HTTPException(403, { message: 'User has only project scope' })
   }
 
   private async resolveContext(

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -342,6 +342,44 @@ export class ProjectService {
     })
   }
 
+  async getProjectMe(
+    projectId: string,
+    userId: string,
+  ): Promise<{ id: string; name: string; role: string; image?: string }> {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+    })
+    if (!user) throw new Error('User not found')
+
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+    })
+    if (!project) throw new Error('Project not found')
+
+    const tm = await prisma.teamMember.findUnique({
+      where: {
+        teamIdUserId: { teamId: project.teamId, userId },
+      },
+    })
+    if (!tm) throw new Error('User is not a team member')
+
+    const pm = await prisma.projectMember.findFirst({
+      where: {
+        projectId,
+        teamMemberId: tm.id,
+      },
+    })
+
+    const role = pm ? pm.role : tm.role
+
+    return {
+      id: user.id,
+      name: user.name,
+      role: role,
+      image: await getAvatarUrl(user.image),
+    }
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async toProjectInfo(p: any): Promise<ProjectInfo> {
     const pi: ProjectInfo = {

--- a/packages/dtos/src/project.ts
+++ b/packages/dtos/src/project.ts
@@ -110,3 +110,17 @@ export interface ServiceUpdateProjectMemberRoleRequest {
   userId: string
   role: 'editor' | 'reviewer'
 }
+
+export const addProjectMemberRequestSchema = z.object({
+  userId: z.string(),
+  role: z.enum(['owner', 'editor', 'reviewer']),
+})
+export type AddProjectMemberRequest = z.infer<typeof addProjectMemberRequestSchema>
+
+export const projectMeResponseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  role: z.enum(['owner', 'editor', 'reviewer', 'bot', 'unknown']),
+  image: z.string().optional(),
+})
+export type ProjectMeResponse = z.infer<typeof projectMeResponseSchema>

--- a/packages/webui/components/breadcrumb-nav.tsx
+++ b/packages/webui/components/breadcrumb-nav.tsx
@@ -71,7 +71,7 @@ export function BreadcrumbNav({
   versions,
 }: BreadcrumbNavProps) {
   const navigate = useNavigate()
-  const { canEdit } = usePermissions()
+  const { canEdit } = usePermissions(projectId)
 
   const handleVersionClick = (versionId: string) => {
     if (!projectId || !fileId) return

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -453,7 +453,7 @@ export function FileBrowser({
   const newVersionInputRef = useRef<HTMLInputElement>(null)
   const [targetVersionFileId, setTargetVersionFileId] = useState<string | null>(null)
   const fileContextMenu = useRef(false)
-  const { canEdit, canAdmin } = usePermissions()
+  const { canEdit, canAdmin } = usePermissions(projectId)
 
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 

--- a/packages/webui/components/file-browser/toolbar.tsx
+++ b/packages/webui/components/file-browser/toolbar.tsx
@@ -49,7 +49,7 @@ export function FileBrowserToolbar({
   onUpdateCollection,
   rootFolderId,
 }: FileBrowserToolbarProps) {
-  const { canEdit } = usePermissions()
+  const { canEdit } = usePermissions(projectId)
   const [popoverOpen, setPopoverOpen] = useState(false)
   const [searchDialogOpen, setSearchDialogOpen] = useState(false)
   const [manageDialogOpen, setManageDialogOpen] = useState(false)
@@ -72,7 +72,7 @@ export function FileBrowserToolbar({
     enabled: isCollection && !!assetId,
   })
 
-  const { data: members } = useQuery({
+  const { data: members, refetch: refetchProjectMembers } = useQuery({
     queryKey: ['projects', projectId, 'members'],
     queryFn: async () => {
       const res = await client.api.projects[':projectId'].members.$get({
@@ -95,16 +95,29 @@ export function FileBrowserToolbar({
     },
   })
 
-  const { data: me } = useQuery({
-    queryKey: ['teams', teamInfo?.teamId, 'me'],
+  const { data: teamMembers } = useQuery({
+    queryKey: ['teams', teamInfo?.teamId, 'members'],
     queryFn: async () => {
-      const res = await client.api.teams[':teamId'].me.$get({
+      const res = await client.api.teams[':teamId'].members.$get({
         param: { teamId: teamInfo?.teamId || '' },
+        query: {},
       })
-      if (!res.ok) throw new Error('Failed to fetch me')
+      if (!res.ok) throw new Error('Failed to fetch team members')
       return await res.json()
     },
-    enabled: !!teamInfo?.teamId,
+    enabled: !!teamInfo?.teamId && isMembersDialogOpen,
+  })
+
+  const { data: me, refetch: refetchMe } = useQuery({
+    queryKey: ['projects', projectId, 'me'],
+    queryFn: async () => {
+      const res = await client.api.projects[':projectId'].me.$get({
+        param: { projectId },
+      })
+      if (!res.ok) throw new Error('Failed to fetch project me')
+      return await res.json()
+    },
+    enabled: !!projectId,
   })
 
   const $inviteProject = client.api.projects[':projectId'].invite.$post
@@ -122,6 +135,23 @@ export function FileBrowserToolbar({
     },
   })
 
+  const $addProjectMember = client.api.projects[':projectId'].members.$post
+  const addProjectMemberMutation = useMutation<
+    InferResponseType<typeof $addProjectMember>,
+    Error,
+    InferRequestType<typeof $addProjectMember>
+  >({
+    mutationFn: async (args) => {
+      const res = await $addProjectMember(args)
+      if (!res.ok) throw new Error('Failed to add project member')
+      return await res.json()
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'members'] })
+      queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'me'] })
+    },
+  })
+
   const handleManageFields = () => {
     setPopoverOpen(false)
     setManageDialogOpen(true)
@@ -133,6 +163,27 @@ export function FileBrowserToolbar({
       json: { role },
     })
     return res.code
+  }
+
+  const handleOpenMembersDialog = (open: boolean) => {
+    setIsMembersDialogOpen(open)
+    if (open) {
+      refetchProjectMembers()
+      refetchMe()
+    }
+  }
+
+  const safeProjectMembers = Array.isArray(members) ? members : []
+  const safeTeamMembers = Array.isArray(teamMembers) ? teamMembers : []
+  const availableMembersToAdd = safeTeamMembers.filter(
+    (tm) => !safeProjectMembers.some((pm) => pm.id === tm.id),
+  )
+
+  const handleAddProjectMember = async (userId: string, role: 'editor' | 'reviewer' | 'owner') => {
+    await addProjectMemberMutation.mutateAsync({
+      param: { projectId },
+      json: { userId, role },
+    })
   }
 
   const updateMemberRoleMutation = useMutation({
@@ -304,7 +355,7 @@ export function FileBrowserToolbar({
         {!isRecentlyDeleted && (
           <div
             className="flex items-center -space-x-2 cursor-pointer hover:opacity-90"
-            onClick={() => setIsMembersDialogOpen(true)}
+            onClick={() => handleOpenMembersDialog(true)}
           >
             {members?.slice(0, 3).map((member) => (
               <Avatar key={member.id} className="border-2 border-background w-8 h-8">
@@ -331,7 +382,7 @@ export function FileBrowserToolbar({
 
       <MembersDialog
         open={isMembersDialogOpen}
-        onOpenChange={setIsMembersDialogOpen}
+        onOpenChange={handleOpenMembersDialog}
         title="Project Members"
         members={members || []}
         isOwner={me?.role === 'owner'}
@@ -343,6 +394,8 @@ export function FileBrowserToolbar({
           await removeMemberMutation.mutateAsync(memberId)
         }}
         currentUserId={me?.id}
+        availableMembersToAdd={availableMembersToAdd}
+        onAddMember={handleAddProjectMember}
       />
 
       <SearchFilterDialog

--- a/packages/webui/components/file-system-manager.tsx
+++ b/packages/webui/components/file-system-manager.tsx
@@ -47,7 +47,7 @@ export default function FileSystemManager({
 }: FileSystemManagerProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const { canEdit } = usePermissions()
+  const { canEdit } = usePermissions(projectId)
   const { loadedProjectId, setFields } = useFieldStore()
   const $patchMetadata = client.api.files[':fileId'].metadata.$patch
   const { mutate: patchMetadata } = useMutation<

--- a/packages/webui/components/file-viewer-right-sidebar.tsx
+++ b/packages/webui/components/file-viewer-right-sidebar.tsx
@@ -49,7 +49,7 @@ export function FileViewerRightSidebar({
   onTyping,
   selectedCommentId,
 }: FileViewerRightSidebarProps) {
-  const { canEdit } = usePermissions()
+  const { canEdit } = usePermissions(projectId)
   const { fields, setFields } = useFieldStore()
   const queryClient = useQueryClient()
   const { ref, inView } = useInView()

--- a/packages/webui/components/folder-tree.tsx
+++ b/packages/webui/components/folder-tree.tsx
@@ -75,7 +75,7 @@ export function FolderTree({
 }: FolderTreeProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const { canEdit } = usePermissions()
+  const { canEdit } = usePermissions(projectId)
   const isRecentlyDeleted = useMatch({
     from: '/projects/$projectId/recently-deleted',
     shouldThrow: false,

--- a/packages/webui/components/members-dialog.tsx
+++ b/packages/webui/components/members-dialog.tsx
@@ -41,6 +41,8 @@ interface MembersDialogProps {
   onUpdateRole?: (memberId: string, role: 'editor' | 'reviewer') => Promise<void>
   onRemoveMember?: (memberId: string) => Promise<void>
   currentUserId?: string
+  availableMembersToAdd?: Member[]
+  onAddMember?: (userId: string, role: 'editor' | 'reviewer') => Promise<void>
 }
 
 export function MembersDialog({
@@ -53,12 +55,17 @@ export function MembersDialog({
   onUpdateRole,
   onRemoveMember,
   currentUserId,
+  availableMembersToAdd,
+  onAddMember,
 }: MembersDialogProps) {
   const [inviteRole, setInviteRole] = useState<'editor' | 'reviewer'>('editor')
   const [inviteLink, setInviteLink] = useState<string | null>(null)
   const [isGenerating, setIsGenerating] = useState(false)
   const [updatingMemberId, setUpdatingMemberId] = useState<string | null>(null)
   const [memberToRemove, setMemberToRemove] = useState<Member | null>(null)
+  const [memberToAddId, setMemberToAddId] = useState<string>('')
+  const [memberToAddRole, setMemberToAddRole] = useState<'editor' | 'reviewer'>('editor')
+  const [isAdding, setIsAdding] = useState(false)
 
   const handleUpdateRole = async (memberId: string, role: 'editor' | 'reviewer') => {
     if (!onUpdateRole) return
@@ -243,6 +250,82 @@ export function MembersDialog({
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>
+
+          {isOwner && onAddMember && availableMembersToAdd && availableMembersToAdd.length > 0 && (
+            <div className="border-t pt-4">
+              <h4 className="text-sm font-medium mb-3">Add Team Member to Project</h4>
+              <div className="space-y-3">
+                <div className="flex gap-2">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="outline" className="flex-1 justify-between text-left">
+                        <span className="truncate">
+                          {availableMembersToAdd.find((m) => m.id === memberToAddId)?.name ||
+                            'Select Team Member'}
+                        </span>
+                        <ChevronDown className="h-4 w-4 opacity-50 ml-2 shrink-0" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent className="max-h-[200px] overflow-y-auto">
+                      <DropdownMenuRadioGroup
+                        value={memberToAddId}
+                        onValueChange={setMemberToAddId}
+                      >
+                        {availableMembersToAdd.map((m) => (
+                          <DropdownMenuRadioItem key={m.id} value={m.id || ''}>
+                            {m.name}
+                          </DropdownMenuRadioItem>
+                        ))}
+                      </DropdownMenuRadioGroup>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="outline" className="w-[120px] justify-between">
+                        {memberToAddRole === 'editor' ? 'Editor' : 'Reviewer'}
+                        <ChevronDown className="h-4 w-4 opacity-50" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent>
+                      <DropdownMenuRadioGroup
+                        value={memberToAddRole}
+                        onValueChange={(v) => setMemberToAddRole(v as 'editor' | 'reviewer')}
+                      >
+                        <DropdownMenuRadioItem value="editor">Editor</DropdownMenuRadioItem>
+                        <DropdownMenuRadioItem value="reviewer">Reviewer</DropdownMenuRadioItem>
+                      </DropdownMenuRadioGroup>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+
+                  <Button
+                    onClick={async () => {
+                      if (!memberToAddId) {
+                        toast.error('Please select a team member')
+                        return
+                      }
+                      setIsAdding(true)
+                      try {
+                        await onAddMember(memberToAddId, memberToAddRole)
+                        toast.success('Member added successfully')
+                        setMemberToAddId('')
+                      } catch (error) {
+                        console.error(error)
+                        toast.error('Failed to add member')
+                      } finally {
+                        setIsAdding(false)
+                      }
+                    }}
+                    disabled={isAdding || !memberToAddId}
+                    className="w-[80px]"
+                  >
+                    {isAdding && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                    Add
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
 
           {isOwner && onInvite && (
             <div className="border-t pt-4">

--- a/packages/webui/components/members-dialog.tsx
+++ b/packages/webui/components/members-dialog.tsx
@@ -63,9 +63,12 @@ export function MembersDialog({
   const [isGenerating, setIsGenerating] = useState(false)
   const [updatingMemberId, setUpdatingMemberId] = useState<string | null>(null)
   const [memberToRemove, setMemberToRemove] = useState<Member | null>(null)
-  const [memberToAddId, setMemberToAddId] = useState<string>('')
-  const [memberToAddRole, setMemberToAddRole] = useState<'editor' | 'reviewer'>('editor')
-  const [isAdding, setIsAdding] = useState(false)
+  const [rolesToAdd, setRolesToAdd] = useState<Record<string, 'editor' | 'reviewer'>>({})
+  const [addingMemberId, setAddingMemberId] = useState<string | null>(null)
+
+  const setRoleToAdd = (memberId: string, role: 'editor' | 'reviewer') => {
+    setRolesToAdd((prev) => ({ ...prev, [memberId]: role }))
+  }
 
   const handleUpdateRole = async (memberId: string, role: 'editor' | 'reviewer') => {
     if (!onUpdateRole) return
@@ -134,6 +137,8 @@ export function MembersDialog({
     if (!newOpen) {
       setInviteLink(null)
       setInviteRole('editor')
+      setRolesToAdd({})
+      setAddingMemberId(null)
     }
     onOpenChange(newOpen)
   }
@@ -226,7 +231,6 @@ export function MembersDialog({
               </div>
             ))}
           </div>
-
           <AlertDialog
             open={!!memberToRemove}
             onOpenChange={(open) => !open && setMemberToRemove(null)}
@@ -249,84 +253,97 @@ export function MembersDialog({
                 </AlertDialogAction>
               </AlertDialogFooter>
             </AlertDialogContent>
-          </AlertDialog>
-
+          </AlertDialog>{' '}
           {isOwner && onAddMember && availableMembersToAdd && availableMembersToAdd.length > 0 && (
             <div className="border-t pt-4">
               <h4 className="text-sm font-medium mb-3">Add Team Member to Project</h4>
-              <div className="space-y-3">
-                <div className="flex gap-2">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="outline" className="flex-1 justify-between text-left">
-                        <span className="truncate">
-                          {availableMembersToAdd.find((m) => m.id === memberToAddId)?.name ||
-                            'Select Team Member'}
-                        </span>
-                        <ChevronDown className="h-4 w-4 opacity-50 ml-2 shrink-0" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent className="max-h-[200px] overflow-y-auto">
-                      <DropdownMenuRadioGroup
-                        value={memberToAddId}
-                        onValueChange={setMemberToAddId}
-                      >
-                        {availableMembersToAdd.map((m) => (
-                          <DropdownMenuRadioItem key={m.id} value={m.id || ''}>
-                            {m.name}
-                          </DropdownMenuRadioItem>
-                        ))}
-                      </DropdownMenuRadioGroup>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+              <div className="max-h-[200px] overflow-y-auto space-y-2 pr-1">
+                {availableMembersToAdd.map((member) => {
+                  const currentRole = rolesToAdd[member.id!] || 'editor'
+                  return (
+                    <div
+                      key={member.id}
+                      className="flex items-center justify-between p-2 rounded-lg hover:bg-muted/50"
+                    >
+                      <div className="flex items-center gap-3">
+                        <Avatar>
+                          {member.image && (
+                            <AvatarImage
+                              src={member.image}
+                              alt={member.name}
+                              className="object-cover"
+                            />
+                          )}
+                          <AvatarFallback>{getInitials(member.name)}</AvatarFallback>
+                        </Avatar>
+                        <div className="flex flex-col">
+                          <span className="text-sm font-medium">{member.name}</span>
+                          <span className="text-xs text-muted-foreground capitalize">
+                            {member.scope === 'team' ? 'Team Member' : 'Project Member'}
+                          </span>
+                        </div>
+                      </div>
 
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="outline" className="w-[120px] justify-between">
-                        {memberToAddRole === 'editor' ? 'Editor' : 'Reviewer'}
-                        <ChevronDown className="h-4 w-4 opacity-50" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent>
-                      <DropdownMenuRadioGroup
-                        value={memberToAddRole}
-                        onValueChange={(v) => setMemberToAddRole(v as 'editor' | 'reviewer')}
-                      >
-                        <DropdownMenuRadioItem value="editor">Editor</DropdownMenuRadioItem>
-                        <DropdownMenuRadioItem value="reviewer">Reviewer</DropdownMenuRadioItem>
-                      </DropdownMenuRadioGroup>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                      <div className="flex items-center gap-2">
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="h-8 px-2 text-xs capitalize w-26"
+                              disabled={addingMemberId === member.id}
+                            >
+                              {currentRole}
+                              <ChevronDown className="ml-1 h-3 w-3 opacity-50" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent>
+                            <DropdownMenuRadioGroup
+                              value={currentRole}
+                              onValueChange={(v) =>
+                                setRoleToAdd(member.id!, v as 'editor' | 'reviewer')
+                              }
+                            >
+                              <DropdownMenuRadioItem value="editor" className="text-xs">
+                                Editor
+                              </DropdownMenuRadioItem>
+                              <DropdownMenuRadioItem value="reviewer" className="text-xs">
+                                Reviewer
+                              </DropdownMenuRadioItem>
+                            </DropdownMenuRadioGroup>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
 
-                  <Button
-                    onClick={async () => {
-                      if (!memberToAddId) {
-                        toast.error('Please select a team member')
-                        return
-                      }
-                      setIsAdding(true)
-                      try {
-                        await onAddMember(memberToAddId, memberToAddRole)
-                        toast.success('Member added successfully')
-                        setMemberToAddId('')
-                      } catch (error) {
-                        console.error(error)
-                        toast.error('Failed to add member')
-                      } finally {
-                        setIsAdding(false)
-                      }
-                    }}
-                    disabled={isAdding || !memberToAddId}
-                    className="w-[80px]"
-                  >
-                    {isAdding && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                    Add
-                  </Button>
-                </div>
+                        <Button
+                          onClick={async () => {
+                            setAddingMemberId(member.id!)
+                            try {
+                              await onAddMember(member.id!, currentRole)
+                              toast.success(`Added ${member.name} successfully`)
+                            } catch (error) {
+                              console.error(error)
+                              toast.error(`Failed to add ${member.name}`)
+                            } finally {
+                              setAddingMemberId(null)
+                            }
+                          }}
+                          disabled={addingMemberId !== null}
+                          size="sm"
+                          className="h-8 text-xs px-3 w-[60px]"
+                        >
+                          {addingMemberId === member.id ? (
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                          ) : (
+                            'Add'
+                          )}
+                        </Button>
+                      </div>
+                    </div>
+                  )
+                })}
               </div>
             </div>
           )}
-
           {isOwner && onInvite && (
             <div className="border-t pt-4">
               <h4 className="text-sm font-medium mb-3">Invite New Member</h4>

--- a/packages/webui/hooks/use-permissions.ts
+++ b/packages/webui/hooks/use-permissions.ts
@@ -22,20 +22,28 @@ export interface Permissions {
  * Reuses the same React Query cache key (['teams', teamId, 'me']) populated
  * by __root.tsx, so no extra API calls are made.
  */
-export function usePermissions(): Permissions {
+export function usePermissions(projectId?: string): Permissions {
   const teamId = useTeamContextStore((s) => s.teamId)
 
   const { data: me } = useQuery({
-    queryKey: ['teams', teamId, 'me'],
+    queryKey: projectId ? ['projects', projectId, 'me'] : ['teams', teamId, 'me'],
     queryFn: async () => {
-      if (!teamId) return null
-      const res = await client.api.teams[':teamId'].me.$get({
-        param: { teamId },
-      })
-      if (!res.ok) throw new Error('Failed to fetch me')
-      return await res.json()
+      if (projectId) {
+        const res = await client.api.projects[':projectId'].me.$get({
+          param: { projectId },
+        })
+        if (!res.ok) throw new Error('Failed to fetch project me')
+        return await res.json()
+      } else {
+        if (!teamId) return null
+        const res = await client.api.teams[':teamId'].me.$get({
+          param: { teamId },
+        })
+        if (!res.ok) throw new Error('Failed to fetch team me')
+        return await res.json()
+      }
     },
-    enabled: !!teamId,
+    enabled: projectId ? !!projectId : !!teamId,
   })
 
   return useMemo(

--- a/packages/webui/routes/__root.tsx
+++ b/packages/webui/routes/__root.tsx
@@ -10,10 +10,10 @@ import { useTeamContextStore } from '@/ui/stores/team-context'
 import { useUploadStore } from '@/ui/stores/upload'
 import { useQuery } from '@tanstack/react-query'
 import {
-    createRootRouteWithContext,
-    Outlet,
-    useNavigate,
-    useRouterState,
+  createRootRouteWithContext,
+  Outlet,
+  useNavigate,
+  useRouterState,
 } from '@tanstack/react-router'
 import { useEffect } from 'react'
 


### PR DESCRIPTION
## Summary

Allow administrators to add existing team members to projects directly, adjust authorization checks so that project-specific memberships take precedence over team-wide fallbacks, and update the frontend project members dialog to show the add user controls and refresh on dialog open.

## Changes

- **DTO**: Added `addProjectMemberRequestSchema` and `projectMeResponseSchema` for validation and type-safety.
- **Authz**: Updated `AuthzService.hasPermission` to check for project-level memberships first, falling back to team-level scopes only if no project-level record is found.
- **API**: Added `POST /projects/:projectId/members` to add project members and `GET /projects/:projectId/me` to get the effective project role.
- **Service**: Added `ProjectService.getProjectMe` to compute the effective project role.
- **Frontend Hook**: Extended `usePermissions` to accept an optional `projectId` and query the project-specific `me` endpoint.
- **Frontend Dialog**: Extended `MembersDialog` to include an "Add Team Member to Project" dropdown section, and updated `toolbar.tsx` to conditionally fetch team members and manually refetch project members / permissions when the dialog opens.

## Verification

Ran the complete vitest suite:
- Added new auth precedence tests to `authz.test.ts` (`should prioritize project-specific role over team role`, `should fall back to team role if no project-specific role exists`, `should deny project-scoped user access to projects they are not member of`).
- Added new endpoints tests to `project.test.ts` (`POST /projects/:projectId/members`, `GET /projects/:projectId/me`).
- Checked typecheck (`bun run typecheck`), linting (`bun run lint`), formatting (`bun run format`), and tests (`bun run test`) across the monorepo; all passed successfully.

## Notes

None.