### PR TITLE
fix(npm): add repository metadata to package.json for provenance verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.2",
   "private": true,
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shumaiOne/shumai.git"
+  },
   "workspaces": [
     "packages/*",
     "apps/*"

--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -161,6 +161,7 @@ async function buildPlatformPackages(
       description: `${target.platform} ${target.arch} binary for ${appName}`,
       os: [target.platform],
       cpu: [target.arch],
+      repository: rootPackageJson.repository,
     }
 
     await writeFile(
@@ -289,6 +290,7 @@ child.on('error', (err) => {
     files: ['bin', ...(hasPrisma ? ['prisma'] : [])],
     dependencies,
     optionalDependencies,
+    repository: rootPackageJson.repository,
   }
 
   await writeFile(


### PR DESCRIPTION
## Summary

This PR resolves the `422 Unprocessable Entity` error when publishing to npm with provenance validation by adding the repository metadata to the generated packages.

## Changes

- Added the standard `repository` metadata block to the root `package.json`.
- Modified `scripts/build-npm.ts` to propagate the `repository` metadata block from the root `package.json` into both the dynamically generated platform-specific sub-packages and the main wrapper packages.

## Verification

- Ran `bun run build-npm` to verify packages are built successfully.
- Inspected the generated `package.json` files in `dist/` (e.g. `dist/shumai/package.json` and `dist/shumai-win32-arm64/package.json`) to confirm the `repository` field is correctly populated.
- Ran all required validation checks:
  - `bun run lint` (Passed)
  - `bun run format` (Passed)
  - `bun run typecheck` (Passed)
  - `bun run test` (All 465 tests passed)

## Notes

None.
