### PR TITLE
ci: add release-npm.yaml workflow

### DIFF
--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -1,0 +1,83 @@
+name: Build, Release & Publish to NPM
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g., v0.12.0)'
+        required: true
+        type: string
+      source_ref:
+        description: 'Source ref to build/publish (defaults to tag)'
+        required: false
+        type: string
+
+permissions: {}
+
+jobs:
+  release:
+    name: Build, Release and Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+      SOURCE_REF: ${{ github.event.inputs.source_ref || github.event.inputs.tag || github.ref_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SOURCE_REF }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep bubblewrap socat libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun run test
+
+      - name: Build NPM packages
+        run: bun run build-npm
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${{ env.RELEASE_TAG }}" >/dev/null 2>&1; then
+            gh release edit "${{ env.RELEASE_TAG }}" \
+              --title "${{ env.RELEASE_TAG }}" \
+              --generate-notes
+          else
+            gh release create "${{ env.RELEASE_TAG }}" \
+              --title "${{ env.RELEASE_TAG }}" \
+              --generate-notes
+          fi
+
+      - name: Publish to NPM
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: bun run scripts/publish.ts

--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     env:
       RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
       SOURCE_REF: ${{ github.event.inputs.source_ref || github.event.inputs.tag || github.ref_name }}
@@ -78,6 +79,4 @@ jobs:
           fi
 
       - name: Publish to NPM
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bun run scripts/publish.ts


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions CI workflow `release-npm.yaml` that triggers when a new version tag is created or manually via workflow dispatch. The workflow builds the packages, runs tests, creates a GitHub Release, and publishes to the NPM registry using NPM Trusted Publisher (OIDC).

## Changes

- Added `.github/workflows/release-npm.yaml`.
- Configured workflow triggers on `push` of tags matching `v*` and `workflow_dispatch`.
- Structured steps to:
  - Checkout code.
  - Setup Bun and Node.js.
  - Install system dependencies matching project needs (`ripgrep`, `bubblewrap`, `socat`, `libcairo2-dev`, `libpango1.0-dev`, `libjpeg-dev`, `libgif-dev`, `librsvg2-dev`, `fd-find`).
  - Install dependencies, lint, typecheck, and run tests.
  - Build NPM packages (`bun run build-npm`).
  - Create/edit GitHub Release (`gh release create` / `gh release edit`).
  - Publish packages to NPM (`bun run scripts/publish.ts`).
- Added `id-token: write` permission to support OIDC exchanges via NPM Trusted Publishers (no NPM token secrets required).

## Verification

- Ran `bun run lint` and `bun run typecheck` successfully.
- Ran the test suite `bun run test` successfully with 465 passing tests.
- Tested `bun run publish:dry` locally to ensure the NPM package build and pack dry-runs succeed for all wrapper and platform-specific packages.

## Notes

- Uses NPM Trusted Publisher (configured on NPM for packages).
