### PR TITLE
fix(webui): avoid refetching all pages on file/folder reorder

### DIFF
--- a/packages/core/src/asset/asset.test.ts
+++ b/packages/core/src/asset/asset.test.ts
@@ -1152,6 +1152,90 @@ describe('AssetService', () => {
     expect(updatedA?.sortIndex && updatedA.sortIndex > 'a1').toBe(true)
   })
 
+  it('reproduces collation mismatch error when reordering assets with mixed-case sort indexes', async () => {
+    const { user, project } = await setupBasicAssets()
+
+    // Create a parent folder to contain our assets
+    const folder = await prisma.asset.create({
+      data: {
+        name: 'Parent Folder',
+        type: AssetType.folder,
+        projectId: project.id,
+        creatorId: user.id,
+        status: 'uploaded',
+      },
+    })
+
+    // Create Asset A: In ASCII, "YjnsD0vZ" > "YjNuyGpV" because "n" (110) > "N" (78).
+    // In default Postgres locale collation, "YjnsD0vZ" < "YjNuyGpV".
+    const assetA = await prisma.asset.create({
+      data: {
+        name: 'Asset A',
+        type: AssetType.file,
+        parentId: folder.id,
+        projectId: project.id,
+        creatorId: user.id,
+        sortIndex: 'YjnsD0vZ',
+        status: 'uploaded',
+      },
+    })
+
+    // Create Asset B
+    const assetB = await prisma.asset.create({
+      data: {
+        name: 'Asset B',
+        type: AssetType.file,
+        parentId: folder.id,
+        projectId: project.id,
+        creatorId: user.id,
+        sortIndex: 'YjNuyGpV',
+        status: 'uploaded',
+      },
+    })
+
+    // Create Asset C
+    const assetC = await prisma.asset.create({
+      data: {
+        name: 'Asset C',
+        type: AssetType.file,
+        parentId: folder.id,
+        projectId: project.id,
+        creatorId: user.id,
+        sortIndex: 'Yjzaaa',
+        status: 'uploaded',
+      },
+    })
+
+    // Verify ASCII ordering in JavaScript: assetA.sortIndex > assetB.sortIndex
+    expect(assetA.sortIndex! > assetB.sortIndex!).toBe(true)
+
+    // Verify Postgres sorting behavior:
+    // If the database collation is locale-aware (case-insensitive or groups n/N),
+    // it will consider assetA.sortIndex < assetB.sortIndex.
+    // So if we find the first asset with sortIndex < assetB.sortIndex,
+    // a locale-aware collation will find assetA, while ASCII ordering would NOT find assetA.
+    const prevAsset = await prisma.asset.findFirst({
+      where: {
+        parentId: folder.id,
+        sortIndex: { lt: assetB.sortIndex! },
+        id: { not: assetC.id },
+      },
+      orderBy: { sortIndex: 'desc' },
+    })
+
+    console.log('Postgres found prevAsset with sortIndex:', prevAsset?.sortIndex)
+
+    // If it finds assetA, it confirms that Postgres is using a different collation order than ASCII.
+    // Then calling updateAssetOrder will call generateKeyBetween("YjnsD0vZ", "YjNuyGpV"), which throws.
+    if (prevAsset?.sortIndex === 'YjnsD0vZ') {
+      await expect(
+        assetService.updateAssetOrder(assetC.id, {
+          beforeIndex: assetB.sortIndex!,
+        })
+      ).rejects.toThrow()
+    }
+  })
+
   describe('Symlinks', () => {
     it('toAssetInfo resolves symlink target metadata', async () => {
       const { project, user } = await setupBasicAssets()

--- a/packages/core/src/asset/asset.test.ts
+++ b/packages/core/src/asset/asset.test.ts
@@ -1394,6 +1394,7 @@ describe('AssetService', () => {
           creatorId: user.id,
           status: 'uploaded',
           sizeByte: 100,
+          sortIndex: 'abc',
         },
       })
 
@@ -1425,6 +1426,7 @@ describe('AssetService', () => {
       expect(res.data).toHaveLength(1)
       const stackAsset = res.data[0]
       expect(stackAsset.type).toBe(AssetType.version_stack)
+      expect(stackAsset.sortIndex).toBe('abc')
       expect(stackAsset.versionStack).toBeDefined()
       expect(stackAsset.versionStack?.versions).toHaveLength(2)
       const versions = stackAsset.versionStack!.versions

--- a/packages/core/src/asset/asset.test.ts
+++ b/packages/core/src/asset/asset.test.ts
@@ -1152,7 +1152,7 @@ describe('AssetService', () => {
     expect(updatedA?.sortIndex && updatedA.sortIndex > 'a1').toBe(true)
   })
 
-  it('reproduces collation mismatch error when reordering assets with mixed-case sort indexes', async () => {
+  it('verifies that sortIndex uses C collation to prevent fractional indexing mismatch', async () => {
     const { user, project } = await setupBasicAssets()
 
     // Create a parent folder to contain our assets
@@ -1210,10 +1210,8 @@ describe('AssetService', () => {
     expect(assetA.sortIndex! > assetB.sortIndex!).toBe(true)
 
     // Verify Postgres sorting behavior:
-    // If the database collation is locale-aware (case-insensitive or groups n/N),
-    // it will consider assetA.sortIndex < assetB.sortIndex.
-    // So if we find the first asset with sortIndex < assetB.sortIndex,
-    // a locale-aware collation will find assetA, while ASCII ordering would NOT find assetA.
+    // With C collation, it must follow ASCII ordering. Therefore, searching for
+    // sortIndex < assetB.sortIndex must NOT find assetA.
     const prevAsset = await prisma.asset.findFirst({
       where: {
         parentId: folder.id,
@@ -1223,17 +1221,15 @@ describe('AssetService', () => {
       orderBy: { sortIndex: 'desc' },
     })
 
-    console.log('Postgres found prevAsset with sortIndex:', prevAsset?.sortIndex)
+    // Assert that the database collation is correctly "C" (returns null for prevAsset)
+    expect(prevAsset).toBeNull()
 
-    // If it finds assetA, it confirms that Postgres is using a different collation order than ASCII.
-    // Then calling updateAssetOrder will call generateKeyBetween("YjnsD0vZ", "YjNuyGpV"), which throws.
-    if (prevAsset?.sortIndex === 'YjnsD0vZ') {
-      await expect(
-        assetService.updateAssetOrder(assetC.id, {
-          beforeIndex: assetB.sortIndex!,
-        })
-      ).rejects.toThrow()
-    }
+    // Assert that updateAssetOrder succeeds without throwing a collation error
+    const updatedC = await assetService.updateAssetOrder(assetC.id, {
+      beforeIndex: assetB.sortIndex!,
+    })
+    expect(updatedC.sortIndex).toBeDefined()
+    expect(updatedC.sortIndex! < assetB.sortIndex!).toBe(true)
   })
 
   describe('Symlinks', () => {

--- a/packages/core/src/asset/asset.test.ts
+++ b/packages/core/src/asset/asset.test.ts
@@ -1232,6 +1232,54 @@ describe('AssetService', () => {
     expect(updatedC.sortIndex! < assetB.sortIndex!).toBe(true)
   })
 
+  it('correctly bounds the new sortIndex when moving an asset after another asset in the middle of the list', async () => {
+    const { user, project } = await setupBasicAssets()
+
+    // Create three assets: A, B, C with specific sort indexes
+    const assetA = await prisma.asset.create({
+      data: {
+        name: 'Asset A',
+        type: AssetType.file,
+        projectId: project.id,
+        creatorId: user.id,
+        sortIndex: 'a0',
+        status: 'uploaded',
+      },
+    })
+
+    const assetB = await prisma.asset.create({
+      data: {
+        name: 'Asset B',
+        type: AssetType.file,
+        projectId: project.id,
+        creatorId: user.id,
+        sortIndex: 'a1',
+        status: 'uploaded',
+      },
+    })
+
+    const assetC = await prisma.asset.create({
+      data: {
+        name: 'Asset C',
+        type: AssetType.file,
+        projectId: project.id,
+        creatorId: user.id,
+        sortIndex: 'a11',
+        status: 'uploaded',
+      },
+    })
+
+    // Move Asset A to be after Asset B (it should be placed between B ("a1") and C ("a11"))
+    const updatedA = await assetService.updateAssetOrder(assetA.id, {
+      afterIndex: assetB.sortIndex!,
+    })
+
+    // Verify it is placed after B
+    expect(updatedA.sortIndex! > assetB.sortIndex!).toBe(true)
+    // Verify it is placed before C (this fails under the buggy code because C's bound is ignored, generating a key greater than "a11")
+    expect(updatedA.sortIndex! < assetC.sortIndex!).toBe(true)
+  })
+
   describe('Symlinks', () => {
     it('toAssetInfo resolves symlink target metadata', async () => {
       const { project, user } = await setupBasicAssets()

--- a/packages/core/src/asset/asset.ts
+++ b/packages/core/src/asset/asset.ts
@@ -533,6 +533,7 @@ export class AssetService {
         parentId: stackParentId,
         creatorId: creatorId,
         name: '',
+        sortIndex: destFile.sortIndex,
       },
     })
 

--- a/packages/core/src/asset/asset.ts
+++ b/packages/core/src/asset/asset.ts
@@ -973,7 +973,15 @@ export class AssetService {
       afterSortIndex = prevAsset?.sortIndex || null
     } else if (req.afterIndex) {
       afterSortIndex = req.afterIndex
-      beforeSortIndex = null
+      const nextAsset = await this.prismaClient.asset.findFirst({
+        where: {
+          parentId: asset.parentId,
+          sortIndex: { gt: req.afterIndex },
+          id: { not: id },
+        },
+        orderBy: { sortIndex: 'asc' },
+      })
+      beforeSortIndex = nextAsset?.sortIndex || null
     }
 
     const newSortIndex = generateKeyBetween(afterSortIndex, beforeSortIndex)

--- a/packages/core/src/versionStack/versionStack.test.ts
+++ b/packages/core/src/versionStack/versionStack.test.ts
@@ -56,6 +56,7 @@ describe('VersionStackService', () => {
           creatorId: user.id,
           status: 'uploaded',
           sizeByte: 100,
+          sortIndex: 'abc',
         },
       })
 
@@ -85,6 +86,7 @@ describe('VersionStackService', () => {
       expect(stack.fileCount).toBe(2)
       expect(stack.sizeByte).toBe(300)
       expect(stack.parentId).toBe(parent.id)
+      expect(stack.sortIndex).toBe('abc')
 
       // Verify Parent file count
       const updatedParent = await prisma.asset.findUnique({ where: { id: parent.id } })

--- a/packages/core/src/versionStack/versionStack.ts
+++ b/packages/core/src/versionStack/versionStack.ts
@@ -58,6 +58,9 @@ export class VersionStackService {
         throw new Error('parent not found')
       }
 
+      const firstFile = files[0]
+      const sortIndex = firstFile?.sortIndex || null
+
       const stack = await tx.asset.create({
         data: {
           type: AssetType.version_stack,
@@ -67,6 +70,7 @@ export class VersionStackService {
           projectId: projectId,
           creatorId: creatorId,
           parentId: parentId,
+          sortIndex: sortIndex,
         },
       })
 

--- a/packages/db/prisma/migrations/20260615115103_add_c_collation_to_sort_index/migration.sql
+++ b/packages/db/prisma/migrations/20260615115103_add_c_collation_to_sort_index/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable: Change sort_index column collation to "C"
+ALTER TABLE "assets" ALTER COLUMN "sort_index" TYPE TEXT COLLATE "C";
+
+-- Recreate index on sort_index with "C" collation
+DROP INDEX IF EXISTS "assets_sort_index_idx";
+CREATE INDEX "assets_sort_index_idx" ON "assets" ("sort_index" COLLATE "C");

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -853,6 +853,7 @@ export function FileBrowser({
             <div
               ref={scrollContainerRef}
               className="flex-1 overflow-y-auto min-h-0 relative flex flex-col"
+              style={{ overflowAnchor: 'none' }}
             >
               {displayStyle === 'list' ? (
                 <FileBrowserListView

--- a/packages/webui/components/file-system-manager.tsx
+++ b/packages/webui/components/file-system-manager.tsx
@@ -12,7 +12,7 @@ import { useMemberStore } from '@/ui/stores/members'
 import { useTopNavStore } from '@/ui/stores/top-nav'
 import { useUiStore } from '@/ui/stores/ui'
 import { useUserMetadataStore } from '@/ui/stores/user-metadata'
-import { PointerActivationConstraints } from '@dnd-kit/dom'
+import { Feedback, PointerActivationConstraints } from '@dnd-kit/dom'
 import { DragDropProvider, DragOverlay, KeyboardSensor, PointerSensor } from '@dnd-kit/react'
 import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
@@ -400,6 +400,17 @@ export default function FileSystemManager({
   return (
     <DragDropProvider
       modifiers={[SnapToPointer.configure({ anchor: { x: 0, y: 0 } })]}
+      plugins={(defaults) =>
+        defaults.map((p) => {
+          if (p === Feedback) {
+            return Feedback.configure({ dropAnimation: null })
+          }
+          if (typeof p === 'object' && p !== null && 'plugin' in p && p.plugin === Feedback) {
+            return Feedback.configure({ dropAnimation: null })
+          }
+          return p
+        })
+      }
       sensors={
         isRecentlyDeleted || !canEdit
           ? []

--- a/packages/webui/components/use-file-system-dnd.ts
+++ b/packages/webui/components/use-file-system-dnd.ts
@@ -40,11 +40,21 @@ export function useFileSystemDnd({
       queryKey: queryKeyPrefix,
     })
 
-    for (const [queryKey, oldData] of queries) {
-      if (!oldData) continue
+    const isSearchSort = (val: unknown): val is SearchSort => {
+      if (typeof val !== 'object' || val === null) return false
+      const obj = val as Record<string, unknown>
+      return (
+        'field' in obj &&
+        'order' in obj &&
+        typeof obj.field === 'string' &&
+        (obj.order === 'asc' || obj.order === 'desc')
+      )
+    }
 
-      const sort = queryKey[5] as SearchSort | undefined
-      const isDesc = sort?.order === 'desc'
+    for (const [queryKey, oldData] of queries) {
+      if (!oldData || !Array.isArray(oldData.pages)) continue
+
+      const sort = queryKey.find(isSearchSort)
 
       const allItems = oldData.pages.flatMap((page) => page.data ?? [])
 
@@ -55,13 +65,19 @@ export function useFileSystemDnd({
 
       allItems[itemIndex] = { ...allItems[itemIndex], ...updatedItem }
 
-      allItems.sort((a, b) => {
-        const indexA = a.sortIndex ?? ''
-        const indexB = b.sortIndex ?? ''
-        if (indexA === indexB) return 0
-        const comp = indexA.localeCompare(indexB)
-        return isDesc ? -comp : comp
-      })
+      if (sort?.field === 'custom') {
+        const isDesc = sort.order === 'desc'
+        allItems.sort((a, b) => {
+          const indexA = a.sortIndex ?? ''
+          const indexB = b.sortIndex ?? ''
+          if (indexA === indexB) return 0
+          if (isDesc) {
+            return indexA < indexB ? 1 : -1
+          } else {
+            return indexA < indexB ? -1 : 1
+          }
+        })
+      }
 
       let pointer = 0
       const newPages = oldData.pages.map((page) => {

--- a/packages/webui/components/use-file-system-dnd.ts
+++ b/packages/webui/components/use-file-system-dnd.ts
@@ -2,8 +2,9 @@
 
 import { client } from '@/ui/api/client'
 import type { InferRequestType, InferResponseType } from 'hono/client'
-import type { AssetInfo } from '@shumai/dtos'
+import type { AssetInfo, AssetInfoPaginatedList, SearchSort } from '@shumai/dtos'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { InfiniteData } from '@tanstack/react-query'
 import { useState } from 'react'
 import { toast } from 'sonner'
 import type { DragEndEvent, DragStartEvent } from '@dnd-kit/react'
@@ -30,6 +31,55 @@ export function useFileSystemDnd({
 }: UseFileSystemDndProps) {
   const queryClient = useQueryClient()
   const [dragState, setDragState] = useState<DragState | undefined>(undefined)
+
+  const updateLocalCache = (isFolder: boolean, updatedItem: AssetInfo) => {
+    const assetType = isFolder ? 'folder' : 'file'
+    const queryKeyPrefix = ['search', teamId, assetId, assetType]
+
+    const queries = queryClient.getQueriesData<InfiniteData<AssetInfoPaginatedList>>({
+      queryKey: queryKeyPrefix,
+    })
+
+    for (const [queryKey, oldData] of queries) {
+      if (!oldData) continue
+
+      const sort = queryKey[5] as SearchSort | undefined
+      const isDesc = sort?.order === 'desc'
+
+      const allItems = oldData.pages.flatMap((page) => page.data ?? [])
+
+      const itemIndex = allItems.findIndex((item) => item.id === updatedItem.id)
+      if (itemIndex === -1) {
+        continue
+      }
+
+      allItems[itemIndex] = { ...allItems[itemIndex], ...updatedItem }
+
+      allItems.sort((a, b) => {
+        const indexA = a.sortIndex ?? ''
+        const indexB = b.sortIndex ?? ''
+        if (indexA === indexB) return 0
+        const comp = indexA.localeCompare(indexB)
+        return isDesc ? -comp : comp
+      })
+
+      let pointer = 0
+      const newPages = oldData.pages.map((page) => {
+        const pageSize = page.data ? page.data.length : 0
+        const pageData = allItems.slice(pointer, pointer + pageSize)
+        pointer += pageSize
+        return {
+          ...page,
+          data: pageData,
+        }
+      })
+
+      queryClient.setQueryData<InfiniteData<AssetInfoPaginatedList>>(queryKey, {
+        ...oldData,
+        pages: newPages,
+      })
+    }
+  }
 
   const $reparent = client.api.projects[':projectId'].reparent.$post
   const { mutate: reparentAssets } = useMutation<
@@ -185,11 +235,9 @@ export function useFileSystemDnd({
                   : { afterIndex: targetItem.sortIndex ?? undefined },
             },
             {
-              onSuccess: () => {
+              onSuccess: (updatedFolder) => {
                 toast.success('Folder reordered')
-                queryClient.invalidateQueries({
-                  queryKey: ['search', teamId, assetId],
-                })
+                updateLocalCache(true, updatedFolder)
                 onClearSelection()
               },
               onError: (err) => {
@@ -207,11 +255,9 @@ export function useFileSystemDnd({
                   : { afterIndex: targetItem.sortIndex ?? undefined },
             },
             {
-              onSuccess: () => {
+              onSuccess: (updatedFile) => {
                 toast.success('File reordered')
-                queryClient.invalidateQueries({
-                  queryKey: ['search', teamId, assetId],
-                })
+                updateLocalCache(false, updatedFile)
                 onClearSelection()
               },
               onError: (err) => {


### PR DESCRIPTION
## Summary

Avoid refetching all cached pages of the search/file browser query when reordering files or folders, and fix a collation mismatch bug under PostgreSQL when doing fractional indexing. Also fix a bug where `afterIndex` reorders were not correctly upper-bounded by the next item. Additionally, fix a bug where `sortIndex` was not set on newly created version stack containers, causing them to sort incorrectly in the file browser. Finally, fix a visual jitter/layout shift issue during drag-and-drop reordering across rows by disabling the dnd-kit drop animation and disabling browser scroll anchoring on the scroll container.

## Changes

- Updated [use-file-system-dnd.ts](file:///Users/yiling/Projects/shumai/packages/webui/components/use-file-system-dnd.ts) to intercept mutation success events.
- Implemented `updateLocalCache` to directly find the reordered item in the React Query cache, update its `sortIndex` from the server response, re-sort items lexicographically, and chunk pages back into place.
- Removed `queryClient.invalidateQueries` call for reordering mutations, eliminating up to 90+ redundant network requests when scrolling to the bottom of the list.
- Created a new PostgreSQL migration to configure the `"C"` collation on the `sort_index` column and index to align database sorting behavior with JavaScript ASCII ordering.
- Fixed `updateAssetOrder` in [asset.ts](file:///Users/yiling/Projects/shumai/packages/core/src/asset/asset.ts#L974) to query for `nextAsset` when `afterIndex` is specified, so that positioning is correctly bounded by the next item in the list instead of placing the item at the end of the list.
- Fixed `reparentAssets` in [asset.ts](file:///Users/yiling/Projects/shumai/packages/core/src/asset/asset.ts#L533) to assign `sortIndex: destFile.sortIndex` to the new `version_stack` container when dropping one file onto another.
- Fixed `createVersionStack` in [versionStack.ts](file:///Users/yiling/Projects/shumai/packages/core/src/versionStack/versionStack.ts#L66) to retrieve the first file in the group and assign `sortIndex: firstFile.sortIndex` to the new `version_stack` container.
- Configured `DragDropProvider` in [file-system-manager.tsx](file:///Users/yiling/Projects/shumai/packages/webui/components/file-system-manager.tsx#L400) to disable the default drop animation for the `Feedback` plugin, avoiding unmount/remount layout shift conflicts when dropping items across rows.
- Configured `overflow-anchor: none` on the scroll container in [file-browser.tsx](file:///Users/yiling/Projects/shumai/packages/webui/components/file-browser/file-browser.tsx#L854) to prevent browser scroll anchoring interference.

## Verification

- Ran linter: `bun run lint` (passed)
- Ran formatter: `bun run format` (passed)
- Ran typechecker: `bun run typecheck` (passed)
- Added a test case to [asset.test.ts](file:///Users/yiling/Projects/shumai/packages/core/src/asset/asset.test.ts#L1152) verifying that the `sortIndex` uses `"C"` collation and does not fail on fractional indexing reordering.
- Added a test case to [asset.test.ts](file:///Users/yiling/Projects/shumai/packages/core/src/asset/asset.test.ts#L1235) verifying that moving an asset after another asset in the middle of the list is correctly bounded.
- Added test cases to [asset.test.ts](file:///Users/yiling/Projects/shumai/packages/core/src/asset/asset.test.ts#L1429) and [versionStack.test.ts](file:///Users/yiling/Projects/shumai/packages/core/src/versionStack/versionStack.test.ts#L89) to reproduce and verify the `sortIndex` inheritance on version stack container creation.
- Manually verified that drag-and-drop file reordering across rows is completely smooth without any layout shifts or visual jitter.
- Ran tests: `bun run test` (passed 65 suites, 477 tests)

## Notes

None.
