### PR TITLE
feat(workflow): configure transcode and agent concurrency via environment variables

### DIFF
--- a/packages/workflow-core/src/local-executor.test.ts
+++ b/packages/workflow-core/src/local-executor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { prisma } from '@shumai/db'
 import { setupTestDbHooks } from '@shumai/db/test'
 import { workflowService } from './workflow'
@@ -343,6 +343,48 @@ describe('LocalExecutor Integration Tests', () => {
 
       expect(limiter.getActiveCount()).toBe(0)
       expect(limiter.getQueueLength()).toBe(0)
+    })
+  })
+
+  describe('Environment Variable Concurrency Config', () => {
+    let originalTranscode: string | undefined
+    let originalAgent: string | undefined
+
+    beforeEach(() => {
+      originalTranscode = process.env.CONCURRENCY_TRANSCODE
+      originalAgent = process.env.CONCURRENCY_AGENT
+    })
+
+    afterEach(() => {
+      if (originalTranscode === undefined) {
+        delete process.env.CONCURRENCY_TRANSCODE
+      } else {
+        process.env.CONCURRENCY_TRANSCODE = originalTranscode
+      }
+
+      if (originalAgent === undefined) {
+        delete process.env.CONCURRENCY_AGENT
+      } else {
+        process.env.CONCURRENCY_AGENT = originalAgent
+      }
+    })
+
+    it('should initialize with values from environment variables', () => {
+      process.env.CONCURRENCY_TRANSCODE = '2'
+      process.env.CONCURRENCY_AGENT = '8'
+
+      const customExecutor = new LocalExecutor()
+      expect(customExecutor.getTranscodeConcurrencyLimit()).toBe(2)
+      expect(customExecutor.getAgentConcurrencyLimit()).toBe(8)
+    })
+
+    it('should fallback to defaults when environment variables are not set', () => {
+      delete process.env.CONCURRENCY_TRANSCODE
+      delete process.env.CONCURRENCY_AGENT
+
+      const defaultExecutor = new LocalExecutor()
+      expect(defaultExecutor.getTranscodeConcurrencyLimit()).toBe(1)
+      expect(defaultExecutor.getAgentConcurrencyLimit()).toBe(5)
     })
   })
 })

--- a/packages/workflow-core/src/local-executor.test.ts
+++ b/packages/workflow-core/src/local-executor.test.ts
@@ -386,5 +386,21 @@ describe('LocalExecutor Integration Tests', () => {
       expect(defaultExecutor.getTranscodeConcurrencyLimit()).toBe(1)
       expect(defaultExecutor.getAgentConcurrencyLimit()).toBe(5)
     })
+
+    it('should fallback to defaults when environment variables are invalid or <= 0', () => {
+      process.env.CONCURRENCY_TRANSCODE = 'invalid'
+      process.env.CONCURRENCY_AGENT = '0'
+
+      const executor1 = new LocalExecutor()
+      expect(executor1.getTranscodeConcurrencyLimit()).toBe(1)
+      expect(executor1.getAgentConcurrencyLimit()).toBe(5)
+
+      process.env.CONCURRENCY_TRANSCODE = '-2'
+      process.env.CONCURRENCY_AGENT = 'abc'
+
+      const executor2 = new LocalExecutor()
+      expect(executor2.getTranscodeConcurrencyLimit()).toBe(1)
+      expect(executor2.getAgentConcurrencyLimit()).toBe(5)
+    })
   })
 })

--- a/packages/workflow-core/src/local-executor.ts
+++ b/packages/workflow-core/src/local-executor.ts
@@ -35,6 +35,10 @@ export class ConcurrencyLimiter {
 
   constructor(private readonly limit: number) {}
 
+  getLimit(): number {
+    return this.limit
+  }
+
   async run<T>(fn: () => Promise<T>): Promise<T> {
     if (this.activeCount >= this.limit) {
       await new Promise<void>((resolve) => this.queue.push(resolve))
@@ -68,9 +72,28 @@ export class LocalExecutor implements Executor {
   private interval: Timer | null = null
   private processingTasks = new Set<string>()
 
-  // 1 concurrency for transcode, 5 for other workflows
-  private transcodeLimiter = new ConcurrencyLimiter(1)
-  private generalLimiter = new ConcurrencyLimiter(5)
+  private transcodeLimiter: ConcurrencyLimiter
+  private generalLimiter: ConcurrencyLimiter
+
+  constructor() {
+    const transcodeLimit = process.env.CONCURRENCY_TRANSCODE
+      ? parseInt(process.env.CONCURRENCY_TRANSCODE, 10)
+      : 1
+    const agentLimit = process.env.CONCURRENCY_AGENT
+      ? parseInt(process.env.CONCURRENCY_AGENT, 10)
+      : 5
+
+    this.transcodeLimiter = new ConcurrencyLimiter(transcodeLimit)
+    this.generalLimiter = new ConcurrencyLimiter(agentLimit)
+  }
+
+  getTranscodeConcurrencyLimit(): number {
+    return this.transcodeLimiter.getLimit()
+  }
+
+  getAgentConcurrencyLimit(): number {
+    return this.generalLimiter.getLimit()
+  }
 
   async submit(task: WorkflowTask): Promise<string> {
     if (task.status !== WorkflowTaskStatus.pending) {

--- a/packages/workflow-core/src/local-executor.ts
+++ b/packages/workflow-core/src/local-executor.ts
@@ -3,6 +3,7 @@ import { WorkflowTask, WorkflowTaskStatus, WorkflowTaskType } from '@shumai/db'
 import { Executor } from './executor'
 import * as taskActivities from './activities/task'
 import { logger } from '@shumai/core/src/logger'
+import { getConcurrencyLimit } from './workflow-utils'
 
 type WorkflowFn = (task: WorkflowTask) => Promise<void>
 
@@ -76,12 +77,8 @@ export class LocalExecutor implements Executor {
   private generalLimiter: ConcurrencyLimiter
 
   constructor() {
-    const transcodeLimit = process.env.CONCURRENCY_TRANSCODE
-      ? parseInt(process.env.CONCURRENCY_TRANSCODE, 10)
-      : 1
-    const agentLimit = process.env.CONCURRENCY_AGENT
-      ? parseInt(process.env.CONCURRENCY_AGENT, 10)
-      : 5
+    const transcodeLimit = getConcurrencyLimit(process.env.CONCURRENCY_TRANSCODE, 1)
+    const agentLimit = getConcurrencyLimit(process.env.CONCURRENCY_AGENT, 5)
 
     this.transcodeLimiter = new ConcurrencyLimiter(transcodeLimit)
     this.generalLimiter = new ConcurrencyLimiter(agentLimit)

--- a/packages/workflow-core/src/workflow-utils.ts
+++ b/packages/workflow-core/src/workflow-utils.ts
@@ -190,3 +190,16 @@ export async function executeActivity(
     throw err
   }
 }
+
+/**
+ * Parses and validates a concurrency limit environment variable.
+ * If the value is undefined, NaN, or <= 0, it falls back to the default value.
+ */
+export function getConcurrencyLimit(envVar: string | undefined, defaultValue: number): number {
+  if (!envVar) return defaultValue
+  const parsed = parseInt(envVar, 10)
+  if (isNaN(parsed) || parsed <= 0) {
+    return defaultValue
+  }
+  return parsed
+}

--- a/packages/workflow-core/src/workflow-workers.test.ts
+++ b/packages/workflow-core/src/workflow-workers.test.ts
@@ -93,4 +93,25 @@ describe('WorkflowService Temporal Workers Concurrency Control', () => {
     const agentSpecificWorkerOptions = mockCreate.mock.calls[1][0]
     expect(agentSpecificWorkerOptions.maxConcurrentActivityTaskExecutions).toBe(12)
   })
+
+  it('should fallback to defaults when environment variables are invalid or <= 0 for specific workers', async () => {
+    process.env.CONCURRENCY_TRANSCODE = 'invalid'
+    process.env.CONCURRENCY_AGENT = '-5'
+
+    // Test Transcode Worker
+    await workflowService.startWorkers(TaskQueueTranscode)
+    expect(mockCreate).toHaveBeenCalledTimes(2)
+
+    const transcodeSpecificWorkerOptions = mockCreate.mock.calls[1][0]
+    expect(transcodeSpecificWorkerOptions.maxConcurrentActivityTaskExecutions).toBe(1)
+
+    vi.clearAllMocks()
+
+    // Test Agent Worker
+    await workflowService.startWorkers(TaskQueueAgent)
+    expect(mockCreate).toHaveBeenCalledTimes(2)
+
+    const agentSpecificWorkerOptions = mockCreate.mock.calls[1][0]
+    expect(agentSpecificWorkerOptions.maxConcurrentActivityTaskExecutions).toBe(5)
+  })
 })

--- a/packages/workflow-core/src/workflow-workers.test.ts
+++ b/packages/workflow-core/src/workflow-workers.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { workflowService } from './workflow'
+import { TaskQueueAgent, TaskQueueTranscode } from './workflow-utils'
+
+const mockCreate = vi.fn().mockResolvedValue({
+  run: vi.fn().mockResolvedValue(undefined),
+})
+
+const mockConnect = vi.fn().mockResolvedValue({})
+
+vi.mock('@temporalio/worker', () => ({
+  Worker: {
+    create: (options: Record<string, unknown>) => mockCreate(options),
+  },
+  NativeConnection: {
+    connect: (options: Record<string, unknown>) => mockConnect(options),
+  },
+}))
+
+describe('WorkflowService Temporal Workers Concurrency Control', () => {
+  let originalExecutor: string | undefined
+  let originalTranscode: string | undefined
+  let originalAgent: string | undefined
+
+  beforeEach(() => {
+    originalExecutor = process.env.WORKFLOW_EXECUTOR
+    originalTranscode = process.env.CONCURRENCY_TRANSCODE
+    originalAgent = process.env.CONCURRENCY_AGENT
+    process.env.WORKFLOW_EXECUTOR = 'temporal'
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    if (originalExecutor === undefined) {
+      delete process.env.WORKFLOW_EXECUTOR
+    } else {
+      process.env.WORKFLOW_EXECUTOR = originalExecutor
+    }
+
+    if (originalTranscode === undefined) {
+      delete process.env.CONCURRENCY_TRANSCODE
+    } else {
+      process.env.CONCURRENCY_TRANSCODE = originalTranscode
+    }
+
+    if (originalAgent === undefined) {
+      delete process.env.CONCURRENCY_AGENT
+    } else {
+      process.env.CONCURRENCY_AGENT = originalAgent
+    }
+  })
+
+  it('should pass default concurrency limits to specific workers', async () => {
+    delete process.env.CONCURRENCY_TRANSCODE
+    delete process.env.CONCURRENCY_AGENT
+
+    // Test Transcode Worker
+    await workflowService.startWorkers(TaskQueueTranscode)
+    // Worker.create should be called twice (shared worker + specific worker)
+    expect(mockCreate).toHaveBeenCalledTimes(2)
+
+    // The second call is for the specific worker
+    const transcodeSpecificWorkerOptions = mockCreate.mock.calls[1][0]
+    expect(transcodeSpecificWorkerOptions.maxConcurrentActivityTaskExecutions).toBe(1)
+
+    vi.clearAllMocks()
+
+    // Test Agent Worker
+    await workflowService.startWorkers(TaskQueueAgent)
+    expect(mockCreate).toHaveBeenCalledTimes(2)
+
+    const agentSpecificWorkerOptions = mockCreate.mock.calls[1][0]
+    expect(agentSpecificWorkerOptions.maxConcurrentActivityTaskExecutions).toBe(5)
+  })
+
+  it('should pass environment variable overridden concurrency limits to specific workers', async () => {
+    process.env.CONCURRENCY_TRANSCODE = '3'
+    process.env.CONCURRENCY_AGENT = '12'
+
+    // Test Transcode Worker
+    await workflowService.startWorkers(TaskQueueTranscode)
+    expect(mockCreate).toHaveBeenCalledTimes(2)
+
+    const transcodeSpecificWorkerOptions = mockCreate.mock.calls[1][0]
+    expect(transcodeSpecificWorkerOptions.maxConcurrentActivityTaskExecutions).toBe(3)
+
+    vi.clearAllMocks()
+
+    // Test Agent Worker
+    await workflowService.startWorkers(TaskQueueAgent)
+    expect(mockCreate).toHaveBeenCalledTimes(2)
+
+    const agentSpecificWorkerOptions = mockCreate.mock.calls[1][0]
+    expect(agentSpecificWorkerOptions.maxConcurrentActivityTaskExecutions).toBe(12)
+  })
+})

--- a/packages/workflow-core/src/workflow.ts
+++ b/packages/workflow-core/src/workflow.ts
@@ -5,7 +5,7 @@ import * as taskActivities from './activities/task'
 import { Executor } from './executor'
 import { LocalExecutor } from './local-executor'
 import { TemporalExecutor } from './temporal-executor'
-import { TaskQueueAgent, TaskQueueTranscode } from './workflow-utils'
+import { TaskQueueAgent, TaskQueueTranscode, getConcurrencyLimit } from './workflow-utils'
 
 export class WorkflowService {
   private executor: Executor
@@ -120,13 +120,12 @@ export class WorkflowService {
 
       let maxConcurrentActivityTaskExecutions: number | undefined
       if (queue === TaskQueueTranscode) {
-        maxConcurrentActivityTaskExecutions = process.env.CONCURRENCY_TRANSCODE
-          ? parseInt(process.env.CONCURRENCY_TRANSCODE, 10)
-          : 1
+        maxConcurrentActivityTaskExecutions = getConcurrencyLimit(
+          process.env.CONCURRENCY_TRANSCODE,
+          1,
+        )
       } else if (queue === TaskQueueAgent) {
-        maxConcurrentActivityTaskExecutions = process.env.CONCURRENCY_AGENT
-          ? parseInt(process.env.CONCURRENCY_AGENT, 10)
-          : 5
+        maxConcurrentActivityTaskExecutions = getConcurrencyLimit(process.env.CONCURRENCY_AGENT, 5)
       }
 
       const specificWorker = await Worker.create({

--- a/packages/workflow-core/src/workflow.ts
+++ b/packages/workflow-core/src/workflow.ts
@@ -5,6 +5,7 @@ import * as taskActivities from './activities/task'
 import { Executor } from './executor'
 import { LocalExecutor } from './local-executor'
 import { TemporalExecutor } from './temporal-executor'
+import { TaskQueueAgent, TaskQueueTranscode } from './workflow-utils'
 
 export class WorkflowService {
   private executor: Executor
@@ -117,11 +118,23 @@ export class WorkflowService {
         },
       })
 
+      let maxConcurrentActivityTaskExecutions: number | undefined
+      if (queue === TaskQueueTranscode) {
+        maxConcurrentActivityTaskExecutions = process.env.CONCURRENCY_TRANSCODE
+          ? parseInt(process.env.CONCURRENCY_TRANSCODE, 10)
+          : 1
+      } else if (queue === TaskQueueAgent) {
+        maxConcurrentActivityTaskExecutions = process.env.CONCURRENCY_AGENT
+          ? parseInt(process.env.CONCURRENCY_AGENT, 10)
+          : 5
+      }
+
       const specificWorker = await Worker.create({
         connection,
         // Register both domain-specific activities and shared task activities
         activities: { ...activities, ...taskActivities },
         taskQueue: workerSpecificQueue,
+        maxConcurrentActivityTaskExecutions,
         bundlerOptions: {
           webpackConfigHook: (config) => {
             config.resolve = config.resolve || {}


### PR DESCRIPTION
## Summary

Allows users to control the concurrency of transcode and agent/general tasks using environment variables `CONCURRENCY_TRANSCODE` and `CONCURRENCY_AGENT`.

## Changes

- **Local Executor**: Configured `LocalExecutor` to read `CONCURRENCY_TRANSCODE` (default `1`) and `CONCURRENCY_AGENT` (default `5`) from `process.env`. Exposed limit values on `ConcurrencyLimiter` and `LocalExecutor` to facilitate clean unit testing.
- **Temporal Workers**: Passed the `maxConcurrentActivityTaskExecutions` option to the specific worker inside `workflowService.startWorkers`, using the environment variables corresponding to the task queue.
- **Tests**:
  - Added unit tests in `packages/workflow-core/src/local-executor.test.ts` to verify `LocalExecutor` reads the environment variables and defaults correctly.
  - Created a new test file `packages/workflow-core/src/workflow-workers.test.ts` to mock Temporal's `@temporalio/worker` and verify the `maxConcurrentActivityTaskExecutions` option is correctly set based on the queue name and environment variables.

## Verification

- Ran `bun run lint` (passed)
- Ran `bun run format` (passed)
- Ran `bun run typecheck` (passed)
- Ran `bun run test` (passed 481/481 tests)

## Notes

None.
