### PR TITLE
feat(webui): replace native overflow with shadcn ScrollArea in settings

### DIFF
--- a/packages/webui/components/file-browser/file-card.tsx
+++ b/packages/webui/components/file-browser/file-card.tsx
@@ -6,11 +6,11 @@ import { Badge } from '@/ui/components/ui/badge'
 import { Button } from '@/ui/components/ui/button'
 import { Checkbox } from '@/ui/components/ui/checkbox'
 import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuSeparator,
-    DropdownMenuTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
 } from '@/ui/components/ui/dropdown-menu'
 import { EditableText } from '@/ui/components/ui/editable-text'
 import { Skeleton } from '@/ui/components/ui/skeleton'

--- a/packages/webui/components/settings/NotificationSettings.tsx
+++ b/packages/webui/components/settings/NotificationSettings.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { client } from '@/ui/api/client'
+import { ScrollArea } from '@/ui/components/ui/scroll-area'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/components/ui/card'
 import { Switch } from '@/ui/components/ui/switch'
 import {
@@ -65,163 +66,169 @@ export function NotificationSettings({ teamId }: { teamId: string }) {
   }
 
   return (
-    <div className="h-full overflow-y-auto space-y-6 pr-1">
-      {/* Comments Settings */}
-      <Card className="border border-slate-200 dark:border-slate-800">
-        <CardHeader className="border-b border-slate-100 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/50">
-          <div className="flex items-center gap-2">
-            <MessageSquare className="w-5 h-5 text-blue-500" />
-            <CardTitle className="text-lg">Comments & Replies</CardTitle>
-          </div>
-          <CardDescription>
-            Control notification preferences when other users comment on assets you collaborate on
-            or mention you.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="divide-y divide-slate-100 dark:divide-slate-800 p-0">
-          {/* General Comments */}
-          <div className="flex items-center justify-between p-6">
-            <div className="flex gap-4">
-              <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400">
-                <MessageSquare className="w-4 h-4" />
-              </div>
-              <div className="space-y-0.5">
-                <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
-                  General Comments
-                </h4>
-                <p className="text-sm text-slate-500 dark:text-slate-400">
-                  When someone comments on an asset
-                </p>
-              </div>
+    <ScrollArea className="h-full">
+      <div className="space-y-6 pr-4 pb-8">
+        {/* Comments Settings */}
+        <Card className="border border-slate-200 dark:border-slate-800">
+          <CardHeader className="border-b border-slate-100 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/50">
+            <div className="flex items-center gap-2">
+              <MessageSquare className="w-5 h-5 text-blue-500" />
+              <CardTitle className="text-lg">Comments & Replies</CardTitle>
             </div>
-            <Switch
-              checked={settings?.comments ?? true}
-              onCheckedChange={() => handleToggle('comments')}
-              disabled={isUpdating}
-            />
-          </div>
+            <CardDescription>
+              Control notification preferences when other users comment on assets you collaborate on
+              or mention you.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="divide-y divide-slate-100 dark:divide-slate-800 p-0">
+            {/* General Comments */}
+            <div className="flex items-center justify-between p-6">
+              <div className="flex gap-4">
+                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400">
+                  <MessageSquare className="w-4 h-4" />
+                </div>
+                <div className="space-y-0.5">
+                  <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
+                    General Comments
+                  </h4>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    When someone comments on an asset
+                  </p>
+                </div>
+              </div>
+              <Switch
+                checked={settings?.comments ?? true}
+                onCheckedChange={() => handleToggle('comments')}
+                disabled={isUpdating}
+              />
+            </div>
 
-          {/* Comment Replies */}
-          <div className="flex items-center justify-between p-6">
-            <div className="flex gap-4">
-              <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-purple-50 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400">
-                <MessageCircle className="w-4 h-4" />
+            {/* Comment Replies */}
+            <div className="flex items-center justify-between p-6">
+              <div className="flex gap-4">
+                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-purple-50 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400">
+                  <MessageCircle className="w-4 h-4" />
+                </div>
+                <div className="space-y-0.5">
+                  <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
+                    Comment Replies
+                  </h4>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    When someone replies to your comment
+                  </p>
+                </div>
               </div>
-              <div className="space-y-0.5">
-                <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
-                  Comment Replies
-                </h4>
-                <p className="text-sm text-slate-500 dark:text-slate-400">
-                  When someone replies to your comment
-                </p>
-              </div>
+              <Switch
+                checked={settings?.replies ?? true}
+                onCheckedChange={() => handleToggle('replies')}
+                disabled={isUpdating}
+              />
             </div>
-            <Switch
-              checked={settings?.replies ?? true}
-              onCheckedChange={() => handleToggle('replies')}
-              disabled={isUpdating}
-            />
-          </div>
 
-          {/* Mentions */}
-          <div className="flex items-center justify-between p-6">
-            <div className="flex gap-4">
-              <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-pink-50 dark:bg-pink-900/20 text-pink-600 dark:text-pink-400">
-                <AtSign className="w-4 h-4" />
+            {/* Mentions */}
+            <div className="flex items-center justify-between p-6">
+              <div className="flex gap-4">
+                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-pink-50 dark:bg-pink-900/20 text-pink-600 dark:text-pink-400">
+                  <AtSign className="w-4 h-4" />
+                </div>
+                <div className="space-y-0.5">
+                  <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
+                    @Mentions
+                  </h4>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    When someone @mentions you in a comment
+                  </p>
+                </div>
               </div>
-              <div className="space-y-0.5">
-                <h4 className="text-sm font-semibold text-slate-900 dark:text-white">@Mentions</h4>
-                <p className="text-sm text-slate-500 dark:text-slate-400">
-                  When someone @mentions you in a comment
-                </p>
-              </div>
+              <Switch
+                checked={settings?.mentions ?? true}
+                onCheckedChange={() => handleToggle('mentions')}
+                disabled={isUpdating}
+              />
             </div>
-            <Switch
-              checked={settings?.mentions ?? true}
-              onCheckedChange={() => handleToggle('mentions')}
-              disabled={isUpdating}
-            />
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
 
-      {/* Assets Settings */}
-      <Card className="border border-slate-200 dark:border-slate-800">
-        <CardHeader className="border-b border-slate-100 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/50">
-          <div className="flex items-center gap-2">
-            <UploadCloud className="w-5 h-5 text-emerald-500" />
-            <CardTitle className="text-lg">Assets & Statuses</CardTitle>
-          </div>
-          <CardDescription>
-            Manage notifications related to file uploads and metadata field status updates.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="divide-y divide-slate-100 dark:divide-slate-800 p-0">
-          {/* Your Uploads */}
-          <div className="flex items-center justify-between p-6">
-            <div className="flex gap-4">
-              <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400">
-                <Bell className="w-4 h-4" />
-              </div>
-              <div className="space-y-0.5">
-                <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
-                  Your Uploads
-                </h4>
-                <p className="text-sm text-slate-500 dark:text-slate-400">When you upload assets</p>
-              </div>
+        {/* Assets Settings */}
+        <Card className="border border-slate-200 dark:border-slate-800">
+          <CardHeader className="border-b border-slate-100 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/50">
+            <div className="flex items-center gap-2">
+              <UploadCloud className="w-5 h-5 text-emerald-500" />
+              <CardTitle className="text-lg">Assets & Statuses</CardTitle>
             </div>
-            <Switch
-              checked={settings?.yourUploads ?? false}
-              onCheckedChange={() => handleToggle('yourUploads')}
-              disabled={isUpdating}
-            />
-          </div>
+            <CardDescription>
+              Manage notifications related to file uploads and metadata field status updates.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="divide-y divide-slate-100 dark:divide-slate-800 p-0">
+            {/* Your Uploads */}
+            <div className="flex items-center justify-between p-6">
+              <div className="flex gap-4">
+                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400">
+                  <Bell className="w-4 h-4" />
+                </div>
+                <div className="space-y-0.5">
+                  <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
+                    Your Uploads
+                  </h4>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    When you upload assets
+                  </p>
+                </div>
+              </div>
+              <Switch
+                checked={settings?.yourUploads ?? false}
+                onCheckedChange={() => handleToggle('yourUploads')}
+                disabled={isUpdating}
+              />
+            </div>
 
-          {/* Other Uploads */}
-          <div className="flex items-center justify-between p-6">
-            <div className="flex gap-4">
-              <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 dark:text-emerald-400">
-                <UploadCloud className="w-4 h-4" />
+            {/* Other Uploads */}
+            <div className="flex items-center justify-between p-6">
+              <div className="flex gap-4">
+                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 dark:text-emerald-400">
+                  <UploadCloud className="w-4 h-4" />
+                </div>
+                <div className="space-y-0.5">
+                  <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
+                    Other Uploads
+                  </h4>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    When other users upload assets
+                  </p>
+                </div>
               </div>
-              <div className="space-y-0.5">
-                <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
-                  Other Uploads
-                </h4>
-                <p className="text-sm text-slate-500 dark:text-slate-400">
-                  When other users upload assets
-                </p>
-              </div>
+              <Switch
+                checked={settings?.otherUploads ?? true}
+                onCheckedChange={() => handleToggle('otherUploads')}
+                disabled={isUpdating}
+              />
             </div>
-            <Switch
-              checked={settings?.otherUploads ?? true}
-              onCheckedChange={() => handleToggle('otherUploads')}
-              disabled={isUpdating}
-            />
-          </div>
 
-          {/* Status Updates */}
-          <div className="flex items-center justify-between p-6">
-            <div className="flex gap-4">
-              <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-amber-50 dark:bg-amber-900/20 text-amber-600 dark:text-amber-400">
-                <Activity className="w-4 h-4" />
+            {/* Status Updates */}
+            <div className="flex items-center justify-between p-6">
+              <div className="flex gap-4">
+                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-amber-50 dark:bg-amber-900/20 text-amber-600 dark:text-amber-400">
+                  <Activity className="w-4 h-4" />
+                </div>
+                <div className="space-y-0.5">
+                  <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
+                    Status Updates
+                  </h4>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    When someone changes an asset’s status
+                  </p>
+                </div>
               </div>
-              <div className="space-y-0.5">
-                <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
-                  Status Updates
-                </h4>
-                <p className="text-sm text-slate-500 dark:text-slate-400">
-                  When someone changes an asset’s status
-                </p>
-              </div>
+              <Switch
+                checked={settings?.statusUpdates ?? true}
+                onCheckedChange={() => handleToggle('statusUpdates')}
+                disabled={isUpdating}
+              />
             </div>
-            <Switch
-              checked={settings?.statusUpdates ?? true}
-              onCheckedChange={() => handleToggle('statusUpdates')}
-              disabled={isUpdating}
-            />
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+          </CardContent>
+        </Card>
+      </div>
+    </ScrollArea>
   )
 }

--- a/packages/webui/components/settings/ProvidersSettings.tsx
+++ b/packages/webui/components/settings/ProvidersSettings.tsx
@@ -1,40 +1,41 @@
 import { client } from '@/ui/api/client'
+import { ScrollArea } from '@/ui/components/ui/scroll-area'
 import {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
 } from '@/ui/components/ui/alert-dialog'
 import { Badge } from '@/ui/components/ui/badge'
 import { Button } from '@/ui/components/ui/button'
 import { Card, CardContent } from '@/ui/components/ui/card'
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
 } from '@/ui/components/ui/dialog'
 import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
 } from '@/ui/components/ui/dropdown-menu'
 import { Field, FieldDescription, FieldError, FieldLabel } from '@/ui/components/ui/field'
 import { Input } from '@/ui/components/ui/input'
 import { Label } from '@/ui/components/ui/label'
 import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from '@/ui/components/ui/select'
 import { Switch } from '@/ui/components/ui/switch'
 import { providerConfigSchema, providerModelSchema } from '@shumai/dtos'
@@ -42,18 +43,18 @@ import { useForm } from '@tanstack/react-form'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { InferResponseType } from 'hono/client'
 import {
-    ChevronRight,
-    Cpu,
-    DollarSign,
-    Globe,
-    Info,
-    Loader2,
-    Maximize2,
-    MoreVertical,
-    Plus,
-    Search,
-    Trash2,
-    Zap,
+  ChevronRight,
+  Cpu,
+  DollarSign,
+  Globe,
+  Info,
+  Loader2,
+  Maximize2,
+  MoreVertical,
+  Plus,
+  Search,
+  Trash2,
+  Zap,
 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
@@ -227,8 +228,8 @@ export function ProvidersSettings({ teamId }: ProvidersSettingsProps) {
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto pr-2 min-h-0 overflow-x-hidden">
-        <div className="grid grid-cols-1 gap-4 py-2">
+      <ScrollArea className="flex-1 min-h-0">
+        <div className="pr-4 py-2 grid grid-cols-1 gap-4">
           {filteredProviders.map((provider) => (
             <Card
               key={provider.id}
@@ -337,7 +338,7 @@ export function ProvidersSettings({ teamId }: ProvidersSettingsProps) {
             </div>
           )}
         </div>
-      </div>
+      </ScrollArea>
 
       <ProviderFormDialog
         isOpen={isCreateDialogOpen}
@@ -505,386 +506,390 @@ function ProviderFormDialog({
           }}
           className="flex flex-col flex-1 overflow-hidden"
         >
-          <div className="flex-1 overflow-y-auto p-6 pt-2 space-y-8">
-            {/* Row 1: Basic Config */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 p-6 rounded-2xl border">
-              <form.Field
-                name="name"
-                children={(field) => {
-                  const isInvalid = !!field.state.meta.errors.length && field.state.meta.isTouched
-                  return (
-                    <Field data-invalid={isInvalid}>
-                      <FieldLabel htmlFor={field.name}>Provider Name</FieldLabel>
-                      <Input
-                        id={field.name}
-                        name={field.name}
-                        value={field.state.value}
-                        onBlur={field.handleBlur}
-                        onChange={(e) => field.handleChange(e.target.value)}
-                        placeholder="e.g., My OpenAI"
-                        disabled={isBuiltin}
-                        aria-invalid={isInvalid}
-                      />
-                      {isInvalid && <FieldError errors={mapErrors(field.state.meta.errors)} />}
-                    </Field>
-                  )
-                }}
-              />
-
-              <form.Field
-                name="config.api"
-                children={(field) => {
-                  const isInvalid = !!field.state.meta.errors.length && field.state.meta.isTouched
-                  return (
-                    <Field data-invalid={isInvalid}>
-                      <FieldLabel htmlFor={field.name}>Global API Protocol</FieldLabel>
-                      <Select
-                        onValueChange={field.handleChange}
-                        value={field.state.value}
-                        disabled={isBuiltin}
-                      >
-                        <SelectTrigger id={field.name} aria-invalid={isInvalid}>
-                          <SelectValue placeholder="Select API Protocol" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="openai-completions">OpenAI Completions</SelectItem>
-                          <SelectItem value="anthropic-messages">Anthropic Messages</SelectItem>
-                          <SelectItem value="google-genai">Google GenAI</SelectItem>
-                          <SelectItem value="bedrock-converse-stream">AWS Bedrock</SelectItem>
-                        </SelectContent>
-                      </Select>
-                      {isInvalid && <FieldError errors={mapErrors(field.state.meta.errors)} />}
-                    </Field>
-                  )
-                }}
-              />
-
-              <div className="md:col-span-2">
+          <ScrollArea className="flex-1 min-h-0">
+            <div className="p-6 pt-2 space-y-8 pr-4">
+              {/* Row 1: Basic Config */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6 p-6 rounded-2xl border">
                 <form.Field
-                  name="config.baseUrl"
+                  name="name"
                   children={(field) => {
                     const isInvalid = !!field.state.meta.errors.length && field.state.meta.isTouched
                     return (
                       <Field data-invalid={isInvalid}>
-                        <FieldLabel htmlFor={field.name}>Base URL (Optional)</FieldLabel>
+                        <FieldLabel htmlFor={field.name}>Provider Name</FieldLabel>
                         <Input
                           id={field.name}
                           name={field.name}
-                          value={field.state.value || ''}
+                          value={field.state.value}
                           onBlur={field.handleBlur}
                           onChange={(e) => field.handleChange(e.target.value)}
-                          placeholder="https://api.openai.com/v1"
+                          placeholder="e.g., My OpenAI"
+                          disabled={isBuiltin}
                           aria-invalid={isInvalid}
                         />
-                        <FieldDescription>Override the default endpoint.</FieldDescription>
                         {isInvalid && <FieldError errors={mapErrors(field.state.meta.errors)} />}
                       </Field>
                     )
                   }}
+                />
+
+                <form.Field
+                  name="config.api"
+                  children={(field) => {
+                    const isInvalid = !!field.state.meta.errors.length && field.state.meta.isTouched
+                    return (
+                      <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor={field.name}>Global API Protocol</FieldLabel>
+                        <Select
+                          onValueChange={field.handleChange}
+                          value={field.state.value}
+                          disabled={isBuiltin}
+                        >
+                          <SelectTrigger id={field.name} aria-invalid={isInvalid}>
+                            <SelectValue placeholder="Select API Protocol" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="openai-completions">OpenAI Completions</SelectItem>
+                            <SelectItem value="anthropic-messages">Anthropic Messages</SelectItem>
+                            <SelectItem value="google-genai">Google GenAI</SelectItem>
+                            <SelectItem value="bedrock-converse-stream">AWS Bedrock</SelectItem>
+                          </SelectContent>
+                        </Select>
+                        {isInvalid && <FieldError errors={mapErrors(field.state.meta.errors)} />}
+                      </Field>
+                    )
+                  }}
+                />
+
+                <div className="md:col-span-2">
+                  <form.Field
+                    name="config.baseUrl"
+                    children={(field) => {
+                      const isInvalid =
+                        !!field.state.meta.errors.length && field.state.meta.isTouched
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor={field.name}>Base URL (Optional)</FieldLabel>
+                          <Input
+                            id={field.name}
+                            name={field.name}
+                            value={field.state.value || ''}
+                            onBlur={field.handleBlur}
+                            onChange={(e) => field.handleChange(e.target.value)}
+                            placeholder="https://api.openai.com/v1"
+                            aria-invalid={isInvalid}
+                          />
+                          <FieldDescription>Override the default endpoint.</FieldDescription>
+                          {isInvalid && <FieldError errors={mapErrors(field.state.meta.errors)} />}
+                        </Field>
+                      )
+                    }}
+                  />
+                </div>
+              </div>
+
+              {/* Row 2: API Key Card */}
+              <Card className="rounded-2xl border bg-transparent">
+                <CardContent className="p-6 pt-2">
+                  <form.Field
+                    name="config.apiKey"
+                    children={(field) => {
+                      const isInvalid =
+                        !!field.state.meta.errors.length && field.state.meta.isTouched
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor={field.name} className="text-base font-semibold">
+                            API Key
+                          </FieldLabel>
+                          <Input
+                            id={field.name}
+                            name={field.name}
+                            type="text"
+                            value={field.state.value || ''}
+                            onBlur={field.handleBlur}
+                            onChange={(e) => field.handleChange(e.target.value)}
+                            placeholder="Enter API Key or Environment Variable"
+                            aria-invalid={isInvalid}
+                          />
+                          <FieldDescription className="text-xs mt-2">
+                            You can provide a literal value (e.g.{' '}
+                            <code className="bg-muted px-1 rounded text-primary">sk-...</code>) or
+                            an Environment variable name (e.g.{' '}
+                            <code className="bg-muted px-1 rounded text-primary">MY_API_KEY</code>
+                            ).
+                          </FieldDescription>
+                          {isInvalid && <FieldError errors={mapErrors(field.state.meta.errors)} />}
+                        </Field>
+                      )
+                    }}
+                  />
+                </CardContent>
+              </Card>
+
+              {/* Models Section */}
+              <div className="space-y-4">
+                <form.Field
+                  name="models"
+                  mode="array"
+                  children={(modelsField) => (
+                    <div className="space-y-4">
+                      <div className="flex items-center justify-between">
+                        <Label className="text-lg font-bold">Models Configuration</Label>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() =>
+                            modelsField.pushValue({
+                              modelId: '',
+                              name: '',
+                              config: {
+                                api: form.getFieldValue('config.api'),
+                                reasoning: false,
+                                input: ['text'],
+                                contextWindow: 128000,
+                                maxTokens: 4096,
+                                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                              },
+                            })
+                          }
+                          className="gap-2"
+                        >
+                          <Plus className="w-4 h-4" />
+                          Add Model
+                        </Button>
+                      </div>
+
+                      <div className="space-y-6">
+                        {modelsField.state.value.map((_, index) => (
+                          <div
+                            key={index}
+                            className="group relative p-6 bg-transparent rounded-2xl border shadow-sm animate-in fade-in zoom-in-95 duration-300"
+                          >
+                            {/* Row 1: ID and Name */}
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                              <form.Field
+                                name={`models[${index}].modelId`}
+                                children={(field) => {
+                                  const isInvalid =
+                                    !!field.state.meta.errors.length && field.state.meta.isTouched
+                                  return (
+                                    <Field data-invalid={isInvalid}>
+                                      <FieldLabel htmlFor={field.name}>Model ID</FieldLabel>
+                                      <Input
+                                        id={field.name}
+                                        name={field.name}
+                                        value={field.state.value}
+                                        onBlur={field.handleBlur}
+                                        onChange={(e) => field.handleChange(e.target.value)}
+                                        placeholder="gpt-4o"
+                                        aria-invalid={isInvalid}
+                                      />
+                                      {isInvalid && (
+                                        <FieldError errors={mapErrors(field.state.meta.errors)} />
+                                      )}
+                                    </Field>
+                                  )
+                                }}
+                              />
+                              <form.Field
+                                name={`models[${index}].name`}
+                                children={(field) => {
+                                  const isInvalid =
+                                    !!field.state.meta.errors.length && field.state.meta.isTouched
+                                  return (
+                                    <Field data-invalid={isInvalid}>
+                                      <FieldLabel htmlFor={field.name}>
+                                        Display Name (Optional)
+                                      </FieldLabel>
+                                      <Input
+                                        id={field.name}
+                                        name={field.name}
+                                        value={field.state.value}
+                                        onBlur={field.handleBlur}
+                                        onChange={(e) => field.handleChange(e.target.value)}
+                                        placeholder="e.g., GPT-4o"
+                                        aria-invalid={isInvalid}
+                                        disabled={isBuiltin}
+                                      />
+                                      {isInvalid && (
+                                        <FieldError errors={mapErrors(field.state.meta.errors)} />
+                                      )}
+                                    </Field>
+                                  )
+                                }}
+                              />
+                            </div>
+
+                            {/* Row 2: Reasoning and Context Window */}
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
+                              <form.Field
+                                name={`models[${index}].config.reasoning`}
+                                children={(field) => (
+                                  <Field
+                                    orientation="horizontal"
+                                    className="rounded-lg border border-border p-3 shadow-sm bg-muted/50 justify-between"
+                                  >
+                                    <FieldLabel htmlFor={field.name}>Reasoning Support</FieldLabel>
+                                    <Switch
+                                      id={field.name}
+                                      checked={field.state.value}
+                                      onCheckedChange={field.handleChange}
+                                      disabled={isBuiltin}
+                                    />
+                                  </Field>
+                                )}
+                              />
+                              <form.Field
+                                name={`models[${index}].config.contextWindow`}
+                                children={(field) => {
+                                  const isInvalid =
+                                    !!field.state.meta.errors.length && field.state.meta.isTouched
+                                  return (
+                                    <Field data-invalid={isInvalid}>
+                                      <FieldLabel htmlFor={field.name} className="text-xs">
+                                        Context Window (tokens)
+                                      </FieldLabel>
+                                      <Input
+                                        id={field.name}
+                                        name={field.name}
+                                        type="number"
+                                        value={field.state.value}
+                                        onBlur={field.handleBlur}
+                                        onChange={(e) =>
+                                          field.handleChange(parseInt(e.target.value) || 0)
+                                        }
+                                        aria-invalid={isInvalid}
+                                        disabled={isBuiltin}
+                                      />
+                                      {isInvalid && (
+                                        <FieldError errors={mapErrors(field.state.meta.errors)} />
+                                      )}
+                                    </Field>
+                                  )
+                                }}
+                              />
+                            </div>
+
+                            {/* Row 3: Constraints and Cost */}
+                            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
+                              <form.Field
+                                name={`models[${index}].config.maxTokens`}
+                                children={(field) => {
+                                  const isInvalid =
+                                    !!field.state.meta.errors.length && field.state.meta.isTouched
+                                  return (
+                                    <Field data-invalid={isInvalid}>
+                                      <FieldLabel htmlFor={field.name} className="text-xs">
+                                        Max Output Tokens
+                                      </FieldLabel>
+                                      <Input
+                                        id={field.name}
+                                        name={field.name}
+                                        type="number"
+                                        value={field.state.value}
+                                        onBlur={field.handleBlur}
+                                        onChange={(e) =>
+                                          field.handleChange(parseInt(e.target.value) || 0)
+                                        }
+                                        aria-invalid={isInvalid}
+                                        disabled={isBuiltin}
+                                      />
+                                      {isInvalid && (
+                                        <FieldError errors={mapErrors(field.state.meta.errors)} />
+                                      )}
+                                    </Field>
+                                  )
+                                }}
+                              />
+                              <form.Field
+                                name={`models[${index}].config.cost.input`}
+                                children={(field) => {
+                                  const isInvalid =
+                                    !!field.state.meta.errors.length && field.state.meta.isTouched
+                                  return (
+                                    <Field data-invalid={isInvalid}>
+                                      <FieldLabel
+                                        htmlFor={field.name}
+                                        className="text-xs flex items-center gap-1"
+                                      >
+                                        <DollarSign className="w-3 h-3" /> Input Cost (1M)
+                                      </FieldLabel>
+                                      <Input
+                                        id={field.name}
+                                        name={field.name}
+                                        type="number"
+                                        step="0.01"
+                                        value={field.state.value}
+                                        onBlur={field.handleBlur}
+                                        onChange={(e) =>
+                                          field.handleChange(parseFloat(e.target.value) || 0)
+                                        }
+                                        aria-invalid={isInvalid}
+                                        disabled={isBuiltin}
+                                      />
+                                      {isInvalid && (
+                                        <FieldError errors={mapErrors(field.state.meta.errors)} />
+                                      )}
+                                    </Field>
+                                  )
+                                }}
+                              />
+                              <form.Field
+                                name={`models[${index}].config.cost.output`}
+                                children={(field) => {
+                                  const isInvalid =
+                                    !!field.state.meta.errors.length && field.state.meta.isTouched
+                                  return (
+                                    <Field data-invalid={isInvalid}>
+                                      <FieldLabel
+                                        htmlFor={field.name}
+                                        className="text-xs flex items-center gap-1"
+                                      >
+                                        <DollarSign className="w-3 h-3" /> Output Cost (1M)
+                                      </FieldLabel>
+                                      <Input
+                                        id={field.name}
+                                        name={field.name}
+                                        type="number"
+                                        step="0.01"
+                                        value={field.state.value}
+                                        onBlur={field.handleBlur}
+                                        onChange={(e) =>
+                                          field.handleChange(parseFloat(e.target.value) || 0)
+                                        }
+                                        aria-invalid={isInvalid}
+                                        disabled={isBuiltin}
+                                      />
+                                      {isInvalid && (
+                                        <FieldError errors={mapErrors(field.state.meta.errors)} />
+                                      )}
+                                    </Field>
+                                  )
+                                }}
+                              />
+                            </div>
+
+                            {!isBuiltin && (
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                className="absolute -top-2 -right-2 h-8 w-8 rounded-full bg-background border border-border text-muted-foreground hover:text-destructive transition-colors shadow-sm"
+                                onClick={() => modelsField.removeValue(index)}
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
                 />
               </div>
             </div>
-
-            {/* Row 2: API Key Card */}
-            <Card className="rounded-2xl border bg-transparent">
-              <CardContent className="p-6 pt-2">
-                <form.Field
-                  name="config.apiKey"
-                  children={(field) => {
-                    const isInvalid = !!field.state.meta.errors.length && field.state.meta.isTouched
-                    return (
-                      <Field data-invalid={isInvalid}>
-                        <FieldLabel htmlFor={field.name} className="text-base font-semibold">
-                          API Key
-                        </FieldLabel>
-                        <Input
-                          id={field.name}
-                          name={field.name}
-                          type="text"
-                          value={field.state.value || ''}
-                          onBlur={field.handleBlur}
-                          onChange={(e) => field.handleChange(e.target.value)}
-                          placeholder="Enter API Key or Environment Variable"
-                          aria-invalid={isInvalid}
-                        />
-                        <FieldDescription className="text-xs mt-2">
-                          You can provide a literal value (e.g.{' '}
-                          <code className="bg-muted px-1 rounded text-primary">sk-...</code>) or an
-                          Environment variable name (e.g.{' '}
-                          <code className="bg-muted px-1 rounded text-primary">MY_API_KEY</code>
-                          ).
-                        </FieldDescription>
-                        {isInvalid && <FieldError errors={mapErrors(field.state.meta.errors)} />}
-                      </Field>
-                    )
-                  }}
-                />
-              </CardContent>
-            </Card>
-
-            {/* Models Section */}
-            <div className="space-y-4">
-              <form.Field
-                name="models"
-                mode="array"
-                children={(modelsField) => (
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <Label className="text-lg font-bold">Models Configuration</Label>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() =>
-                          modelsField.pushValue({
-                            modelId: '',
-                            name: '',
-                            config: {
-                              api: form.getFieldValue('config.api'),
-                              reasoning: false,
-                              input: ['text'],
-                              contextWindow: 128000,
-                              maxTokens: 4096,
-                              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                            },
-                          })
-                        }
-                        className="gap-2"
-                      >
-                        <Plus className="w-4 h-4" />
-                        Add Model
-                      </Button>
-                    </div>
-
-                    <div className="space-y-6">
-                      {modelsField.state.value.map((_, index) => (
-                        <div
-                          key={index}
-                          className="group relative p-6 bg-transparent rounded-2xl border shadow-sm animate-in fade-in zoom-in-95 duration-300"
-                        >
-                          {/* Row 1: ID and Name */}
-                          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            <form.Field
-                              name={`models[${index}].modelId`}
-                              children={(field) => {
-                                const isInvalid =
-                                  !!field.state.meta.errors.length && field.state.meta.isTouched
-                                return (
-                                  <Field data-invalid={isInvalid}>
-                                    <FieldLabel htmlFor={field.name}>Model ID</FieldLabel>
-                                    <Input
-                                      id={field.name}
-                                      name={field.name}
-                                      value={field.state.value}
-                                      onBlur={field.handleBlur}
-                                      onChange={(e) => field.handleChange(e.target.value)}
-                                      placeholder="gpt-4o"
-                                      aria-invalid={isInvalid}
-                                    />
-                                    {isInvalid && (
-                                      <FieldError errors={mapErrors(field.state.meta.errors)} />
-                                    )}
-                                  </Field>
-                                )
-                              }}
-                            />
-                            <form.Field
-                              name={`models[${index}].name`}
-                              children={(field) => {
-                                const isInvalid =
-                                  !!field.state.meta.errors.length && field.state.meta.isTouched
-                                return (
-                                  <Field data-invalid={isInvalid}>
-                                    <FieldLabel htmlFor={field.name}>
-                                      Display Name (Optional)
-                                    </FieldLabel>
-                                    <Input
-                                      id={field.name}
-                                      name={field.name}
-                                      value={field.state.value}
-                                      onBlur={field.handleBlur}
-                                      onChange={(e) => field.handleChange(e.target.value)}
-                                      placeholder="e.g., GPT-4o"
-                                      aria-invalid={isInvalid}
-                                      disabled={isBuiltin}
-                                    />
-                                    {isInvalid && (
-                                      <FieldError errors={mapErrors(field.state.meta.errors)} />
-                                    )}
-                                  </Field>
-                                )
-                              }}
-                            />
-                          </div>
-
-                          {/* Row 2: Reasoning and Context Window */}
-                          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
-                            <form.Field
-                              name={`models[${index}].config.reasoning`}
-                              children={(field) => (
-                                <Field
-                                  orientation="horizontal"
-                                  className="rounded-lg border border-border p-3 shadow-sm bg-muted/50 justify-between"
-                                >
-                                  <FieldLabel htmlFor={field.name}>Reasoning Support</FieldLabel>
-                                  <Switch
-                                    id={field.name}
-                                    checked={field.state.value}
-                                    onCheckedChange={field.handleChange}
-                                    disabled={isBuiltin}
-                                  />
-                                </Field>
-                              )}
-                            />
-                            <form.Field
-                              name={`models[${index}].config.contextWindow`}
-                              children={(field) => {
-                                const isInvalid =
-                                  !!field.state.meta.errors.length && field.state.meta.isTouched
-                                return (
-                                  <Field data-invalid={isInvalid}>
-                                    <FieldLabel htmlFor={field.name} className="text-xs">
-                                      Context Window (tokens)
-                                    </FieldLabel>
-                                    <Input
-                                      id={field.name}
-                                      name={field.name}
-                                      type="number"
-                                      value={field.state.value}
-                                      onBlur={field.handleBlur}
-                                      onChange={(e) =>
-                                        field.handleChange(parseInt(e.target.value) || 0)
-                                      }
-                                      aria-invalid={isInvalid}
-                                      disabled={isBuiltin}
-                                    />
-                                    {isInvalid && (
-                                      <FieldError errors={mapErrors(field.state.meta.errors)} />
-                                    )}
-                                  </Field>
-                                )
-                              }}
-                            />
-                          </div>
-
-                          {/* Row 3: Constraints and Cost */}
-                          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
-                            <form.Field
-                              name={`models[${index}].config.maxTokens`}
-                              children={(field) => {
-                                const isInvalid =
-                                  !!field.state.meta.errors.length && field.state.meta.isTouched
-                                return (
-                                  <Field data-invalid={isInvalid}>
-                                    <FieldLabel htmlFor={field.name} className="text-xs">
-                                      Max Output Tokens
-                                    </FieldLabel>
-                                    <Input
-                                      id={field.name}
-                                      name={field.name}
-                                      type="number"
-                                      value={field.state.value}
-                                      onBlur={field.handleBlur}
-                                      onChange={(e) =>
-                                        field.handleChange(parseInt(e.target.value) || 0)
-                                      }
-                                      aria-invalid={isInvalid}
-                                      disabled={isBuiltin}
-                                    />
-                                    {isInvalid && (
-                                      <FieldError errors={mapErrors(field.state.meta.errors)} />
-                                    )}
-                                  </Field>
-                                )
-                              }}
-                            />
-                            <form.Field
-                              name={`models[${index}].config.cost.input`}
-                              children={(field) => {
-                                const isInvalid =
-                                  !!field.state.meta.errors.length && field.state.meta.isTouched
-                                return (
-                                  <Field data-invalid={isInvalid}>
-                                    <FieldLabel
-                                      htmlFor={field.name}
-                                      className="text-xs flex items-center gap-1"
-                                    >
-                                      <DollarSign className="w-3 h-3" /> Input Cost (1M)
-                                    </FieldLabel>
-                                    <Input
-                                      id={field.name}
-                                      name={field.name}
-                                      type="number"
-                                      step="0.01"
-                                      value={field.state.value}
-                                      onBlur={field.handleBlur}
-                                      onChange={(e) =>
-                                        field.handleChange(parseFloat(e.target.value) || 0)
-                                      }
-                                      aria-invalid={isInvalid}
-                                      disabled={isBuiltin}
-                                    />
-                                    {isInvalid && (
-                                      <FieldError errors={mapErrors(field.state.meta.errors)} />
-                                    )}
-                                  </Field>
-                                )
-                              }}
-                            />
-                            <form.Field
-                              name={`models[${index}].config.cost.output`}
-                              children={(field) => {
-                                const isInvalid =
-                                  !!field.state.meta.errors.length && field.state.meta.isTouched
-                                return (
-                                  <Field data-invalid={isInvalid}>
-                                    <FieldLabel
-                                      htmlFor={field.name}
-                                      className="text-xs flex items-center gap-1"
-                                    >
-                                      <DollarSign className="w-3 h-3" /> Output Cost (1M)
-                                    </FieldLabel>
-                                    <Input
-                                      id={field.name}
-                                      name={field.name}
-                                      type="number"
-                                      step="0.01"
-                                      value={field.state.value}
-                                      onBlur={field.handleBlur}
-                                      onChange={(e) =>
-                                        field.handleChange(parseFloat(e.target.value) || 0)
-                                      }
-                                      aria-invalid={isInvalid}
-                                      disabled={isBuiltin}
-                                    />
-                                    {isInvalid && (
-                                      <FieldError errors={mapErrors(field.state.meta.errors)} />
-                                    )}
-                                  </Field>
-                                )
-                              }}
-                            />
-                          </div>
-
-                          {!isBuiltin && (
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon"
-                              className="absolute -top-2 -right-2 h-8 w-8 rounded-full bg-background border border-border text-muted-foreground hover:text-destructive transition-colors shadow-sm"
-                              onClick={() => modelsField.removeValue(index)}
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </Button>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              />
-            </div>
-          </div>
+          </ScrollArea>
 
           <DialogFooter className="p-6 pt-4 border-t border-border gap-2">
             <Button type="button" variant="outline" onClick={onClose} disabled={isLoading}>

--- a/packages/webui/components/settings/SandboxSettings.tsx
+++ b/packages/webui/components/settings/SandboxSettings.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { client } from '@/ui/api/client'
+import { ScrollArea } from '@/ui/components/ui/scroll-area'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/components/ui/card'
 import { Input } from '@/ui/components/ui/input'
 import { Button } from '@/ui/components/ui/button'
@@ -79,129 +80,133 @@ export function SandboxSettings({ teamId }: { teamId: string }) {
   }
 
   return (
-    <div className="h-full overflow-y-auto space-y-6 pr-1">
-      <Card>
-        <CardHeader>
-          <div className="flex items-center gap-2">
-            <Globe className="w-5 h-5 text-primary" />
-            <CardTitle>Network Sandbox</CardTitle>
-          </div>
-          <CardDescription>
-            Configure allowed domains for the sandboxed agent. By default, only essential domains
-            are allowed.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleAddDomain} className="flex gap-2 mb-6">
-            <Input
-              placeholder="e.g. api.openai.com"
-              value={newDomain}
-              onChange={(e) => setNewDomain(e.target.value)}
-              disabled={isUpdating}
-            />
-            <Button type="submit" disabled={isUpdating}>
-              {isUpdating ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
-              ) : (
-                <Plus className="w-4 h-4 mr-2" />
-              )}
-              Add Domain
-            </Button>
-          </form>
-
-          <div className="space-y-2">
-            <h4 className="text-sm font-medium text-muted-foreground mb-3">Allowed Domains</h4>
-            <div className="flex flex-wrap gap-2">
-              {sandbox?.allowedDomains.map((domain) => (
-                <div
-                  key={domain}
-                  className="flex items-center gap-1 px-3 py-1.5 bg-muted rounded-full text-sm border border-border transition-all hover:border-muted-foreground/50"
-                >
-                  <span className="font-medium text-foreground">{domain}</span>
-                  <button
-                    onClick={() => handleRemoveDomain(domain)}
-                    className="ml-1 text-muted-foreground hover:text-destructive transition-colors"
-                    disabled={isUpdating}
-                  >
-                    <X className="w-3.5 h-3.5" />
-                  </button>
-                </div>
-              ))}
-              {sandbox?.allowedDomains.length === 0 && (
-                <div className="text-sm text-muted-foreground italic">No custom domains allowed</div>
-              )}
+    <ScrollArea className="h-full">
+      <div className="space-y-6 pr-4 pb-8">
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Globe className="w-5 h-5 text-primary" />
+              <CardTitle>Network Sandbox</CardTitle>
             </div>
-          </div>
-        </CardContent>
-      </Card>
+            <CardDescription>
+              Configure allowed domains for the sandboxed agent. By default, only essential domains
+              are allowed.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleAddDomain} className="flex gap-2 mb-6">
+              <Input
+                placeholder="e.g. api.openai.com"
+                value={newDomain}
+                onChange={(e) => setNewDomain(e.target.value)}
+                disabled={isUpdating}
+              />
+              <Button type="submit" disabled={isUpdating}>
+                {isUpdating ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Plus className="w-4 h-4 mr-2" />
+                )}
+                Add Domain
+              </Button>
+            </form>
 
-      {/* Pending Domains Section */}
-      <Card className="border-orange-500/20 bg-orange-500/5">
-        <CardHeader>
-          <div className="flex items-center gap-2">
-            <ShieldAlert className="w-5 h-5 text-orange-500" />
-            <CardTitle>Pending Domain Approvals</CardTitle>
-          </div>
-          <CardDescription>
-            These domains were blocked during agent execution. You can approve them to allow future
-            network requests, or delete them from this list.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {sandbox?.pendingDomains && sandbox.pendingDomains.length > 0 ? (
-              <div className="divide-y divide-border">
-                {sandbox.pendingDomains.map((domain) => (
+            <div className="space-y-2">
+              <h4 className="text-sm font-medium text-muted-foreground mb-3">Allowed Domains</h4>
+              <div className="flex flex-wrap gap-2">
+                {sandbox?.allowedDomains.map((domain) => (
                   <div
                     key={domain}
-                    className="flex items-center justify-between py-2.5 first:pt-0 last:pb-0"
+                    className="flex items-center gap-1 px-3 py-1.5 bg-muted rounded-full text-sm border border-border transition-all hover:border-muted-foreground/50"
                   >
-                    <span className="font-mono text-sm text-foreground bg-muted px-2 py-1 rounded break-all">
-                      {domain}
-                    </span>
-                    <div className="flex items-center gap-2">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        className="h-8 border-emerald-500/20 text-emerald-600 hover:bg-emerald-500/10 hover:text-emerald-600 dark:text-emerald-400 dark:hover:bg-emerald-500/20"
-                        onClick={() => handleApproveDomain(domain)}
-                        disabled={isUpdating}
-                      >
-                        <Check className="w-4 h-4 mr-1.5" />
-                        Approve
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        className="h-8 border-destructive/20 text-destructive hover:bg-destructive/10"
-                        onClick={() => handleDeletePendingDomain(domain)}
-                        disabled={isUpdating}
-                      >
-                        <Trash2 className="w-4 h-4 mr-1.5" />
-                        Delete
-                      </Button>
-                    </div>
+                    <span className="font-medium text-foreground">{domain}</span>
+                    <button
+                      onClick={() => handleRemoveDomain(domain)}
+                      className="ml-1 text-muted-foreground hover:text-destructive transition-colors"
+                      disabled={isUpdating}
+                    >
+                      <X className="w-3.5 h-3.5" />
+                    </button>
                   </div>
                 ))}
+                {sandbox?.allowedDomains.length === 0 && (
+                  <div className="text-sm text-muted-foreground italic">
+                    No custom domains allowed
+                  </div>
+                )}
               </div>
-            ) : (
-              <div className="text-sm text-muted-foreground italic py-2">
-                No pending domains requiring approval
-              </div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+            </div>
+          </CardContent>
+        </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Filesystem Restriction</CardTitle>
-          <CardDescription>
-            The agent is restricted to reading and writing only within the <code>.pi</code> and{' '}
-            <code>/tmp</code> folders. These settings are currently hardcoded for security.
-          </CardDescription>
-        </CardHeader>
-      </Card>
-    </div>
+        {/* Pending Domains Section */}
+        <Card className="border-orange-500/20 bg-orange-500/5">
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <ShieldAlert className="w-5 h-5 text-orange-500" />
+              <CardTitle>Pending Domain Approvals</CardTitle>
+            </div>
+            <CardDescription>
+              These domains were blocked during agent execution. You can approve them to allow
+              future network requests, or delete them from this list.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {sandbox?.pendingDomains && sandbox.pendingDomains.length > 0 ? (
+                <div className="divide-y divide-border">
+                  {sandbox.pendingDomains.map((domain) => (
+                    <div
+                      key={domain}
+                      className="flex items-center justify-between py-2.5 first:pt-0 last:pb-0"
+                    >
+                      <span className="font-mono text-sm text-foreground bg-muted px-2 py-1 rounded break-all">
+                        {domain}
+                      </span>
+                      <div className="flex items-center gap-2">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-8 border-emerald-500/20 text-emerald-600 hover:bg-emerald-500/10 hover:text-emerald-600 dark:text-emerald-400 dark:hover:bg-emerald-500/20"
+                          onClick={() => handleApproveDomain(domain)}
+                          disabled={isUpdating}
+                        >
+                          <Check className="w-4 h-4 mr-1.5" />
+                          Approve
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-8 border-destructive/20 text-destructive hover:bg-destructive/10"
+                          onClick={() => handleDeletePendingDomain(domain)}
+                          disabled={isUpdating}
+                        >
+                          <Trash2 className="w-4 h-4 mr-1.5" />
+                          Delete
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-sm text-muted-foreground italic py-2">
+                  No pending domains requiring approval
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Filesystem Restriction</CardTitle>
+            <CardDescription>
+              The agent is restricted to reading and writing only within the <code>.pi</code> and{' '}
+              <code>/tmp</code> folders. These settings are currently hardcoded for security.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    </ScrollArea>
   )
 }

--- a/packages/webui/components/settings/SkillsConfigCard.tsx
+++ b/packages/webui/components/settings/SkillsConfigCard.tsx
@@ -5,6 +5,7 @@ import React, { useState, useRef } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/components/ui/card'
 import { Button } from '@/ui/components/ui/button'
 import { cn } from '@/ui/lib/utils'
+import { ScrollArea } from '@/ui/components/ui/scroll-area'
 import {
   Dialog,
   DialogContent,
@@ -397,9 +398,7 @@ const AddSkillDialog = ({
                 <Upload className="w-6 h-6 text-muted-foreground group-hover:text-primary" />
               </div>
               <div className="mt-3 text-center">
-                <p className="text-sm font-medium text-foreground">
-                  Select ZIP file
-                </p>
+                <p className="text-sm font-medium text-foreground">Select ZIP file</p>
                 <p className="text-[10px] text-muted-foreground mt-1 uppercase tracking-wider font-semibold">
                   Packages must contain a SKILL.md
                 </p>
@@ -549,56 +548,58 @@ const ConfigSkillDialog = ({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="py-4 space-y-4 max-h-[60vh] overflow-y-auto pr-2 custom-scrollbar">
-          {envVars.length === 0 ? (
-            <div className="text-center py-10 bg-muted/50 rounded-xl border border-dashed border-border">
-              <p className="text-muted-foreground text-sm italic">
-                No environment variables found. Click "Add Variable" to create one.
-              </p>
-            </div>
-          ) : (
-            envVars.map((env: { name: string; default?: string | undefined }, index: number) => (
-              <div
-                key={index}
-                className="p-4 bg-muted/50 rounded-xl border border-border space-y-3 relative group"
-              >
-                <button
-                  onClick={() => removeEnvVar(index)}
-                  className="absolute top-2 right-2 p-1 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-md transition-colors opacity-0 group-hover:opacity-100"
-                >
-                  <X className="w-4 h-4" />
-                </button>
-
-                <div className="space-y-1.5">
-                  <Label className="text-[10px] uppercase tracking-wider font-bold text-muted-foreground">
-                    Variable Name
-                  </Label>
-                  <Input
-                    value={env.name}
-                    onChange={(e) => handleEnvVarNameChange(index, e.target.value)}
-                    placeholder="e.app. API_KEY"
-                    className="h-8 bg-background border-border text-sm font-mono"
-                  />
-                </div>
-
-                <div className="space-y-1.5">
-                  <Label className="text-[10px] uppercase tracking-wider font-bold text-muted-foreground">
-                    Default Value
-                  </Label>
-                  <Input
-                    value={env.default || ''}
-                    onChange={(e) => handleEnvVarValueChange(index, e.target.value)}
-                    placeholder="Optional default value..."
-                    className="h-8 bg-background border-border text-sm"
-                  />
-                  <p className="text-[10px] text-muted-foreground italic">
-                    If left empty, the value will be read from the host machine's environment.
-                  </p>
-                </div>
+        <ScrollArea className="max-h-[60vh]">
+          <div className="py-4 space-y-4 pr-4">
+            {envVars.length === 0 ? (
+              <div className="text-center py-10 bg-muted/50 rounded-xl border border-dashed border-border">
+                <p className="text-muted-foreground text-sm italic">
+                  No environment variables found. Click "Add Variable" to create one.
+                </p>
               </div>
-            ))
-          )}
-        </div>
+            ) : (
+              envVars.map((env: { name: string; default?: string | undefined }, index: number) => (
+                <div
+                  key={index}
+                  className="p-4 bg-muted/50 rounded-xl border border-border space-y-3 relative group"
+                >
+                  <button
+                    onClick={() => removeEnvVar(index)}
+                    className="absolute top-2 right-2 p-1 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-md transition-colors opacity-0 group-hover:opacity-100"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+
+                  <div className="space-y-1.5">
+                    <Label className="text-[10px] uppercase tracking-wider font-bold text-muted-foreground">
+                      Variable Name
+                    </Label>
+                    <Input
+                      value={env.name}
+                      onChange={(e) => handleEnvVarNameChange(index, e.target.value)}
+                      placeholder="e.app. API_KEY"
+                      className="h-8 bg-background border-border text-sm font-mono"
+                    />
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <Label className="text-[10px] uppercase tracking-wider font-bold text-muted-foreground">
+                      Default Value
+                    </Label>
+                    <Input
+                      value={env.default || ''}
+                      onChange={(e) => handleEnvVarValueChange(index, e.target.value)}
+                      placeholder="Optional default value..."
+                      className="h-8 bg-background border-border text-sm"
+                    />
+                    <p className="text-[10px] text-muted-foreground italic">
+                      If left empty, the value will be read from the host machine's environment.
+                    </p>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </ScrollArea>
 
         <DialogFooter className="flex items-center justify-between sm:justify-between w-full pt-2 border-t border-border">
           <Button
@@ -613,11 +614,7 @@ const ConfigSkillDialog = ({
             <Button variant="ghost" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button
-              onClick={handleSave}
-              disabled={isSaving}
-              className="px-8"
-            >
+            <Button onClick={handleSave} disabled={isSaving} className="px-8">
               {isSaving ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : null}
               Save Changes
             </Button>


### PR DESCRIPTION
## Summary
Replace native `overflow-y-auto` with shadcn `ScrollArea` component in settings components for a more consistent and better-looking scroll experience.

## Changes
- Updated `SkillsConfigCard.tsx`, `SandboxSettings.tsx`, `NotificationSettings.tsx`, and `ProvidersSettings.tsx` to use `ScrollArea`.
- Adjusted padding and layout to ensure compatibility with custom scrollbars.
- Formatted modified files with Prettier.

## Verification
- Ran `bun run lint`, `bun run format`, and `bun run typecheck` - all passed.
- Ran `bun run test` - all tests passed.