### PR TITLE
docs(readme): improve remote deployment and temporal execution instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ The easiest way to run Shumai is using Docker Compose. You do not need to clone 
 2. Configure environment variables (if deploying remotely):
    If you are deploying Shumai to a remote server (e.g., AWS ECS, EC2, VPS), you must edit `docker-compose.yaml` under `shumai -> environment` to set:
    - `AWS_ENDPOINT_URL_S3` to your server's public IP or domain name (e.g., `http://43.153.213.233:3000`).
-   - `BETTER_AUTH_URL` to your server's public IP or domain name (e.g., `http://43.153.213.233:3000`).
 3. Start the services:
    ```bash
    docker compose up -d
@@ -96,13 +95,12 @@ Create a `.env` file in this folder and add the following configuration (which a
 ```env
 DATABASE_URL=postgresql://shumai:shumai_password@localhost:5432/shumai_db?schema=public
 BETTER_AUTH_SECRET=ySxs7DxzHDZBbeeHNPEwBuspYwipBqz5Gk5XdBjNhWw=
-BETTER_AUTH_URL=http://localhost:3000
 STORAGE_BACKEND=local
 AWS_ENDPOINT_URL_S3=http://localhost:3000
 ```
 
 > [!NOTE]
-> If you are deploying on a remote server, make sure to change `BETTER_AUTH_URL` and `AWS_ENDPOINT_URL_S3` from `http://localhost:3000` to your server's public IP address or domain name (e.g., `http://43.153.213.233:3000`).
+> If you are deploying on a remote server, make sure to change `AWS_ENDPOINT_URL_S3` from `http://localhost:3000` to your server's public IP address or domain name (e.g., `http://43.153.213.233:3000`).
 
 #### Step 4: Run Shumai
 
@@ -160,7 +158,7 @@ Spin up the database, Temporal server, and the main Shumai web application on yo
    ```
 2. Configure the environment variables in `docker-compose.yaml`:
    - Set the S3 storage environment variables (`S3_ENDPOINT_URL`, `S3_REGION`, `BUCKET_NAME`, etc.).
-   - If deploying to a remote host (e.g., AWS ECS, EC2, VPS), update `AWS_ENDPOINT_URL_S3` and `BETTER_AUTH_URL` under the `shumai` service to your server's public IP address or domain name (e.g., `http://43.153.213.233:3000`).
+   - If deploying to a remote host (e.g., AWS ECS, EC2, VPS), update `AWS_ENDPOINT_URL_S3` under the `shumai` service to your server's public IP address or domain name (e.g., `http://43.153.213.233:3000`).
    - Note: The `TEMPORAL_ADDRESS` environment variable for the main Shumai application is pre-configured as `temporal:7233` (referencing the Temporal container within the same Docker network) and does not need to be changed.
 3. Start the services:
    ```bash

--- a/README.md
+++ b/README.md
@@ -41,15 +41,16 @@ The easiest way to run Shumai is using Docker Compose. You do not need to clone 
    ```bash
    curl -o docker-compose.yaml https://raw.githubusercontent.com/shumaiOne/shumai/main/docker-compose/local/docker-compose.yaml
    ```
-2. Start the services:
+2. Configure environment variables (if deploying remotely):
+   If you are deploying Shumai to a remote server (e.g., AWS ECS, EC2, VPS), you must edit `docker-compose.yaml` under `shumai -> environment` to set:
+   - `AWS_ENDPOINT_URL_S3` to your server's public IP or domain name (e.g., `http://43.153.213.233:3000`).
+   - `BETTER_AUTH_URL` to your server's public IP or domain name (e.g., `http://43.153.213.233:3000`).
+3. Start the services:
    ```bash
    docker compose up -d
    ```
-3. Access the application in your browser at:
-   ```
-   http://localhost:3000
-   ```
-4. Stop and remove the services:
+4. Access the application in your browser at `http://localhost:3000` (or `http://<your-server-ip>:3000` for remote deployments).
+5. Stop and remove the services:
    ```bash
    docker compose down
    ```
@@ -94,10 +95,14 @@ Create a `.env` file in this folder and add the following configuration (which a
 
 ```env
 DATABASE_URL=postgresql://shumai:shumai_password@localhost:5432/shumai_db?schema=public
-BETTER_AUTH_SECRET=ySxs7DxzHDGBbeeHNPEwBuspYwipBqz5Gk5XdBjNhWw=
+BETTER_AUTH_SECRET=ySxs7DxzHDZBbeeHNPEwBuspYwipBqz5Gk5XdBjNhWw=
 BETTER_AUTH_URL=http://localhost:3000
 STORAGE_BACKEND=local
+AWS_ENDPOINT_URL_S3=http://localhost:3000
 ```
+
+> [!NOTE]
+> If you are deploying on a remote server, make sure to change `BETTER_AUTH_URL` and `AWS_ENDPOINT_URL_S3` from `http://localhost:3000` to your server's public IP address or domain name (e.g., `http://43.153.213.233:3000`).
 
 #### Step 4: Run Shumai
 
@@ -142,39 +147,52 @@ For production environments or workloads with heavy media processing and AI agen
 
 By setting the environment variable `WORKFLOW_EXECUTOR=temporal`, the main Shumai application will delegate background workflows to a Temporal cluster instead of using the local polling-based engine. This allows you to run independent worker processes (`shumai-agent` and `shumai-transcode`) on separate specialized machines (e.g., transcoding workers on GPU-accelerated instances, and agents on sandboxed environments).
 
-### 1. Configure the environment
+> [!IMPORTANT]
+> **Storage Requirement**: Because the main Shumai application and the background workers run on different machines in a distributed setup, **you must use S3-compatible storage** (e.g., AWS S3, Cloudflare R2, MinIO). Local storage (`STORAGE_BACKEND=local`) will not work because the workers and the main application do not share a common local filesystem.
 
-Add the following variables to your `.env` configuration on all machines:
+### 1. Set up the Core Stack
 
-```env
-WORKFLOW_EXECUTOR=temporal
-TEMPORAL_ADDRESS=localhost:7233
-```
+Spin up the database, Temporal server, and the main Shumai web application on your primary host machine using Docker Compose:
 
-### 2. Set up the stack
-
-You can spin up the main application, database, and Temporal services using Docker Compose:
-
-1. Create a `docker-compose.yaml` file by downloading the configuration:
+1. Download the Temporal-enabled `docker-compose.yaml` file:
    ```bash
    curl -o docker-compose.yaml https://raw.githubusercontent.com/shumaiOne/shumai/main/docker-compose/temporal/docker-compose.yaml
    ```
-2. Start the services:
+2. Configure the environment variables in `docker-compose.yaml`:
+   - Set the S3 storage environment variables (`S3_ENDPOINT_URL`, `S3_REGION`, `BUCKET_NAME`, etc.).
+   - If deploying to a remote host (e.g., AWS ECS, EC2, VPS), update `AWS_ENDPOINT_URL_S3` and `BETTER_AUTH_URL` under the `shumai` service to your server's public IP address or domain name (e.g., `http://43.153.213.233:3000`).
+   - Note: The `TEMPORAL_ADDRESS` environment variable for the main Shumai application is pre-configured as `temporal:7233` (referencing the Temporal container within the same Docker network) and does not need to be changed.
+3. Start the services:
    ```bash
    docker compose up -d
    ```
-   This exposes the Shumai Web UI at `http://localhost:3000` and the Temporal dashboard at `http://localhost:8080`.
+   This exposes the Shumai Web UI at `http://<host-ip>:3000`, the database at port `5432`, the Temporal gRPC service at port `7233`, and the Temporal dashboard at `http://<host-ip>:8080`. Ensure that port `7233` is exposed and accessible by your background worker machines.
 
-### 3. Run the background workers
+### 2. Run the Background Workers
 
-When running in Temporal mode, the main Shumai application only submits tasks to the Temporal queue. To process these tasks, you must run at least one agent worker and one transcoding worker:
+When running in Temporal mode, the main Shumai application only submits tasks to the Temporal queue. To process these tasks, you must run at least one agent worker and one transcoding worker on their respective machines.
+
+Configure a `.env` file on each worker machine. It must contain the following variables:
+
+```env
+DATABASE_URL=postgresql://shumai:shumai_password@<host-ip>:5432/shumai_db?schema=public
+TEMPORAL_ADDRESS=<host-ip>:7233
+STORAGE_BACKEND=s3
+AWS_ENDPOINT_URL_S3=http://<host-ip>:3000 # Or your public S3/R2 endpoint URL
+S3_REGION=us-east-1
+S3_BUCKET=shumai
+S3_ACCESS_KEY_ID=your-access-key-id
+S3_SECRET_ACCESS_KEY=your-secret-access-key
+```
+
+Run the workers:
 
 - **Transcoding Worker**:
   Install `@shumai-one/shumai-transcode` and run it on a machine with sufficient transcoding resources:
 
   ```bash
   npm install -g @shumai-one/shumai-transcode
-  # Run worker with correct .env containing DATABASE_URL and TEMPORAL_ADDRESS
+  # Run worker with the configured .env
   shumai-transcode
   ```
 
@@ -182,6 +200,6 @@ When running in Temporal mode, the main Shumai application only submits tasks to
   Install `@shumai-one/shumai-agent` and run it on a machine configured for AI tasks (with access to sandbox environments and `GEMINI_API_KEY`):
   ```bash
   npm install -g @shumai-one/shumai-agent
-  # Run worker with correct .env containing DATABASE_URL and TEMPORAL_ADDRESS
+  # Run worker with the configured .env (must include GEMINI_API_KEY)
   shumai-agent
   ```

--- a/README.md
+++ b/README.md
@@ -42,17 +42,12 @@ The easiest way to run Shumai is using Docker Compose. You do not need to clone 
    curl -o docker-compose.yaml https://raw.githubusercontent.com/shumaiOne/shumai/main/docker-compose/local/docker-compose.yaml
    ```
 2. Configure environment variables (if deploying remotely):
-   If you are deploying Shumai to a remote server (e.g., AWS ECS, EC2, VPS), you must edit `docker-compose.yaml` under `shumai -> environment` to set:
-   - `AWS_ENDPOINT_URL_S3` to your server's public IP or domain name (e.g., `http://43.153.213.233:3000`).
+   If you are deploying Shumai to a remote server (e.g., AWS ECS, EC2, VPS), you must edit `docker-compose.yaml`, set `AWS_ENDPOINT_URL_S3` to your server's public IP or domain name (e.g., `http://12.345.567.789:3000`).
 3. Start the services:
    ```bash
    docker compose up -d
    ```
 4. Access the application in your browser at `http://localhost:3000` (or `http://<your-server-ip>:3000` for remote deployments).
-5. Stop and remove the services:
-   ```bash
-   docker compose down
-   ```
 
 ### Option 2: Install from NPM
 
@@ -86,8 +81,8 @@ npm install -g @shumai-one/shumai
 Create a new directory for your Shumai configuration and navigate into it:
 
 ```bash
-mkdir my-shumai-app
-cd my-shumai-app
+mkdir shumai
+cd shumai
 ```
 
 Create a `.env` file in this folder and add the following configuration (which aligns with the Docker database command in Step 1):
@@ -100,7 +95,7 @@ AWS_ENDPOINT_URL_S3=http://localhost:3000
 ```
 
 > [!NOTE]
-> If you are deploying on a remote server, make sure to change `AWS_ENDPOINT_URL_S3` from `http://localhost:3000` to your server's public IP address or domain name (e.g., `http://43.153.213.233:3000`).
+> If you are deploying on a remote server, make sure to change `AWS_ENDPOINT_URL_S3` from `http://localhost:3000` to your server's public IP address or domain name.
 
 #### Step 4: Run Shumai
 
@@ -158,7 +153,7 @@ Spin up the database, Temporal server, and the main Shumai web application on yo
    ```
 2. Configure the environment variables in `docker-compose.yaml`:
    - Set the S3 storage environment variables (`S3_ENDPOINT_URL`, `S3_REGION`, `BUCKET_NAME`, etc.).
-   - If deploying to a remote host (e.g., AWS ECS, EC2, VPS), update `AWS_ENDPOINT_URL_S3` under the `shumai` service to your server's public IP address or domain name (e.g., `http://43.153.213.233:3000`).
+   - If deploying to a remote host (e.g., AWS ECS, EC2, VPS), update `AWS_ENDPOINT_URL_S3` under the `shumai` service to your server's public IP address or domain name.
    - Note: The `TEMPORAL_ADDRESS` environment variable for the main Shumai application is pre-configured as `temporal:7233` (referencing the Temporal container within the same Docker network) and does not need to be changed.
 3. Start the services:
    ```bash
@@ -195,7 +190,7 @@ Run the workers:
   ```
 
 - **AI Agent Worker**:
-  Install `@shumai-one/shumai-agent` and run it on a machine configured for AI tasks (with access to sandbox environments and `GEMINI_API_KEY`):
+  Install `@shumai-one/shumai-agent` and run it on a machine configured for Agent tasks:
   ```bash
   npm install -g @shumai-one/shumai-agent
   # Run worker with the configured .env (must include GEMINI_API_KEY)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,13 @@ docker run --name shumai_postgres \
 Install the main Shumai package using `npm`, `pnpm`, `bun`, or `yarn`:
 
 > [!IMPORTANT]
-> **Prerequisite**: Because Shumai uses a secure sandboxed execution environment for its AI agents, your machine must meet the platform requirements for the sandbox. Please verify you have installed the required dependencies for your OS as detailed in the [Agent Sandbox Platform Support](#agent-sandbox-platform-support) section.
+> **Prerequisites**:
+>
+> - **Agent Sandbox**: Because Shumai uses a secure sandboxed execution environment for its AI agents, your machine must meet the platform requirements for the sandbox. Please verify you have installed the required dependencies for your OS as detailed in the [Agent Sandbox Platform Support](#agent-sandbox-platform-support) section.
+> - **FFmpeg & FFprobe**: Shumai requires `ffmpeg` and `ffprobe` to be installed on your system path for handling media transcoding and metadata extraction.
+>   - macOS: `brew install ffmpeg`
+>   - Ubuntu/Debian: `sudo apt-get install ffmpeg`
+>   - Fedora: `sudo dnf install ffmpeg`
 
 ```bash
 npm install -g @shumai-one/shumai
@@ -180,6 +186,7 @@ Configure a `.env` file on each worker machine. It must contain the following va
 
 ```env
 DATABASE_URL=postgresql://shumai:shumai_password@<host-ip>:5432/shumai_db?schema=public
+WORKFLOW_EXECUTOR=temporal
 TEMPORAL_ADDRESS=<host-ip>:7233
 STORAGE_BACKEND=s3
 AWS_ENDPOINT_URL_S3=http://<host-ip>:3000 # Or your public S3/R2 endpoint URL
@@ -193,6 +200,12 @@ Run the workers:
 
 - **Transcoding Worker**:
   Install `@shumai-one/shumai-transcode` and run it on a machine with sufficient transcoding resources:
+
+  > [!IMPORTANT]
+  > **FFmpeg Requirement**: The transcoding worker requires `ffmpeg` and `ffprobe` to be installed and available on the machine's system path.
+  >
+  > - macOS: `brew install ffmpeg`
+  > - Ubuntu/Debian: `sudo apt-get install ffmpeg`
 
   ```bash
   npm install -g @shumai-one/shumai-transcode

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
   <strong>An open-source platform for all your creative work.</strong>
 </p>
 
----
+<p align="center">
+  <a target="_blank" href="https://shumai.one/">Website</a> | <a target="_blank" href="https://docs.shumai.one/introduction">Docs</a> | <a target="_blank" href="https://staging.shumai.one">Demo</a>
+</p>
+
 
 ![Shumai App Screenshot](docs/screenshot.webp)
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ Spin up the database, Temporal server, and the main Shumai web application on yo
 
 When running in Temporal mode, the main Shumai application only submits tasks to the Temporal queue. To process these tasks, you must run at least one agent worker and one transcoding worker on their respective machines.
 
+> [!NOTE]
+> **Network & Access Requirements**:
+>
+> - Both the transcode worker and the agent worker must have network access to the PostgreSQL database and the S3-compatible storage.
+> - Because the transcode worker needs to download and upload large media files for transcoding, it is highly recommended to deploy the transcode worker in the same cloud provider and region as your S3 storage to minimize transfer latency and data egress fees.
+
 Configure a `.env` file on each worker machine. It must contain the following variables:
 
 ```env

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Spin up the database, Temporal server, and the main Shumai web application on yo
    curl -o docker-compose.yaml https://raw.githubusercontent.com/shumaiOne/shumai/main/docker-compose/temporal/docker-compose.yaml
    ```
 2. Configure the environment variables in `docker-compose.yaml`:
-   - Set the S3 storage environment variables (`S3_ENDPOINT_URL`, `S3_REGION`, `BUCKET_NAME`, etc.).
+   - Set the S3 storage environment variables (`AWS_ENDPOINT_URL_S3`, `S3_REGION`, `S3_BUCKET`, etc.).
    - If deploying to a remote host (e.g., AWS ECS, EC2, VPS), update `AWS_ENDPOINT_URL_S3` under the `shumai` service to your server's public IP address or domain name.
    - Note: The `TEMPORAL_ADDRESS` environment variable for the main Shumai application is pre-configured as `temporal:7233` (referencing the Temporal container within the same Docker network) and does not need to be changed.
 3. Start the services:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - **Scalable Transcode Workflows via Temporal**: Offload resource-heavy video transcoding to a reliable background worker pool orchestrated by Temporal.
 - **Flexible Asset Metadata System**: Customize your workspace metadata with dynamic, user-defined fields tailored to your production pipeline.
 
-### Shumai Agent
+#### Shumai Agent
 
 - **Chat with Agent as a Collaborator**: Converse with a context-aware AI agent directly within your project workspace.
 - **Extend Agent with Skills**: Easily register new tools and custom skills for the agent to run and automate workflows.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
   <a target="_blank" href="https://shumai.one/">Website</a> | <a target="_blank" href="https://docs.shumai.one/introduction">Docs</a> | <a target="_blank" href="https://staging.shumai.one">Demo</a>
 </p>
 
-
 ![Shumai App Screenshot](docs/screenshot.webp)
 
 ## Features
@@ -72,6 +71,9 @@ docker run --name shumai_postgres \
 #### Step 2: Install Shumai globally
 
 Install the main Shumai package using `npm`, `pnpm`, `bun`, or `yarn`:
+
+> [!IMPORTANT]
+> **Prerequisite**: Because Shumai uses a secure sandboxed execution environment for its AI agents, your machine must meet the platform requirements for the sandbox. Please verify you have installed the required dependencies for your OS as detailed in the [Agent Sandbox Platform Support](#agent-sandbox-platform-support) section.
 
 ```bash
 npm install -g @shumai-one/shumai
@@ -200,8 +202,66 @@ Run the workers:
 
 - **AI Agent Worker**:
   Install `@shumai-one/shumai-agent` and run it on a machine configured for Agent tasks:
+
+  > [!IMPORTANT]
+  > Because the AI Agent worker runs sandboxed agent scripts, the host machine must have the necessary dependencies installed. Please refer to [Agent Sandbox Platform Support](#agent-sandbox-platform-support) for setup details.
+
   ```bash
   npm install -g @shumai-one/shumai-agent
   # Run worker with the configured .env (must include GEMINI_API_KEY)
   shumai-agent
   ```
+
+---
+
+## Agent Sandbox Platform Support
+
+Shumai uses `anthropic-experimental/sandbox-runtime` to execute AI agent scripts and tasks in a secure, isolated sandbox environment. When installing Shumai or the AI Agent worker from NPM, ensure your host platform meets the following requirements:
+
+### Platform Support
+
+- **macOS**: Uses `sandbox-exec` with custom profiles (no additional OS-level containerization dependencies).
+- **Linux**: Uses `bubblewrap` (bwrap) for containerization.
+- **Windows**: Not yet supported.
+
+### Platform-Specific Dependencies
+
+#### Linux
+
+The following system packages must be installed on your Linux host:
+
+- `bubblewrap` - Container runtime
+  - Ubuntu/Debian: `sudo apt-get install bubblewrap`
+  - Fedora: `sudo dnf install bubblewrap`
+  - Arch: `sudo pacman -S bubblewrap`
+- `socat` - Socket relay for proxy bridging
+  - Ubuntu/Debian: `sudo apt-get install socat`
+  - Fedora: `sudo dnf install socat`
+  - Arch: `sudo pacman -S socat`
+- `ripgrep` - Fast search tool for deny path detection
+  - Ubuntu/Debian: `sudo apt-get install ripgrep`
+  - Fedora: `sudo dnf install ripgrep`
+  - Arch: `sudo pacman -S ripgrep`
+
+**Ubuntu 24.04+ Note**: These releases restrict unprivileged user namespaces by default. Disable this restriction so that `bubblewrap` and the seccomp isolation layer can function:
+
+```bash
+sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+```
+
+**Optional Linux Dependencies (for seccomp fallback)**:
+Pre-generated seccomp filters are provided for x86-64 and arm architectures. If you run on a different architecture, you will need a C compiler and development files:
+
+- `gcc` or `clang`
+- `libseccomp` development headers
+  - Ubuntu/Debian: `sudo apt-get install gcc libseccomp-dev`
+  - Fedora: `sudo dnf install gcc libseccomp-devel`
+  - Arch: `sudo pacman -S gcc libseccomp`
+
+#### macOS
+
+The following dependencies are required on macOS:
+
+- `ripgrep` - Fast search tool for deny path detection
+  - Install via Homebrew: `brew install ripgrep`
+  - Or download from: https://github.com/BurntSushi/ripgrep/releases

--- a/docker-compose/local/docker-compose.yaml
+++ b/docker-compose/local/docker-compose.yaml
@@ -32,7 +32,6 @@ services:
 
       # Better Auth
       BETTER_AUTH_SECRET: qSxs9DxzHDZBbeeTNPEwBuspYwipBqz5Gk5XdBjNhWw=
-      BETTER_AUTH_URL: https://staging.shumai.one/
 
     depends_on:
       postgres:

--- a/docker-compose/temporal/docker-compose.yaml
+++ b/docker-compose/temporal/docker-compose.yaml
@@ -33,7 +33,6 @@ services:
       S3_ACCESS_KEY_ID: ID
       S3_SECRET_ACCESS_KEY: KEY
       BETTER_AUTH_SECRET: qSxs9DxzHDZBbeeTNPEwBuspYwipBqz5Gk5XdBjNhWw=
-      BETTER_AUTH_URL: http://localhost:3000
       WORKFLOW_EXECUTOR: temporal
       TEMPORAL_ADDRESS: temporal:7233
       GEMINI_API_KEY: KEY

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -15,7 +15,7 @@ export const auth = betterAuth({
   },
   secret: process.env.BETTER_AUTH_SECRET,
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  baseURL: process.env.BETTER_AUTH_URL,
+  baseURL: process.env.BETTER_AUTH_URL || 'http://localhost:3000',
   basePath: '/api/auth',
   trustedOrigins: ['http://localhost:3000', 'http://127.0.0.1:3000'],
   advanced: {


### PR DESCRIPTION
## Summary

This PR improves the deployment and Temporal distributed execution documentation in the `README.md` to clarify remote server configurations, S3 requirements, and correct Temporal server addresses. Additionally, it removes obsolete `BETTER_AUTH_URL` environment variables since only email auth is supported, adds a default fallback in the auth service, details network access and cloud region suggestions for background workers, lists platform-specific dependencies for the AI Agent sandbox, and adds FFmpeg/FFprobe system requirements.

## Changes

- **Option 1 & Option 2 (Remote Server Deployments)**:
  - Explicitly guide users to set `AWS_ENDPOINT_URL_S3` to the host machine's public IP/domain when deploying remotely (e.g. AWS ECS/EC2) instead of defaulting to `localhost:3000`.
  - Removed all mentions of `BETTER_AUTH_URL` in the `README.md`, `local/docker-compose.yaml`, and `temporal/docker-compose.yaml`.
  - Added system package requirements for `ffmpeg` and `ffprobe` to NPM installation.
- **Advanced: Distributed Execution with Temporal**:
  - Added a warning that S3-compatible storage (`STORAGE_BACKEND=s3`) is required because local storage does not work across different machines.
  - Reordered the steps to instruct users to start the Core Stack (Docker Compose) first, which pre-configures `TEMPORAL_ADDRESS` internally within the container network without manual adjustment.
  - Corrected the `TEMPORAL_ADDRESS` instruction for background workers running on separate machines to point to the host machine's IP (e.g., `<host-ip>:7233`) instead of `localhost:7233`.
  - Added a note detailing that background workers require database and S3 access, and that the transcode worker should be deployed in the same cloud provider and region as the S3 storage to optimize performance and prevent egress fees.
  - Added `WORKFLOW_EXECUTOR=temporal` to the Temporal worker's example `.env` block.
  - Added `ffmpeg` and `ffprobe` requirement warning for the Transcoding Worker.
- **Auth Service**:
  - Updated the betterAuth initialization in `packages/core/src/auth/auth.ts` to fallback `baseURL` to `process.env.BETTER_AUTH_URL || 'http://localhost:3000'` to prevent the initialization warning message.
- **Agent Sandbox Platform Support**:
  - Documented OS-level dependencies required for running `sandbox-runtime` on macOS and Linux (including `ripgrep`, `bubblewrap`, `socat`, AppArmor settings, and `libseccomp` fallback compilation).
  - Linked to the platform support guide from global NPM installation and AI Agent Worker setup steps.

## Verification

- Ran `bun run lint` (passed)
- Ran `bun run format` (passed)
- Ran `bun run typecheck` (passed)
- Ran `bun run test` (passed successfully with all 473 tests passing)

## Notes

None.
