### PR TITLE
refactor(webui): use requestAnimationFrame for smooth video progress bar updates

### DIFF
--- a/packages/webui/components/viewers/video-player.tsx
+++ b/packages/webui/components/viewers/video-player.tsx
@@ -517,10 +517,10 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
             progress: duration > 0 ? (current / duration) * 100 : 0,
           }
         })
+      }
 
-        if (onTimeUpdate) {
-          onTimeUpdate(current)
-        }
+      if (onTimeUpdate) {
+        onTimeUpdate(current)
       }
     })
 
@@ -577,10 +577,6 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
           }
         })
 
-        if (onTimeUpdate) {
-          onTimeUpdate(current)
-        }
-
         animationFrameId = requestAnimationFrame(updateProgress)
       }
     }
@@ -594,7 +590,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         cancelAnimationFrame(animationFrameId)
       }
     }
-  }, [state.isPlaying, playerRef, data.media?.metadata?.duration, onTimeUpdate])
+  }, [state.isPlaying, playerRef, data.media?.metadata?.duration])
 
   const handleMouseMove = useCallback(() => {
     // Always show controls on movement

--- a/packages/webui/components/viewers/video-player.tsx
+++ b/packages/webui/components/viewers/video-player.tsx
@@ -505,15 +505,22 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         setBuffered((bufferedEnd / duration) * 100)
       }
 
-      setState((prev) => ({
-        ...prev,
-        currentTime: current,
-        duration: duration || prev.duration,
-        progress: duration > 0 ? (current / duration) * 100 : 0,
-      }))
+      // Only update state here if the player is paused.
+      // When playing, requestAnimationFrame handles smooth updates.
+      if (player.paused()) {
+        setState((prev) => {
+          if (prev.currentTime === current) return prev
+          return {
+            ...prev,
+            currentTime: current,
+            duration: duration || prev.duration,
+            progress: duration > 0 ? (current / duration) * 100 : 0,
+          }
+        })
 
-      if (onTimeUpdate) {
-        onTimeUpdate(current)
+        if (onTimeUpdate) {
+          onTimeUpdate(current)
+        }
       }
     })
 
@@ -549,6 +556,45 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       }
     }
   }, [data])
+
+  // Smooth progress updates using requestAnimationFrame when playing
+  useEffect(() => {
+    let animationFrameId: number
+
+    const updateProgress = () => {
+      const player = playerRef.current
+      if (player && !player.paused()) {
+        const current = player.currentTime() || 0
+        const duration = player.duration() || data.media?.metadata?.duration || 0
+
+        setState((prev) => {
+          if (prev.currentTime === current) return prev
+          return {
+            ...prev,
+            currentTime: current,
+            duration: duration || prev.duration,
+            progress: duration > 0 ? (current / duration) * 100 : 0,
+          }
+        })
+
+        if (onTimeUpdate) {
+          onTimeUpdate(current)
+        }
+
+        animationFrameId = requestAnimationFrame(updateProgress)
+      }
+    }
+
+    if (state.isPlaying) {
+      animationFrameId = requestAnimationFrame(updateProgress)
+    }
+
+    return () => {
+      if (animationFrameId) {
+        cancelAnimationFrame(animationFrameId)
+      }
+    }
+  }, [state.isPlaying, playerRef, data.media?.metadata?.duration, onTimeUpdate])
 
   const handleMouseMove = useCallback(() => {
     // Always show controls on movement


### PR DESCRIPTION
## Summary

This PR improves the smoothness of the video player's progress bar animation by utilizing `requestAnimationFrame` when the video is actively playing.

## Changes

- Modified the native `timeupdate` handler in [video-player.tsx](file:///Users/yiling/Projects/shumai/packages/webui/components/viewers/video-player.tsx) to only update the `currentTime` and `progress` states when the video is paused (to handle seek/scrub events).
- Added a `useEffect` hook that triggers when the video is playing to run a `requestAnimationFrame` loop. This loop fetches and updates the player's time at the display's native refresh rate.
- Kept the `onTimeUpdate` callback tied to the native `timeupdate` event (which fires at standard ~4-15Hz frequency) to prevent performance issues in parent components from high-frequency updates.
- Removed `onTimeUpdate` from the `useEffect` dependency list to avoid tearing down the animation loop if parent components pass unmemoized callback instances.
- Implemented state checking inside the loop to prevent redundant React renders if the time has not actually changed.

## Verification

- Verified that all workspace checks pass successfully:
  - `bun run lint` (passed)
  - `bun run format` (passed)
  - `bun run typecheck` (passed)
  - `bun run test` (all 473 tests passed)

## Notes

No external dependencies were modified or added. The solution preserves the existing fallback mechanisms for buffered progress and text track synchronization.
