### PR TITLE
fix(cli): resolve platform binary path resolution under nested node_modules

### DIFF
--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -223,7 +223,7 @@ if (platform === 'darwin' && arch === 'arm64') {
 
 const pathsToTry = [
   join(__dirname, '..', '..', '..', pkgName, 'bin', binaryName), // Flat node_modules
-  join(__dirname, '..', '..', 'node_modules', pkgName, 'bin', binaryName), // Nested node_modules
+  join(__dirname, '..', 'node_modules', pkgName, 'bin', binaryName), // Nested node_modules
 ]
 
 let binaryPath = ''


### PR DESCRIPTION
## Summary

This PR fixes a bug in the global/nested installation of `@shumai-one/shumai` CLI where the wrapper script fails to find the platform-specific compiled binary package if it is installed as a nested optional dependency inside `shumai/node_modules`.

## Changes

- Updated `pathsToTry` resolution in `scripts/build-npm.ts` to look under `join(__dirname, '..', 'node_modules', pkgName)` instead of `join(__dirname, '..', '..', 'node_modules', pkgName)` for nested package structures.

## Verification

- Built npm packages using `bun run build-npm`.
- Created simulated nested installation layout and verified the compiled binary loads and starts correctly.
- Verified that all workspace checks (`bun run lint`, `bun run format`, `bun run typecheck`, `bun run test`) pass simultaneously.

## Notes

None.