### PR TITLE
fix(transcode): handle high-precision FPS using rational fractions

### DIFF
--- a/packages/core/src/transcode/transcode.test.ts
+++ b/packages/core/src/transcode/transcode.test.ts
@@ -145,6 +145,29 @@ describe('TranscodeService', () => {
     )
   })
 
+  it('should handle rational fraction frame rate for video transcoding', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(child_process.execFile as any).mockImplementation((file: string, args: string[], cb: any) => {
+      cb(null, { stdout: '', stderr: '' })
+    })
+
+    const outputFile = path.join(tempDir, 'output_rational.mp4')
+    await transcodeService.transcodeVideo({
+      inputFile: 'input.mp4',
+      outputFile,
+      width: 1280,
+      height: 720,
+      frameRate: '160000/142512',
+      disableAudio: true,
+    })
+
+    expect(child_process.execFile).toHaveBeenCalledWith(
+      'ffmpeg',
+      expect.arrayContaining(['-filter_complex', expect.stringContaining('fps=160000/142512')]),
+      expect.any(Function),
+    )
+  })
+
   it('should use sharp for image transcoding', async () => {
     const outputFile = path.join(tempDir, 'output.webp')
     await transcodeService.transcodeImage('input.png', outputFile, 480, 80)

--- a/packages/core/src/transcode/transcode.ts
+++ b/packages/core/src/transcode/transcode.ts
@@ -32,7 +32,7 @@ export interface TranscodeVideoParams {
   outputFile: string
   width: number
   height: number
-  frameRate?: number
+  frameRate?: number | string
   disableAudio?: boolean
 }
 

--- a/packages/transcode/src/activities/transcode.ts
+++ b/packages/transcode/src/activities/transcode.ts
@@ -166,7 +166,7 @@ export async function transcodeVideoActivity(
   const outputFile = path.join(tmpDir, `video-${params.videoSpec.height}p.mp4`)
 
   try {
-    let targetFps = 0
+    let targetFps: number | string = 0
     let disableAudio = false
 
     if (params.videoSpec.resolution === '180p') {
@@ -175,8 +175,8 @@ export async function transcodeVideoActivity(
       if (params.originalFps > 0 && params.originalFps < 24.0) {
         targetFps = params.originalFps
       }
-      if (params.duration * targetFps > 1600) {
-        targetFps = 1600 / params.duration
+      if (params.duration * (targetFps as number) > 1600) {
+        targetFps = `160000/${Math.floor(params.duration * 100)}`
       }
     }
 


### PR DESCRIPTION
## Summary

Fixed transcoding failures for long videos (e.g. 23:45) where the calculated FPS for 180p previews was a high-precision float that FFmpeg's `fps` filter couldn't parse. Now using rational fractions (e.g. `160000/duration*100`) to ensure compatibility.

## Changes

- Updated `TranscodeVideoParams` to accept `string | number` for `frameRate`.
- Modified `transcodeVideoActivity` to use rational fraction strings for 180p resolution when frames exceed 1600.
- Added unit tests to verify FFmpeg argument construction with rational fractions.

## Verification

- `bun run test packages/core/src/transcode/transcode.test.ts` passed.
- `bun run typecheck` passed.
- `bun run lint` & `bun run format` passed.