### PR TITLE
feat(webui): always show right sidebar and implement left vertical carousel

### DIFF
--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -203,11 +203,13 @@ describe('Sandbox Network isolation integration', () => {
 
     // Mock SandboxManager.initialize to behave like a process-global singleton
     let registeredCallback: SandboxAskCallback | null = null
-    const initializeSpy = vi.spyOn(SandboxManager, 'initialize').mockImplementation(async (config, cb) => {
-      if (!registeredCallback) {
-        registeredCallback = cb || null
-      }
-    })
+    const initializeSpy = vi
+      .spyOn(SandboxManager, 'initialize')
+      .mockImplementation(async (config, cb) => {
+        if (!registeredCallback) {
+          registeredCallback = cb || null
+        }
+      })
     const resetSpy = vi.spyOn(SandboxManager, 'reset').mockImplementation(async () => {
       // In the real SandboxManager, reset clears the global initialization promise and servers,
       // which allows subsequent initialize calls to register a new callback.

--- a/packages/webui/components/breadcrumb-nav.tsx
+++ b/packages/webui/components/breadcrumb-nav.tsx
@@ -240,65 +240,67 @@ export function BreadcrumbNav({
         )}
       </div>
 
-      <div className="flex flex-shrink-0 items-center gap-1 rounded-md border border-border bg-background p-1">
-        {/* Left Sidebar Toggle */}
-        {!isPublic && onLeftSidebarToggle && (
+      {!fileId && (
+        <div className="flex flex-shrink-0 items-center gap-1 rounded-md border border-border bg-background p-1">
+          {/* Left Sidebar Toggle */}
+          {!isPublic && onLeftSidebarToggle && (
+            <button
+              onClick={onLeftSidebarToggle}
+              className="rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+              title={isLeftSidebarCollapsed ? 'Show Left Sidebar' : 'Hide Left Sidebar'}
+            >
+              {isLeftSidebarCollapsed ? (
+                <DockToLeft className="h-4 w-4" />
+              ) : (
+                <DockToLeftFilled className="h-4 w-4 fill-primary stroke-0" />
+              )}
+            </button>
+          )}
+
+          {/* Card View */}
+          {!isPublic && displayStyle && onDisplayStyleChange && (
+            <>
+              <button
+                onClick={() => onDisplayStyleChange('card')}
+                className={`rounded p-1.5 transition-colors ${
+                  displayStyle === 'card'
+                    ? 'bg-accent text-accent-foreground'
+                    : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+                }`}
+                title="Card View"
+              >
+                <LayoutGrid className="h-4 w-4" />
+              </button>
+
+              {/* List View */}
+              <button
+                onClick={() => onDisplayStyleChange('list')}
+                className={`rounded p-1.5 transition-colors ${
+                  displayStyle === 'list'
+                    ? 'bg-accent text-accent-foreground'
+                    : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+                }`}
+                title="List View"
+              >
+                <List className="h-4 w-4" />
+              </button>
+            </>
+          )}
+
+          {/* Right Sidebar Toggle */}
           <button
-            onClick={onLeftSidebarToggle}
+            onClick={onRightSidebarToggle}
             className="rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
-            title={isLeftSidebarCollapsed ? 'Show Left Sidebar' : 'Hide Left Sidebar'}
+            title={isRightSidebarCollapsed ? 'Show Right Sidebar' : 'Hide Right Sidebar'}
           >
-            {isLeftSidebarCollapsed ? (
-              <DockToLeft className="h-4 w-4" />
+            {isRightSidebarCollapsed ? (
+              <DockToRight className="h-4 w-4" />
             ) : (
-              <DockToLeftFilled className="h-4 w-4 fill-primary stroke-0" />
+              <DockToRightFilled className="h-4 w-4 fill-primary stroke-0" />
             )}
           </button>
-        )}
-
-        {/* Card View */}
-        {!isPublic && displayStyle && onDisplayStyleChange && (
-          <>
-            <button
-              onClick={() => onDisplayStyleChange('card')}
-              className={`rounded p-1.5 transition-colors ${
-                displayStyle === 'card'
-                  ? 'bg-accent text-accent-foreground'
-                  : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
-              }`}
-              title="Card View"
-            >
-              <LayoutGrid className="h-4 w-4" />
-            </button>
-
-            {/* List View */}
-            <button
-              onClick={() => onDisplayStyleChange('list')}
-              className={`rounded p-1.5 transition-colors ${
-                displayStyle === 'list'
-                  ? 'bg-accent text-accent-foreground'
-                  : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
-              }`}
-              title="List View"
-            >
-              <List className="h-4 w-4" />
-            </button>
-          </>
-        )}
-
-        {/* Right Sidebar Toggle */}
-        <button
-          onClick={onRightSidebarToggle}
-          className="rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
-          title={isRightSidebarCollapsed ? 'Show Right Sidebar' : 'Hide Right Sidebar'}
-        >
-          {isRightSidebarCollapsed ? (
-            <DockToRight className="h-4 w-4" />
-          ) : (
-            <DockToRightFilled className="h-4 w-4 fill-primary stroke-0" />
-          )}
-        </button>
-      </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/webui/components/chat/message-input.tsx
+++ b/packages/webui/components/chat/message-input.tsx
@@ -457,125 +457,126 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
           cursor: text;
         }
       `}</style>
-        {showMentionList && (membersLoading || filteredAgents.length > 0 || filteredHumans.length > 0) && (
-          <div className="absolute bottom-full left-4 mb-2 w-64 rounded-xl shadow-lg border border-border overflow-hidden z-20 bg-popover text-popover-foreground animate-in fade-in slide-in-from-bottom-2 duration-200">
-            <div className="h-64 overflow-y-auto">
-              {membersLoading ? (
-                <div className="p-2 space-y-4 animate-pulse">
-                  {/* Agents Skeleton */}
-                  <div className="space-y-2">
-                    <div className="px-3 py-1.5 bg-muted/50 border-b border-border">
-                      <Skeleton className="h-3 w-16" />
+        {showMentionList &&
+          (membersLoading || filteredAgents.length > 0 || filteredHumans.length > 0) && (
+            <div className="absolute bottom-full left-4 mb-2 w-64 rounded-xl shadow-lg border border-border overflow-hidden z-20 bg-popover text-popover-foreground animate-in fade-in slide-in-from-bottom-2 duration-200">
+              <div className="h-64 overflow-y-auto">
+                {membersLoading ? (
+                  <div className="p-2 space-y-4 animate-pulse">
+                    {/* Agents Skeleton */}
+                    <div className="space-y-2">
+                      <div className="px-3 py-1.5 bg-muted/50 border-b border-border">
+                        <Skeleton className="h-3 w-16" />
+                      </div>
+                      <div className="flex items-center gap-2 px-3 py-2">
+                        <Skeleton className="w-6 h-6 rounded-full" />
+                        <Skeleton className="h-4 w-28" />
+                      </div>
+                      <div className="flex items-center gap-2 px-3 py-2">
+                        <Skeleton className="w-6 h-6 rounded-full" />
+                        <Skeleton className="h-4 w-20" />
+                      </div>
                     </div>
-                    <div className="flex items-center gap-2 px-3 py-2">
-                      <Skeleton className="w-6 h-6 rounded-full" />
-                      <Skeleton className="h-4 w-28" />
-                    </div>
-                    <div className="flex items-center gap-2 px-3 py-2">
-                      <Skeleton className="w-6 h-6 rounded-full" />
-                      <Skeleton className="h-4 w-20" />
+                    {/* Members Skeleton */}
+                    <div className="space-y-2">
+                      <div className="px-3 py-1.5 bg-muted/50 border-b border-border">
+                        <Skeleton className="h-3 w-16" />
+                      </div>
+                      <div className="flex items-center gap-2 px-3 py-2">
+                        <Skeleton className="w-6 h-6 rounded-full" />
+                        <Skeleton className="h-4 w-32" />
+                      </div>
+                      <div className="flex items-center gap-2 px-3 py-2">
+                        <Skeleton className="w-6 h-6 rounded-full" />
+                        <Skeleton className="h-4 w-24" />
+                      </div>
                     </div>
                   </div>
-                  {/* Members Skeleton */}
-                  <div className="space-y-2">
-                    <div className="px-3 py-1.5 bg-muted/50 border-b border-border">
-                      <Skeleton className="h-3 w-16" />
-                    </div>
-                    <div className="flex items-center gap-2 px-3 py-2">
-                      <Skeleton className="w-6 h-6 rounded-full" />
-                      <Skeleton className="h-4 w-32" />
-                    </div>
-                    <div className="flex items-center gap-2 px-3 py-2">
-                      <Skeleton className="w-6 h-6 rounded-full" />
-                      <Skeleton className="h-4 w-24" />
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                <>
-                  {filteredAgents.length > 0 && (
-                    <>
-                      <button
-                        onClick={(e) => {
-                          e.preventDefault()
-                          e.stopPropagation()
-                          setCollapsedSections((prev) => ({ ...prev, bots: !prev.bots }))
-                        }}
-                        className="w-full text-xs font-semibold text-muted-foreground px-3 py-2 bg-muted/50 border-b border-border sticky top-0 flex items-center justify-between hover:bg-muted transition-colors"
-                      >
-                        <span>Agents</span>
-                        <ChevronDown
-                          className={`w-3 h-3 transition-transform ${collapsedSections.bots ? '-rotate-90' : ''}`}
-                        />
-                      </button>
-                      {!collapsedSections.bots &&
-                        filteredAgents.map((item, index) => {
-                          const actualIndex = index
-                          return (
-                            <button
-                              key={item.data.id}
-                              onClick={() => handleSelectEntity(item)}
-                              onMouseEnter={() => setHighlightedIndex(actualIndex)}
-                              className={`w-full flex items-center gap-2 px-3 py-2 transition-colors text-left ${
-                                actualIndex === highlightedIndex
-                                  ? 'bg-accent text-accent-foreground'
-                                  : 'hover:bg-accent/50'
-                              }`}
-                            >
-                              <div className="w-6 h-6 rounded-full bg-purple-100 dark:bg-purple-900/40 flex items-center justify-center text-xs font-bold text-purple-600 dark:text-purple-300">
-                                {item.data.name?.[0]}
-                              </div>
-                              <span className="text-sm">{item.data.name}</span>
-                            </button>
-                          )
-                        })}
-                    </>
-                  )}
+                ) : (
+                  <>
+                    {filteredAgents.length > 0 && (
+                      <>
+                        <button
+                          onClick={(e) => {
+                            e.preventDefault()
+                            e.stopPropagation()
+                            setCollapsedSections((prev) => ({ ...prev, bots: !prev.bots }))
+                          }}
+                          className="w-full text-xs font-semibold text-muted-foreground px-3 py-2 bg-muted/50 border-b border-border sticky top-0 flex items-center justify-between hover:bg-muted transition-colors"
+                        >
+                          <span>Agents</span>
+                          <ChevronDown
+                            className={`w-3 h-3 transition-transform ${collapsedSections.bots ? '-rotate-90' : ''}`}
+                          />
+                        </button>
+                        {!collapsedSections.bots &&
+                          filteredAgents.map((item, index) => {
+                            const actualIndex = index
+                            return (
+                              <button
+                                key={item.data.id}
+                                onClick={() => handleSelectEntity(item)}
+                                onMouseEnter={() => setHighlightedIndex(actualIndex)}
+                                className={`w-full flex items-center gap-2 px-3 py-2 transition-colors text-left ${
+                                  actualIndex === highlightedIndex
+                                    ? 'bg-accent text-accent-foreground'
+                                    : 'hover:bg-accent/50'
+                                }`}
+                              >
+                                <div className="w-6 h-6 rounded-full bg-purple-100 dark:bg-purple-900/40 flex items-center justify-center text-xs font-bold text-purple-600 dark:text-purple-300">
+                                  {item.data.name?.[0]}
+                                </div>
+                                <span className="text-sm">{item.data.name}</span>
+                              </button>
+                            )
+                          })}
+                      </>
+                    )}
 
-                  {filteredHumans.length > 0 && (
-                    <>
-                      <button
-                        onClick={(e) => {
-                          e.preventDefault()
-                          e.stopPropagation()
-                          setCollapsedSections((prev) => ({ ...prev, users: !prev.users }))
-                        }}
-                        className="w-full text-xs font-semibold text-muted-foreground px-3 py-2 bg-muted/50 border-b border-border sticky top-0 flex items-center justify-between hover:bg-muted transition-colors"
-                      >
-                        <span>Members</span>
-                        <ChevronDown
-                          className={`w-3 h-3 transition-transform ${collapsedSections.users ? '-rotate-90' : ''}`}
-                        />
-                      </button>
-                      {!collapsedSections.users &&
-                        filteredHumans.map((item, index) => {
-                          const actualIndex =
-                            (collapsedSections.bots ? 0 : filteredAgents.length) + index
-                          return (
-                            <button
-                              key={item.data.id}
-                              onClick={() => handleSelectEntity(item)}
-                              onMouseEnter={() => setHighlightedIndex(actualIndex)}
-                              className={`w-full flex items-center gap-2 px-3 py-2 transition-colors text-left ${
-                                actualIndex === highlightedIndex
-                                  ? 'bg-accent text-accent-foreground'
-                                  : 'hover:bg-accent/50'
-                              }`}
-                            >
-                              <div className="w-6 h-6 rounded-full bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center text-xs font-bold text-blue-600 dark:text-blue-300">
-                                {item.data.name?.[0]}
-                              </div>
-                              <span className="text-sm">{item.data.name}</span>
-                            </button>
-                          )
-                        })}
-                    </>
-                  )}
-                </>
-              )}
+                    {filteredHumans.length > 0 && (
+                      <>
+                        <button
+                          onClick={(e) => {
+                            e.preventDefault()
+                            e.stopPropagation()
+                            setCollapsedSections((prev) => ({ ...prev, users: !prev.users }))
+                          }}
+                          className="w-full text-xs font-semibold text-muted-foreground px-3 py-2 bg-muted/50 border-b border-border sticky top-0 flex items-center justify-between hover:bg-muted transition-colors"
+                        >
+                          <span>Members</span>
+                          <ChevronDown
+                            className={`w-3 h-3 transition-transform ${collapsedSections.users ? '-rotate-90' : ''}`}
+                          />
+                        </button>
+                        {!collapsedSections.users &&
+                          filteredHumans.map((item, index) => {
+                            const actualIndex =
+                              (collapsedSections.bots ? 0 : filteredAgents.length) + index
+                            return (
+                              <button
+                                key={item.data.id}
+                                onClick={() => handleSelectEntity(item)}
+                                onMouseEnter={() => setHighlightedIndex(actualIndex)}
+                                className={`w-full flex items-center gap-2 px-3 py-2 transition-colors text-left ${
+                                  actualIndex === highlightedIndex
+                                    ? 'bg-accent text-accent-foreground'
+                                    : 'hover:bg-accent/50'
+                                }`}
+                              >
+                                <div className="w-6 h-6 rounded-full bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center text-xs font-bold text-blue-600 dark:text-blue-300">
+                                  {item.data.name?.[0]}
+                                </div>
+                                <span className="text-sm">{item.data.name}</span>
+                              </button>
+                            )
+                          })}
+                      </>
+                    )}
+                  </>
+                )}
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
         {showUpperPart && (
           <div className="flex flex-col gap-2 p-3 pb-0 animate-in fade-in slide-in-from-bottom-2 duration-200">

--- a/packages/webui/components/file-viewer-left-sidebar.tsx
+++ b/packages/webui/components/file-viewer-left-sidebar.tsx
@@ -100,6 +100,7 @@ export const FileViewerLeftSidebar: FC<FileViewerLeftSidebarProps> = ({
     if (activeFileInView && activeItemRef.current && !hasScrolledRef.current) {
       activeItemRef.current.scrollIntoView({
         block: 'center',
+        inline: 'center',
         behavior: 'smooth',
       })
       hasScrolledRef.current = true
@@ -107,8 +108,8 @@ export const FileViewerLeftSidebar: FC<FileViewerLeftSidebarProps> = ({
   }, [files, currentAssetId])
 
   return (
-    <div className="h-full w-24 bg-gray-100 dark:bg-gray-950 flex flex-col flex-shrink-0 select-none">
-      <div className="flex-1 overflow-y-auto py-4 flex flex-col items-center gap-3 no-scrollbar">
+    <div className="h-24 md:h-full w-full md:w-24 bg-gray-100 dark:bg-gray-950 flex flex-row md:flex-col flex-shrink-0 select-none">
+      <div className="flex-1 overflow-x-auto overflow-y-hidden md:overflow-y-auto md:overflow-x-hidden px-4 md:px-0 py-2 md:py-4 flex flex-row md:flex-col items-center gap-3 no-scrollbar">
         {files.map((file) => {
           if (!file) return null
           const isActive = file.id === currentAssetId
@@ -137,7 +138,10 @@ export const FileViewerLeftSidebar: FC<FileViewerLeftSidebarProps> = ({
 
         {/* Infinite Scroll Trigger */}
         {hasMore && (
-          <div ref={ref} className="py-2 flex justify-center items-center w-full">
+          <div
+            ref={ref}
+            className="px-2 md:px-0 py-2 md:py-4 flex justify-center items-center h-full md:w-full flex-shrink-0"
+          >
             {isFetchingNext && <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />}
           </div>
         )}

--- a/packages/webui/components/file-viewer-left-sidebar.tsx
+++ b/packages/webui/components/file-viewer-left-sidebar.tsx
@@ -1,11 +1,11 @@
 import { client } from '@/ui/api/client'
+import { cn } from '@/ui/lib/utils'
+import type { AssetInfo, AssetInfoPaginatedList } from '@shumai/dtos'
+import { Link } from '@tanstack/react-router'
 import { File, Loader2 } from 'lucide-react'
 import type { FC } from 'react'
-import type { AssetInfo, AssetInfoPaginatedList } from '@shumai/dtos'
 import { useEffect, useRef, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
-import { Link } from '@tanstack/react-router'
-import { cn } from '@/ui/lib/utils'
 
 interface FileViewerLeftSidebarProps {
   projectId: string
@@ -107,7 +107,7 @@ export const FileViewerLeftSidebar: FC<FileViewerLeftSidebarProps> = ({
   }, [files, currentAssetId])
 
   return (
-    <div className="h-full w-24 bg-transparent border-r border-border flex flex-col flex-shrink-0 select-none">
+    <div className="h-full w-24 bg-gray-100 dark:bg-gray-950 flex flex-col flex-shrink-0 select-none">
       <div className="flex-1 overflow-y-auto py-4 flex flex-col items-center gap-3 no-scrollbar">
         {files.map((file) => {
           if (!file) return null
@@ -125,8 +125,8 @@ export const FileViewerLeftSidebar: FC<FileViewerLeftSidebarProps> = ({
                 className={cn(
                   'rounded-lg border overflow-hidden flex items-center justify-center transition-all bg-muted/30 block',
                   isActive
-                    ? 'w-[60px] h-[60px] border-primary ring-2 ring-primary opacity-100'
-                    : 'w-[54px] h-[54px] border-border hover:border-primary/50 opacity-65 hover:opacity-100',
+                    ? 'w-[62px] h-[62px] opacity-100'
+                    : 'w-[52px] h-[52px] opacity-60 hover:opacity-100',
                 )}
               >
                 <CarouselFilePreview item={file} />

--- a/packages/webui/components/file-viewer-left-sidebar.tsx
+++ b/packages/webui/components/file-viewer-left-sidebar.tsx
@@ -107,7 +107,7 @@ export const FileViewerLeftSidebar: FC<FileViewerLeftSidebarProps> = ({
   }, [files, currentAssetId])
 
   return (
-    <div className="h-full w-24 bg-card border-r border-border flex flex-col flex-shrink-0 select-none">
+    <div className="h-full w-24 bg-transparent border-r border-border flex flex-col flex-shrink-0 select-none">
       <div className="flex-1 overflow-y-auto py-4 flex flex-col items-center gap-3 no-scrollbar">
         {files.map((file) => {
           if (!file) return null
@@ -123,10 +123,10 @@ export const FileViewerLeftSidebar: FC<FileViewerLeftSidebarProps> = ({
                 params={{ projectId, fileId: file.id }}
                 search={{ version: undefined }}
                 className={cn(
-                  'w-[54px] h-[54px] rounded-lg border overflow-hidden flex items-center justify-center transition-all bg-muted/30 block',
+                  'rounded-lg border overflow-hidden flex items-center justify-center transition-all bg-muted/30 block',
                   isActive
-                    ? 'border-primary ring-2 ring-primary opacity-100 scale-105'
-                    : 'border-border hover:border-primary/50 opacity-65 hover:opacity-100',
+                    ? 'w-[60px] h-[60px] border-primary ring-2 ring-primary opacity-100'
+                    : 'w-[54px] h-[54px] border-border hover:border-primary/50 opacity-65 hover:opacity-100',
                 )}
               >
                 <CarouselFilePreview item={file} />

--- a/packages/webui/components/file-viewer-left-sidebar.tsx
+++ b/packages/webui/components/file-viewer-left-sidebar.tsx
@@ -1,26 +1,40 @@
 import { client } from '@/ui/api/client'
-import { useInfiniteQuery } from '@tanstack/react-query'
-import { Loader2, PanelLeftClose } from 'lucide-react'
+import { File, Loader2 } from 'lucide-react'
 import type { FC } from 'react'
-import type { AssetInfoPaginatedList } from '@shumai/dtos'
-import { useEffect, useRef } from 'react'
+import type { AssetInfo, AssetInfoPaginatedList } from '@shumai/dtos'
+import { useEffect, useRef, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
-import { SidebarFileCard } from './sidebar-file-card'
-import { Button } from './ui/button'
-import { ScrollArea } from './ui/scroll-area'
+import { Link } from '@tanstack/react-router'
+import { cn } from '@/ui/lib/utils'
 
 interface FileViewerLeftSidebarProps {
   projectId: string
   currentAssetId: string
   parentFolderId: string
-  onCollapse: () => void
+  initialFiles: AssetInfo[]
+  initialNextCursor: string | undefined
+}
+
+export const CarouselFilePreview = ({ item }: { item: AssetInfo }) => {
+  if (item.preview?.thumbnailUrl) {
+    return (
+      <img src={item.preview.thumbnailUrl} alt="Preview" className="w-full h-full object-cover" />
+    )
+  }
+
+  return (
+    <div className="w-full h-full flex items-center justify-center bg-muted">
+      <File className="w-5 h-5 text-muted-foreground" />
+    </div>
+  )
 }
 
 export const FileViewerLeftSidebar: FC<FileViewerLeftSidebarProps> = ({
   projectId,
   currentAssetId,
   parentFolderId,
-  onCollapse,
+  initialFiles,
+  initialNextCursor,
 }) => {
   const { ref, inView } = useInView({
     threshold: 0,
@@ -29,38 +43,51 @@ export const FileViewerLeftSidebar: FC<FileViewerLeftSidebarProps> = ({
   const activeItemRef = useRef<HTMLDivElement>(null)
   const hasScrolledRef = useRef(false)
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery({
-    queryKey: [
-      'folders',
-      parentFolderId,
-      'children',
-      {
-        assetType: 'file',
-      },
-    ],
-    queryFn: async ({ pageParam }) => {
-      const res = await client.api.folders[':folderId'].children.$get({
-        param: { folderId: parentFolderId },
-        query: {
-          assetType: 'file',
-          after: pageParam,
-          first: '20',
-        },
-      })
-      if (!res.ok) throw new Error('failed to fetch folder children')
-      return (await res.json()) as unknown as AssetInfoPaginatedList
-    },
-    initialPageParam: '',
-    getNextPageParam: (lastPage) => lastPage.pageInfo?.cursor || undefined,
-  })
+  const [files, setFiles] = useState<AssetInfo[]>(initialFiles)
+  const [nextCursor, setNextCursor] = useState<string | undefined>(initialNextCursor)
+  const [hasMore, setHasMore] = useState<boolean>(!!initialNextCursor)
+  const [isFetchingNext, setIsFetchingNext] = useState<boolean>(false)
 
-  const files = data?.pages.flatMap((page) => page.data) ?? []
-
+  // Sync state if initial files / cursor changes (due to parent folder change)
   useEffect(() => {
-    if (inView && hasNextPage && !isFetchingNextPage) {
-      fetchNextPage()
+    setFiles(initialFiles)
+    setNextCursor(initialNextCursor)
+    setHasMore(!!initialNextCursor)
+    hasScrolledRef.current = false
+  }, [initialFiles, initialNextCursor])
+
+  // Fetch next page when scrolling near bottom
+  useEffect(() => {
+    const fetchNextPage = async () => {
+      if (!nextCursor || isFetchingNext || !inView || !hasMore) return
+      setIsFetchingNext(true)
+      try {
+        const res = await client.api.folders[':folderId'].search.$post({
+          param: { folderId: parentFolderId },
+          json: {
+            assetType: 'file',
+            after: nextCursor,
+            first: 200,
+            recursively: false,
+            conditions: [],
+          },
+        })
+        if (!res.ok) throw new Error('Failed to fetch next page')
+        const result = (await res.json()) as unknown as AssetInfoPaginatedList
+        const batchFiles = (result.data || []) as AssetInfo[]
+
+        setFiles((prev) => [...prev, ...batchFiles])
+        setNextCursor(result.pageInfo?.cursor || undefined)
+        setHasMore(!!result.pageInfo?.cursor && batchFiles.length > 0)
+      } catch (err) {
+        console.error('Error fetching next page:', err)
+      } finally {
+        setIsFetchingNext(false)
+      }
     }
-  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage])
+
+    fetchNextPage()
+  }, [inView, nextCursor, hasMore, isFetchingNext, parentFolderId])
 
   // Reset scroll lock when current asset changes
   useEffect(() => {
@@ -73,47 +100,48 @@ export const FileViewerLeftSidebar: FC<FileViewerLeftSidebarProps> = ({
     if (activeFileInView && activeItemRef.current && !hasScrolledRef.current) {
       activeItemRef.current.scrollIntoView({
         block: 'center',
+        behavior: 'smooth',
       })
       hasScrolledRef.current = true
     }
   }, [files, currentAssetId])
 
   return (
-    <div className="h-full w-full bg-card border-r border-border flex flex-col">
-      <div className="p-2 border-b flex items-center justify-between">
-        <h3 className="text-sm font-semibold px-2">Current Folder</h3>
-        <Button variant="ghost" size="icon-sm" onClick={onCollapse}>
-          <PanelLeftClose className="h-4 w-4" />
-        </Button>
-      </div>
-      <ScrollArea className="flex-1 [&>div>div]:block! px-2">
-        <div className="p-2 space-y-2">
-          {isLoading && (
-            <div className="flex justify-center items-center p-4">
-              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+    <div className="h-full w-24 bg-card border-r border-border flex flex-col flex-shrink-0 select-none">
+      <div className="flex-1 overflow-y-auto py-4 flex flex-col items-center gap-3 no-scrollbar">
+        {files.map((file) => {
+          if (!file) return null
+          const isActive = file.id === currentAssetId
+          return (
+            <div
+              key={file.id}
+              ref={file.id === currentAssetId ? activeItemRef : null}
+              className="flex-shrink-0"
+            >
+              <Link
+                to="/projects/$projectId/files/$fileId"
+                params={{ projectId, fileId: file.id }}
+                search={{ version: undefined }}
+                className={cn(
+                  'w-[54px] h-[54px] rounded-lg border overflow-hidden flex items-center justify-center transition-all bg-muted/30 block',
+                  isActive
+                    ? 'border-primary ring-2 ring-primary opacity-100 scale-105'
+                    : 'border-border hover:border-primary/50 opacity-65 hover:opacity-100',
+                )}
+              >
+                <CarouselFilePreview item={file} />
+              </Link>
             </div>
-          )}
-          {files.map(
-            (file) =>
-              file && (
-                <SidebarFileCard
-                  ref={file.id === currentAssetId ? activeItemRef : null}
-                  key={file.id}
-                  projectId={projectId}
-                  item={file}
-                  isActive={file.id === currentAssetId}
-                />
-              ),
-          )}
-          <div ref={ref}>
-            {isFetchingNextPage && (
-              <div className="flex justify-center items-center p-4">
-                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-              </div>
-            )}
+          )
+        })}
+
+        {/* Infinite Scroll Trigger */}
+        {hasMore && (
+          <div ref={ref} className="py-2 flex justify-center items-center w-full">
+            {isFetchingNext && <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />}
           </div>
-        </div>
-      </ScrollArea>
+        )}
+      </div>
     </div>
   )
 }

--- a/packages/webui/components/file-viewer.tsx
+++ b/packages/webui/components/file-viewer.tsx
@@ -2,7 +2,7 @@ import { useScreenSize } from '@/ui/hooks/useScreenSize'
 import { getBestTranscode } from '@/ui/lib/media'
 import type { AssetInfo } from '@shumai/dtos'
 import { Check, Copy, Download, Minus, Plus } from 'lucide-react'
-import type { RefObject } from 'react'
+import type { ReactNode, RefObject } from 'react'
 import { useEffect, useRef, useState } from 'react'
 import type Player from 'video.js/dist/types/player'
 import DrawingCanvas from './drawing-canvas'
@@ -18,6 +18,7 @@ type FileViewerProps = {
   onPause?: () => void
   onTimeUpdate?: (time: number) => void
   annotations?: Annotation[]
+  children?: ReactNode
 }
 
 export function FileViewer({
@@ -27,6 +28,7 @@ export function FileViewer({
   onPause,
   onTimeUpdate,
   annotations,
+  children,
 }: FileViewerProps) {
   const { width: screenWidth } = useScreenSize()
   const isImage = file.mediaType?.startsWith('image/')
@@ -186,10 +188,28 @@ export function FileViewer({
     }
   }
 
-  if (!bestUrl) {
+  const isUnsupported = !bestUrl || (!isImage && !isVideo)
+
+  if (isUnsupported) {
     return (
-      <div className="flex flex-1 items-center justify-center">
-        <p className="text-muted-foreground">Preview unavailable</p>
+      <div className="flex flex-col flex-1 h-full overflow-hidden bg-gray-100 dark:bg-gray-950 relative">
+        <div className="flex-1 flex min-h-0 relative">
+          {children}
+          <div className="flex-1 flex items-center justify-center">
+            <p className="text-muted-foreground">Preview unavailable</p>
+          </div>
+        </div>
+        <div className="relative px-4 py-3 bg-card border-t border-gray-200 dark:border-gray-700 z-10 flex items-center justify-end gap-2 transition-colors duration-200">
+          <button
+            onClick={handleDownload}
+            disabled={!file.media?.original?.downloadUrl}
+            className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded bg-gray-200/50 dark:bg-white/10 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 transition-colors border border-transparent disabled:opacity-50 animate-in fade-in zoom-in-95 duration-200"
+            title="Download original file"
+          >
+            <Download size={14} />
+            Download
+          </button>
+        </div>
       </div>
     )
   }
@@ -201,26 +221,29 @@ export function FileViewer({
     <div className="flex flex-col flex-1 h-full overflow-hidden bg-gray-100 dark:bg-gray-950 relative">
       {isImage && (
         <>
-          <div ref={containerRef} className="flex-1 relative overflow-hidden">
-            <DrawingCanvas
-              width={conW}
-              height={conH}
-              mediaDimensions={{
-                width: imgW,
-                height: imgH,
-              }}
-              imageUrl={bestUrl}
-              annotations={displayAnnotations}
-              scale={zoom}
-              offset={pan}
-              onPan={setPan}
-              className="absolute inset-0 z-0"
-              // Drawing Props
-              isDrawing={isDrawing}
-              currentTool={currentTool}
-              currentColor={currentColor}
-              onAddAnnotation={addAnnotation}
-            />
+          <div className="flex-1 flex min-h-0 relative">
+            {children}
+            <div ref={containerRef} className="flex-1 relative overflow-hidden">
+              <DrawingCanvas
+                width={conW}
+                height={conH}
+                mediaDimensions={{
+                  width: imgW,
+                  height: imgH,
+                }}
+                imageUrl={bestUrl}
+                annotations={displayAnnotations}
+                scale={zoom}
+                offset={pan}
+                onPan={setPan}
+                className="absolute inset-0 z-0"
+                // Drawing Props
+                isDrawing={isDrawing}
+                currentTool={currentTool}
+                currentColor={currentColor}
+                onAddAnnotation={addAnnotation}
+              />
+            </div>
           </div>
           {/* Zoom Toolbar */}
           <div className="relative px-4 py-3 bg-card border-t border-gray-200 dark:border-gray-700 z-10 flex items-center justify-end gap-2 transition-colors duration-200">
@@ -278,7 +301,9 @@ export function FileViewer({
           onPause={onPause}
           onTimeUpdate={onTimeUpdate}
           annotations={displayAnnotations}
-        />
+        >
+          {children}
+        </VideoPlayer>
       )}
     </div>
   )

--- a/packages/webui/components/file-viewer.tsx
+++ b/packages/webui/components/file-viewer.tsx
@@ -3,7 +3,7 @@ import { getBestTranscode } from '@/ui/lib/media'
 import type { AssetInfo } from '@shumai/dtos'
 import { Check, Copy, Download, Minus, Plus } from 'lucide-react'
 import type { ReactNode, RefObject } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type Player from 'video.js/dist/types/player'
 import DrawingCanvas from './drawing-canvas'
 import VideoPlayer from './viewers/video-player'
@@ -51,10 +51,32 @@ export function FileViewer({
 
   // State for Image Viewer
   const [containerSize, setContainerSize] = useState({ width: 0, height: 0 })
-  const containerRef = useRef<HTMLDivElement>(null)
   const [zoom, setZoom] = useState(1)
   const [pan, setPan] = useState({ x: 0, y: 0 })
   const [copied, setCopied] = useState(false)
+
+  const observerRef = useRef<ResizeObserver | null>(null)
+
+  const containerRef = useCallback((node: HTMLDivElement | null) => {
+    if (observerRef.current) {
+      observerRef.current.disconnect()
+      observerRef.current = null
+    }
+
+    if (node !== null) {
+      const observer = new ResizeObserver((entries) => {
+        const entry = entries[0]
+        if (entry) {
+          setContainerSize({
+            width: entry.contentRect.width,
+            height: entry.contentRect.height,
+          })
+        }
+      })
+      observer.observe(node)
+      observerRef.current = observer
+    }
+  }, [])
 
   const imgW = file.media?.metadata?.originalWidth ?? 1920
   const imgH = file.media?.metadata?.originalHeight ?? 1080
@@ -77,22 +99,6 @@ export function FileViewer({
       setPan({ x, y })
     }
   }, [file.id, conW, conH, isImage, baseScale, imgW, imgH])
-
-  // Resize Observer
-  useEffect(() => {
-    if (!containerRef.current) return
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries[0]
-      if (entry) {
-        setContainerSize({
-          width: entry.contentRect.width,
-          height: entry.contentRect.height,
-        })
-      }
-    })
-    observer.observe(containerRef.current)
-    return () => observer.disconnect()
-  }, [])
 
   const handleZoom = (factor: number) => {
     const cx = conW / 2

--- a/packages/webui/components/file-viewer.tsx
+++ b/packages/webui/components/file-viewer.tsx
@@ -199,7 +199,7 @@ export function FileViewer({
   if (isUnsupported) {
     return (
       <div className="flex flex-col flex-1 h-full overflow-hidden bg-gray-100 dark:bg-gray-950 relative">
-        <div className="flex-1 flex min-h-0 relative">
+        <div className="flex-1 flex flex-col-reverse md:flex-row min-h-0 relative">
           {children}
           <div className="flex-1 flex items-center justify-center">
             <p className="text-muted-foreground">Preview unavailable</p>
@@ -227,7 +227,7 @@ export function FileViewer({
     <div className="flex flex-col flex-1 h-full overflow-hidden bg-gray-100 dark:bg-gray-950 relative">
       {isImage && (
         <>
-          <div className="flex-1 flex min-h-0 relative">
+          <div className="flex-1 flex flex-col-reverse md:flex-row min-h-0 relative">
             {children}
             <div ref={containerRef} className="flex-1 relative overflow-hidden">
               <DrawingCanvas

--- a/packages/webui/components/viewers/video-player.tsx
+++ b/packages/webui/components/viewers/video-player.tsx
@@ -53,6 +53,7 @@ interface VideoPlayerProps {
   onPause?: () => void
   onTimeUpdate?: (time: number) => void
   annotations?: Annotation[]
+  children?: React.ReactNode
 }
 
 type DisplayTranscode = VideoTranscode & { resolution: string }
@@ -310,6 +311,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   onPause,
   onTimeUpdate,
   annotations,
+  children,
 }) => {
   const localPlayerRef = useRef<Player | null>(null)
   const playerRef = passedPlayerRef || localPlayerRef
@@ -797,49 +799,54 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
     >
-      {/* Video Area */}
-      <div
-        ref={containerRef}
-        className={cn(
-          'w-full bg-black cursor-pointer relative flex items-center justify-center overflow-hidden flex-1 min-h-0',
-        )}
-        onClick={togglePlay}
-        data-vjs-player
-      >
-        {/* Hidden VideoJS container */}
-        <div ref={videoContainerRef} className="absolute inset-0 z-[-1]" />
+      <div className="flex-1 flex min-h-0 relative">
+        {/* Render Carousel/Sidebar here if not fullscreen */}
+        {!state.isFullScreen && children}
 
-        {/* Drawing Canvas (Visible) */}
-        {videoHtmlEl && containerSize.width > 0 && (
-          <DrawingCanvas
-            width={containerSize.width}
-            height={containerSize.height}
-            mediaDimensions={{
-              width: vidW,
-              height: vidH,
-            }}
-            videoElement={videoHtmlEl}
-            annotations={displayAnnotations}
-            scale={scale}
-            offset={{ x: panX, y: panY }}
-            className="absolute inset-0"
-            onClick={togglePlay}
-            // Drawing Props
-            isDrawing={isDrawing}
-            currentTool={currentTool}
-            currentColor={currentColor}
-            onAddAnnotation={addAnnotation}
-          />
-        )}
+        {/* Video Area */}
+        <div
+          ref={containerRef}
+          className={cn(
+            'flex-1 bg-black cursor-pointer relative flex items-center justify-center overflow-hidden min-h-0',
+          )}
+          onClick={togglePlay}
+          data-vjs-player
+        >
+          {/* Hidden VideoJS container */}
+          <div ref={videoContainerRef} className="absolute inset-0 z-[-1]" />
 
-        {/* Big Play Button Overlay (when paused) */}
-        {!state.isPlaying && !isDrawing && (
-          <div className="absolute inset-0 flex items-center justify-center bg-black/20 pointer-events-none z-10">
-            <div className="w-20 h-20 bg-white/10 backdrop-blur-sm rounded-full flex items-center justify-center border-2 border-white/30 animate-pulse">
-              <Play className="w-10 h-10 text-white ml-1 fill-white" />
+          {/* Drawing Canvas (Visible) */}
+          {videoHtmlEl && containerSize.width > 0 && (
+            <DrawingCanvas
+              width={containerSize.width}
+              height={containerSize.height}
+              mediaDimensions={{
+                width: vidW,
+                height: vidH,
+              }}
+              videoElement={videoHtmlEl}
+              annotations={displayAnnotations}
+              scale={scale}
+              offset={{ x: panX, y: panY }}
+              className="absolute inset-0"
+              onClick={togglePlay}
+              // Drawing Props
+              isDrawing={isDrawing}
+              currentTool={currentTool}
+              currentColor={currentColor}
+              onAddAnnotation={addAnnotation}
+            />
+          )}
+
+          {/* Big Play Button Overlay (when paused) */}
+          {!state.isPlaying && !isDrawing && (
+            <div className="absolute inset-0 flex items-center justify-center bg-black/20 pointer-events-none z-10">
+              <div className="w-20 h-20 bg-white/10 backdrop-blur-sm rounded-full flex items-center justify-center border-2 border-white/30 animate-pulse">
+                <Play className="w-10 h-10 text-white ml-1 fill-white" />
+              </div>
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
 
       <ControlBar

--- a/packages/webui/components/viewers/video-player.tsx
+++ b/packages/webui/components/viewers/video-player.tsx
@@ -799,7 +799,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
     >
-      <div className="flex-1 flex min-h-0 relative">
+      <div className="flex-1 flex flex-col-reverse md:flex-row min-h-0 relative">
         {/* Render Carousel/Sidebar here if not fullscreen */}
         {!state.isFullScreen && children}
 

--- a/packages/webui/globals.css
+++ b/packages/webui/globals.css
@@ -159,3 +159,11 @@
     @apply bg-background text-foreground;
   }
 }
+
+.no-scrollbar {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none; /* Chrome, Safari and Opera */
+}

--- a/packages/webui/routes/projects/$projectId/files/$fileId.tsx
+++ b/packages/webui/routes/projects/$projectId/files/$fileId.tsx
@@ -310,15 +310,6 @@ function FileViewPage() {
   return (
     <div className="h-full flex flex-1 flex-col bg-background">
       <div className="h-full flex flex-1 overflow-hidden">
-        {carouselState.show && (
-          <FileViewerLeftSidebar
-            projectId={projectId}
-            currentAssetId={activeFileId}
-            parentFolderId={parentFolderId}
-            initialFiles={carouselState.files}
-            initialNextCursor={carouselState.nextCursor}
-          />
-        )}
         <div className="flex-1 relative">
           {isFetching && (
             <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/50">
@@ -331,7 +322,17 @@ function FileViewPage() {
             onPlay={handlePlay}
             onTimeUpdate={setCurrentTime}
             annotations={annotations}
-          />
+          >
+            {carouselState.show && (
+              <FileViewerLeftSidebar
+                projectId={projectId}
+                currentAssetId={activeFileId}
+                parentFolderId={parentFolderId}
+                initialFiles={carouselState.files}
+                initialNextCursor={carouselState.nextCursor}
+              />
+            )}
+          </FileViewer>
         </div>
         <ResizeHandle
           onResize={(delta) => {

--- a/packages/webui/routes/projects/$projectId/files/$fileId.tsx
+++ b/packages/webui/routes/projects/$projectId/files/$fileId.tsx
@@ -7,12 +7,11 @@ import { FileDetailSkeleton } from '@/ui/components/loading-skeletons'
 import { useMemberStore } from '@/ui/stores/members'
 import { useTeamContextStore } from '@/ui/stores/team-context'
 import { useTopNavStore } from '@/ui/stores/top-nav'
-import { useUiStore } from '@/ui/stores/ui'
 import { type Annotation } from '@/ui/types'
 import { useMutation } from '@tanstack/react-query'
 import { InferRequestType, InferResponseType } from 'hono/client'
 
-import type { AssetInfo, CommentInfo } from '@shumai/dtos'
+import type { AssetInfo, AssetInfoPaginatedList, CommentInfo } from '@shumai/dtos'
 import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Loader2 } from 'lucide-react'
@@ -26,13 +25,7 @@ function FileViewPage() {
   const activeFileId = versionAssetId || fileId
 
   const videoRef = useRef<Player | null>(null)
-  const {
-    fileViewRightSidebarCollapsed: isRightSidebarCollapsed,
-    fileViewLeftSidebarCollapsed: isLeftSidebarCollapsed,
-    setFileViewLeftSidebarCollapsed: setIsLeftSidebarCollapsed,
-  } = useUiStore()
   const { teamId, ensureTeamIdForProject } = useTeamContextStore()
-  const [leftSidebarWidth, setLeftSidebarWidth] = useState(280)
   const [rightSidebarWidth, setRightSidebarWidth] = useState(360)
   const [annotations, setAnnotations] = useState<Annotation[]>([])
   const [currentTime, setCurrentTime] = useState(0)
@@ -222,30 +215,110 @@ function FileViewPage() {
     setSelectedCommentId(null)
   }
 
+  const parentFolderId =
+    fileData.ancestorFolders?.[fileData.ancestorFolders.length - 1]?.id ??
+    projectInfo.rootFolder ??
+    ''
+
+  const [carouselState, setCarouselState] = useState<{
+    show: boolean
+    files: AssetInfo[]
+    nextCursor?: string
+    folderId?: string
+  }>({ show: false, files: [], nextCursor: undefined, folderId: undefined })
+
+  useEffect(() => {
+    if (!parentFolderId || !activeFileId) return
+    if (carouselState.folderId === parentFolderId) {
+      return
+    }
+
+    let isMounted = true
+
+    const fetchCarouselData = async () => {
+      try {
+        let cursor = ''
+        let found = false
+        const allFiles: AssetInfo[] = []
+        let lastCursor: string | undefined = undefined
+
+        for (let batch = 0; batch < 5; batch++) {
+          const res = await client.api.folders[':folderId'].search.$post({
+            param: { folderId: parentFolderId },
+            json: {
+              assetType: 'file',
+              after: cursor,
+              first: 200,
+              recursively: false,
+              conditions: [],
+            },
+          })
+          if (!res.ok) {
+            throw new Error('Failed to search parent folder for carousel')
+          }
+          const result = (await res.json()) as unknown as AssetInfoPaginatedList
+          const batchFiles = (result.data || []) as AssetInfo[]
+          allFiles.push(...batchFiles)
+
+          if (batchFiles.some((f) => f.id === activeFileId)) {
+            found = true
+            lastCursor = result.pageInfo?.cursor || undefined
+            break
+          }
+          if (!result.pageInfo?.cursor || batchFiles.length < 200) {
+            break
+          }
+          cursor = result.pageInfo.cursor
+        }
+
+        if (isMounted) {
+          if (found) {
+            setCarouselState({
+              show: true,
+              files: allFiles,
+              nextCursor: lastCursor,
+              folderId: parentFolderId,
+            })
+          } else {
+            setCarouselState({
+              show: false,
+              files: [],
+              nextCursor: undefined,
+              folderId: parentFolderId,
+            })
+          }
+        }
+      } catch (err) {
+        console.error(err)
+        if (isMounted) {
+          setCarouselState({
+            show: false,
+            files: [],
+            nextCursor: undefined,
+            folderId: parentFolderId,
+          })
+        }
+      }
+    }
+
+    fetchCarouselData()
+
+    return () => {
+      isMounted = false
+    }
+  }, [parentFolderId, activeFileId, carouselState.folderId])
+
   return (
     <div className="h-full flex flex-1 flex-col bg-background">
       <div className="h-full flex flex-1 overflow-hidden">
-        {!isLeftSidebarCollapsed && (
-          <>
-            <div style={{ width: leftSidebarWidth }} className="flex-shrink-0">
-              <FileViewerLeftSidebar
-                projectId={projectId}
-                currentAssetId={activeFileId}
-                parentFolderId={
-                  fileData.ancestorFolders?.[fileData.ancestorFolders.length - 1]?.id ??
-                  projectInfo.rootFolder ??
-                  ''
-                }
-                onCollapse={() => setIsLeftSidebarCollapsed(true)}
-              />
-            </div>
-            <ResizeHandle
-              onResize={(delta) => {
-                setLeftSidebarWidth((prev) => Math.max(200, Math.min(500, prev + delta)))
-              }}
-              className="hidden md:block"
-            />
-          </>
+        {carouselState.show && (
+          <FileViewerLeftSidebar
+            projectId={projectId}
+            currentAssetId={activeFileId}
+            parentFolderId={parentFolderId}
+            initialFiles={carouselState.files}
+            initialNextCursor={carouselState.nextCursor}
+          />
         )}
         <div className="flex-1 relative">
           {isFetching && (
@@ -261,33 +334,29 @@ function FileViewPage() {
             annotations={annotations}
           />
         </div>
-        {!isRightSidebarCollapsed && (
-          <>
-            <ResizeHandle
-              onResize={(delta) => {
-                setRightSidebarWidth((prev) => Math.max(300, Math.min(600, prev - delta)))
-              }}
-              className="hidden md:block"
-            />
-            <div style={{ width: rightSidebarWidth }} className="flex-shrink-0">
-              <FileViewerRightSidebar
-                teamId={teamId}
-                projectId={projectId}
-                file={fileData as unknown as AssetInfo}
-                onSaveField={handleSaveField}
-                members={members}
-                onCommentSelect={handleCommentSelect}
-                currentTime={currentTime}
-                onTyping={() => {
-                  if (videoRef.current) {
-                    videoRef.current.pause()
-                  }
-                }}
-                selectedCommentId={selectedCommentId}
-              />
-            </div>
-          </>
-        )}
+        <ResizeHandle
+          onResize={(delta) => {
+            setRightSidebarWidth((prev) => Math.max(300, Math.min(600, prev - delta)))
+          }}
+          className="hidden md:block"
+        />
+        <div style={{ width: rightSidebarWidth }} className="flex-shrink-0">
+          <FileViewerRightSidebar
+            teamId={teamId}
+            projectId={projectId}
+            file={fileData as unknown as AssetInfo}
+            onSaveField={handleSaveField}
+            members={members}
+            onCommentSelect={handleCommentSelect}
+            currentTime={currentTime}
+            onTyping={() => {
+              if (videoRef.current) {
+                videoRef.current.pause()
+              }
+            }}
+            selectedCommentId={selectedCommentId}
+          />
+        </div>
       </div>
     </div>
   )

--- a/packages/webui/routes/projects/$projectId/files/$fileId.tsx
+++ b/packages/webui/routes/projects/$projectId/files/$fileId.tsx
@@ -30,6 +30,12 @@ function FileViewPage() {
   const [annotations, setAnnotations] = useState<Annotation[]>([])
   const [currentTime, setCurrentTime] = useState(0)
   const [selectedCommentId, setSelectedCommentId] = useState<string | null>(null)
+  const [carouselState, setCarouselState] = useState<{
+    show: boolean
+    files: AssetInfo[]
+    nextCursor?: string
+    folderId?: string
+  }>({ show: false, files: [], nextCursor: undefined, folderId: undefined })
   const $patchMetadata = client.api.files[':fileId'].metadata.$patch
   const { mutate: patchMetadata } = useMutation<
     InferResponseType<typeof $patchMetadata>,
@@ -164,68 +170,10 @@ function FileViewPage() {
     navigate,
   ])
 
-  if (isLoading && !fileData) {
-    return <FileDetailSkeleton />
-  }
-
-  if (isError || !fileData || !projectInfo || !teamId) {
-    return <div>File not found.</div>
-  }
-
-  const handleSaveField = (fieldId: string, value: unknown) => {
-    if (!teamId) return
-    patchMetadata(
-      {
-        param: { fileId: activeFileId },
-        json: [{ key: fieldId, value }] as InferRequestType<typeof $patchMetadata>['json'],
-      },
-      {
-        onSuccess: () => {
-          queryClient.invalidateQueries({
-            queryKey: ['files', activeFileId],
-          })
-        },
-      },
-    )
-  }
-
-  const handleCommentSelect = (comment: CommentInfo) => {
-    setSelectedCommentId(comment.id || null)
-    const newAnnotations = comment.annotations as Annotation[]
-    if (newAnnotations && newAnnotations.length > 0) {
-      setAnnotations(newAnnotations)
-    } else {
-      setAnnotations([])
-    }
-
-    if (comment.second !== null && comment.second !== undefined) {
-      if (videoRef.current) {
-        videoRef.current.currentTime(comment.second)
-        videoRef.current.pause()
-      }
-    } else if (newAnnotations && newAnnotations.length > 0) {
-      if (videoRef.current) {
-        videoRef.current.pause()
-      }
-    }
-  }
-
-  const handlePlay = () => {
-    setAnnotations([])
-    setSelectedCommentId(null)
-  }
-
   const parentFolderId =
-    fileData.ancestorFolders?.[fileData.ancestorFolders.length - 1]?.id ??
-    projectInfo.rootFolder ??
+    fileData?.ancestorFolders?.[fileData.ancestorFolders.length - 1]?.id ??
+    projectInfo?.rootFolder ??
     ''
-
-  const [carouselState, setCarouselState] = useState<{
-    show: boolean
-    files: AssetInfo[]
-    nextCursor?: string
-    folderId?: string
-  }>({ show: false, files: [], nextCursor: undefined, folderId: undefined })
 
   useEffect(() => {
     if (!parentFolderId || !activeFileId) return
@@ -307,6 +255,57 @@ function FileViewPage() {
       isMounted = false
     }
   }, [parentFolderId, activeFileId, carouselState.folderId])
+
+  if (isLoading && !fileData) {
+    return <FileDetailSkeleton />
+  }
+
+  if (isError || !fileData || !projectInfo || !teamId) {
+    return <div>File not found.</div>
+  }
+
+  const handleSaveField = (fieldId: string, value: unknown) => {
+    if (!teamId) return
+    patchMetadata(
+      {
+        param: { fileId: activeFileId },
+        json: [{ key: fieldId, value }] as InferRequestType<typeof $patchMetadata>['json'],
+      },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({
+            queryKey: ['files', activeFileId],
+          })
+        },
+      },
+    )
+  }
+
+  const handleCommentSelect = (comment: CommentInfo) => {
+    setSelectedCommentId(comment.id || null)
+    const newAnnotations = comment.annotations as Annotation[]
+    if (newAnnotations && newAnnotations.length > 0) {
+      setAnnotations(newAnnotations)
+    } else {
+      setAnnotations([])
+    }
+
+    if (comment.second !== null && comment.second !== undefined) {
+      if (videoRef.current) {
+        videoRef.current.currentTime(comment.second)
+        videoRef.current.pause()
+      }
+    } else if (newAnnotations && newAnnotations.length > 0) {
+      if (videoRef.current) {
+        videoRef.current.pause()
+      }
+    }
+  }
+
+  const handlePlay = () => {
+    setAnnotations([])
+    setSelectedCommentId(null)
+  }
 
   return (
     <div className="h-full flex flex-1 flex-col bg-background">


### PR DESCRIPTION
## Summary

This PR refactors the file detail page layout. It permanently displays the right sidebar (removing hide/collapse controls) and replaces the left folder files sidebar with a vertical carousel of width 96px showing image/video previews with infinite scroll support.

## Changes

- Modified `breadcrumb-nav.tsx` to conditionally hide sidebar and view mode toggle buttons when a file is viewed (`fileId` is present).
- Redesigned `file-viewer-left-sidebar.tsx` into a vertical carousel of width 96px displaying 54x54 image/video previews with opacity-based highlighting (100% for active, 65% for inactive).
- Added an initial parent folder files lookup search loop (up to 1000 items in batches of 200) inside `fileId.tsx` to verify if the file exists within the range before rendering the carousel.
- Enabled auto infinite scroll in the left sidebar carousel to fetch subsequent pages as the user scrolls.
- Made the right sidebar permanently visible.

## Verification

- Ran `bun run lint` (passed)
- Ran `bun run format` (passed)
- Ran `bun run typecheck` (passed)
- Ran `bun run test` (passed successfully: 65 test files passed, 475 tests passed)
