### PR TITLE
fix(webui): force video-player mime type to video/mp4

### DIFF
--- a/packages/webui/components/viewers/video-player.tsx
+++ b/packages/webui/components/viewers/video-player.tsx
@@ -470,7 +470,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       sources: [
         {
           src: state.currentSrc,
-          type: data.media?.mimeType || 'video/mp4',
+          type: 'video/mp4',
         },
       ],
     }))
@@ -732,7 +732,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       currentSrc: res.url,
     }))
 
-    player.src({ type: data.media?.mimeType || 'video/mp4', src: res.url })
+    player.src({ type: 'video/mp4', src: res.url })
 
     player.one('loadedmetadata', () => {
       player.currentTime(currentTime)


### PR DESCRIPTION
## Summary

This PR fixes an issue where `.mov` video files (and potentially other non-MP4 native file formats) would fail to play in the web UI due to mismatched MIME type initialization.

## Changes

- Changed `data.media?.mimeType || 'video/mp4'` to `'video/mp4'` in [video-player.tsx](file:///Users/yiling/Projects/shumai/packages/webui/components/viewers/video-player.tsx) when initializing and updating the Video.js player source.

## Verification

- Ran `bun run lint` (passed)
- Ran `bun run format` (passed)
- Ran `bun run typecheck` (passed)
- Ran `bun run test` (all 477 tests passed)

## Notes

None.