### PR TITLE
fix(webui): reload video player and reset state when switching assets

### DIFF
--- a/packages/webui/components/file-viewer.tsx
+++ b/packages/webui/components/file-viewer.tsx
@@ -301,6 +301,7 @@ export function FileViewer({
       )}
       {isVideo && (
         <VideoPlayer
+          key={file.id}
           data={file}
           playerRef={videoRef}
           onPlay={onPlay}

--- a/packages/webui/routes/projects/$projectId/files/$fileId.tsx
+++ b/packages/webui/routes/projects/$projectId/files/$fileId.tsx
@@ -260,7 +260,7 @@ function FileViewPage() {
     setCurrentTime(0)
     setSelectedCommentId(null)
     setAnnotations([])
-  }, [activeFileId])
+  }, [fileData?.id])
 
   if (isLoading && !fileData) {
     return <FileDetailSkeleton />

--- a/packages/webui/routes/projects/$projectId/files/$fileId.tsx
+++ b/packages/webui/routes/projects/$projectId/files/$fileId.tsx
@@ -256,6 +256,12 @@ function FileViewPage() {
     }
   }, [parentFolderId, activeFileId, carouselState.folderId])
 
+  useEffect(() => {
+    setCurrentTime(0)
+    setSelectedCommentId(null)
+    setAnnotations([])
+  }, [activeFileId])
+
   if (isLoading && !fileData) {
     return <FileDetailSkeleton />
   }


### PR DESCRIPTION
## Summary

This PR fixes a bug where selecting a new video file via the left sidebar carousel did not update the video playing in the player, even though the aspect ratio adjusted. It also ensures that the player state (current time, selected comment, and annotations) is reset when switching between files in the file viewer.

## Changes

- Added `key={file.id}` to the `<VideoPlayer>` component in `packages/webui/components/file-viewer.tsx` to force a complete unmount/remount when switching between video files. This disposes of the stale Video.js instance and mounts a fresh one initialized with the correct video source.
- Added a `useEffect` hook in `packages/webui/routes/projects/$projectId/files/$fileId.tsx` to reset `currentTime`, `selectedCommentId`, and `annotations` when `activeFileId` changes, preventing state leak between different assets.

## Verification

- Ran `bun run lint` successfully.
- Ran `bun run format` successfully.
- Ran `bun run typecheck` successfully.
- Ran `bun run test` (all 477 tests passed).

## Notes

None.
