### PR TITLE
feat(embedding): defer embedding workflow, use transcoded assets, and execute chunks in separate activities

### DIFF
--- a/docs/configuration/env-variables.mdx
+++ b/docs/configuration/env-variables.mdx
@@ -54,10 +54,11 @@ Shumai supports storing files locally or on S3-compatible endpoints.
 
 Configures whether background transcoding and AI agents are executed locally or offloaded to a Temporal cluster.
 
-| Variable            | Description                                                                                        | Example / Default               |
-| :------------------ | :------------------------------------------------------------------------------------------------- | :------------------------------ |
-| `WORKFLOW_EXECUTOR` | Engine choice. Use `local` for in-process database polling, or `temporal` for distributed workers. | `local` (default) or `temporal` |
-| `TEMPORAL_ADDRESS`  | Host and port of the Temporal cluster gRPC service.                                                | `localhost:7233` (default)      |
+| Variable                   | Description                                                                                        | Example / Default               |
+| :------------------------- | :------------------------------------------------------------------------------------------------- | :------------------------------ |
+| `WORKFLOW_EXECUTOR`        | Engine choice. Use `local` for in-process database polling, or `temporal` for distributed workers. | `local` (default) or `temporal` |
+| `TEMPORAL_ADDRESS`         | Host and port of the Temporal cluster gRPC service.                                                | `localhost:7233` (default)      |
+| `EMBEDDING_CHUNK_DURATION` | The duration in seconds for each video chunk when generating video embeddings.                     | `60.0` (default)                |
 
 ---
 

--- a/docs/using-shumai/agents.mdx
+++ b/docs/using-shumai/agents.mdx
@@ -34,6 +34,7 @@ A specialized utility agent that processes assets to generate search indexes. Yo
 - Once created and enabled, Shumai automatically runs embedding generation for new file uploads if the file type is supported (image or video).
 - These search indexes are saved to power Shumai's natural language semantic search capabilities.
 - **Note:** The Embedding Agent is hardcoded to use `google-embedding-2` as the LLM model. Because of this, you cannot choose a provider or model. Make sure you set the `GEMINI_API_KEY` environment variable to make it work.
+- **Chunk Duration:** You can configure the duration of chunks used for long video indexing via the `EMBEDDING_CHUNK_DURATION` environment variable (defaults to 60 seconds).
 
 ---
 

--- a/packages/agent/src/activities/ai.test.ts
+++ b/packages/agent/src/activities/ai.test.ts
@@ -279,6 +279,68 @@ describe('AI Database Activities Integration', () => {
       expect(ctx.asset.id).toBe(asset.id)
       expect(ctx.asset.mediaType).toBe('video/mp4')
     })
+
+    it('should parse valid positive chunk duration and fallback on invalid or negative ones', async () => {
+      // Create embedding agent if not already present
+      const existingAgent = await prisma.agent.findUnique({ where: { id: user.id } })
+      if (!existingAgent) {
+        await prisma.agent.create({
+          data: {
+            id: user.id,
+            teamId: team.id,
+            type: 'embedding',
+            enabled: true,
+            config: {
+              provider: 'openai',
+              model: 'gpt-4',
+            },
+          },
+        })
+      }
+
+      // Test default/fallback
+      delete process.env.EMBEDDING_CHUNK_DURATION
+      let ctx = await getEmbeddingContextActivity({
+        teamId: team.id,
+        assetId: asset.id,
+      })
+      expect(ctx.chunkDuration).toBe(60.0)
+
+      // Test valid positive
+      process.env.EMBEDDING_CHUNK_DURATION = '45.5'
+      ctx = await getEmbeddingContextActivity({
+        teamId: team.id,
+        assetId: asset.id,
+      })
+      expect(ctx.chunkDuration).toBe(45.5)
+
+      // Test negative
+      process.env.EMBEDDING_CHUNK_DURATION = '-10.0'
+      ctx = await getEmbeddingContextActivity({
+        teamId: team.id,
+        assetId: asset.id,
+      })
+      expect(ctx.chunkDuration).toBe(60.0)
+
+      // Test zero
+      process.env.EMBEDDING_CHUNK_DURATION = '0'
+      ctx = await getEmbeddingContextActivity({
+        teamId: team.id,
+        assetId: asset.id,
+      })
+      expect(ctx.chunkDuration).toBe(60.0)
+
+      // Test non-numeric
+      process.env.EMBEDDING_CHUNK_DURATION = 'invalid'
+      ctx = await getEmbeddingContextActivity({
+        teamId: team.id,
+        assetId: asset.id,
+      })
+      expect(ctx.chunkDuration).toBe(60.0)
+
+      // Cleanup env
+      delete process.env.EMBEDDING_CHUNK_DURATION
+    })
   })
 
   describe('saveAssetEmbeddingsActivity', () => {

--- a/packages/agent/src/activities/ai.test.ts
+++ b/packages/agent/src/activities/ai.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import {
-  generateEmbeddingActivity,
   generateTextEmbeddingActivity,
   extractAiMetadataActivity,
   getEmbeddingContextActivity,
   saveAssetEmbeddingsActivity,
+  generateImageEmbeddingActivity,
+  generateVideoChunkEmbeddingActivity,
 } from './ai'
 import { s3Service } from '@shumai/core/src/s3/s3'
 import { transcodeService } from '@shumai/core'
@@ -93,19 +94,13 @@ describe('AI Activities Unit Tests', () => {
       contentType: 'image/png',
     } as unknown as { buffer: Buffer; contentType: string })
 
-    const context = {
-      agent: { config: { provider: 'google', model: 'gemini' } },
-      asset: { id: 'a1', mediaType: 'image/png', storageKey: { key: 'test.png' } },
-    }
-
-    const res = await generateEmbeddingActivity({
+    const res = await generateImageEmbeddingActivity({
       teamId: 't1',
-      assetId: 'a1',
-      context,
+      assetKey: 'test.png',
+      mediaType: 'image/png',
     })
 
-    expect(res.embeddings.length).toBe(1)
-    expect(res.embeddings[0].embedding).toEqual([0.1, 0.2, 0.3])
+    expect(res.embedding).toEqual([0.1, 0.2, 0.3])
     expect(s3Service.getObject).toHaveBeenCalledWith('shumai', 'test.png')
   })
 
@@ -115,22 +110,15 @@ describe('AI Activities Unit Tests', () => {
       contentType: 'video/mp4',
     } as unknown as { buffer: Buffer; contentType: string })
 
-    const context = {
-      agent: { config: { provider: 'google', model: 'gemini' } },
-      asset: { id: 'a2', mediaType: 'video/mp4', storageKey: { key: 'test.mp4' } },
-    }
-
-    const res = await generateEmbeddingActivity({
+    const res = await generateVideoChunkEmbeddingActivity({
       teamId: 't1',
-      assetId: 'a2',
-      context,
+      assetKey: 'test.mp4',
+      startTime: 0,
+      endTime: 60,
     })
 
-    // Duration is 120s, chunks are 60s, so it should generate 2 chunks (0-60, 60-120)
-    expect(res.embeddings.length).toBe(2)
-    expect(res.embeddings[0]).toEqual({ embedding: [0.1, 0.2, 0.3], startTime: 0, endTime: 60 })
-    expect(res.embeddings[1]).toEqual({ embedding: [0.1, 0.2, 0.3], startTime: 60, endTime: 120 })
-
+    expect(res.embedding).toEqual([0.1, 0.2, 0.3])
+    expect(s3Service.getObject).toHaveBeenCalledWith('shumai', 'test.mp4')
     expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalled()
     expect(vi.mocked(fs.readFileSync)).toHaveBeenCalled()
     expect(vi.mocked(fs.unlinkSync)).toHaveBeenCalled()

--- a/packages/agent/src/activities/ai.test.ts
+++ b/packages/agent/src/activities/ai.test.ts
@@ -11,7 +11,6 @@ import { s3Service } from '@shumai/core/src/s3/s3'
 import { transcodeService } from '@shumai/core'
 import { prisma, AssetType, AssetStatus } from '@shumai/db'
 import { setupTestDbHooks } from '@shumai/db/test'
-import * as fs from 'fs'
 
 vi.mock('fs', async (importOriginal) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- importOriginal returns the raw fs module, typed dynamically as any here
@@ -112,16 +111,14 @@ describe('AI Activities Unit Tests', () => {
 
     const res = await generateVideoChunkEmbeddingActivity({
       teamId: 't1',
-      assetKey: 'test.mp4',
-      startTime: 0,
-      endTime: 60,
+      chunkKey: 'files/a1/tmp-embedding-chunks/chunk-0-60.mp4',
     })
 
     expect(res.embedding).toEqual([0.1, 0.2, 0.3])
-    expect(s3Service.getObject).toHaveBeenCalledWith('shumai', 'test.mp4')
-    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalled()
-    expect(vi.mocked(fs.readFileSync)).toHaveBeenCalled()
-    expect(vi.mocked(fs.unlinkSync)).toHaveBeenCalled()
+    expect(s3Service.getObject).toHaveBeenCalledWith(
+      'shumai',
+      'files/a1/tmp-embedding-chunks/chunk-0-60.mp4',
+    )
   })
 
   it('should generate text embedding successfully', async () => {

--- a/packages/agent/src/activities/ai.ts
+++ b/packages/agent/src/activities/ai.ts
@@ -140,6 +140,8 @@ export async function generateEmbeddingActivity(params: GenerateEmbeddingParams)
         const chunkTmp = path.join(os.tmpdir(), `video-chunk-${Date.now()}.mp4`)
         await execFileAsync('ffmpeg', [
           '-y',
+          '-loglevel',
+          'warning',
           '-i',
           tmpFile,
           '-ss',

--- a/packages/agent/src/activities/ai.ts
+++ b/packages/agent/src/activities/ai.ts
@@ -309,9 +309,12 @@ export async function getEmbeddingContextActivity(params: { teamId: string; asse
     throw ApplicationFailure.create({ message: 'asset has no media type', nonRetryable: true })
   }
 
+  const chunkDuration = parseFloat(process.env.EMBEDDING_CHUNK_DURATION || '60.0') || 60.0
+
   return {
     agent,
     asset,
+    chunkDuration,
   }
 }
 
@@ -336,5 +339,118 @@ export async function saveAssetEmbeddingsActivity(params: {
         VALUES (gen_random_uuid()::text, ${params.assetId}, ${embVec}::vector, NOW())
       `
     }
+  }
+}
+
+export interface GenerateImageEmbeddingParams {
+  teamId: string
+  assetKey: string
+  mediaType: string
+}
+
+export async function generateImageEmbeddingActivity(
+  params: GenerateImageEmbeddingParams,
+): Promise<{
+  embedding: number[]
+  usage: Usage
+}> {
+  const apiKey = process.env.GEMINI_API_KEY
+  if (!apiKey) {
+    throw ApplicationFailure.create({
+      message: 'GEMINI_API_KEY environment variable is not configured',
+      nonRetryable: true,
+    })
+  }
+
+  const resolvedApiKey = process.env[apiKey] || apiKey
+  const ai = new GoogleGenAI({ apiKey: resolvedApiKey })
+
+  const usage: Usage = {
+    model: 'gemini-embedding-2',
+    inputTokens: 0,
+    outputTokens: 0,
+  }
+
+  const { buffer: data } = await s3Service.getObject(
+    process.env.S3_BUCKET || 'shumai',
+    params.assetKey,
+  )
+  const embVec = await generateMultimodalEmbedding(ai, data, params.mediaType)
+
+  return {
+    embedding: embVec,
+    usage,
+  }
+}
+
+export interface GenerateVideoChunkEmbeddingParams {
+  teamId: string
+  assetKey: string
+  startTime: number
+  endTime: number
+}
+
+export async function generateVideoChunkEmbeddingActivity(
+  params: GenerateVideoChunkEmbeddingParams,
+): Promise<{
+  embedding: number[]
+  usage: Usage
+}> {
+  const apiKey = process.env.GEMINI_API_KEY
+  if (!apiKey) {
+    throw ApplicationFailure.create({
+      message: 'GEMINI_API_KEY environment variable is not configured',
+      nonRetryable: true,
+    })
+  }
+
+  const resolvedApiKey = process.env[apiKey] || apiKey
+  const ai = new GoogleGenAI({ apiKey: resolvedApiKey })
+
+  const usage: Usage = {
+    model: 'gemini-embedding-2',
+    inputTokens: 0,
+    outputTokens: 0,
+  }
+
+  const { buffer: data } = await s3Service.getObject(
+    process.env.S3_BUCKET || 'shumai',
+    params.assetKey,
+  )
+
+  const tmpFile = path.join(os.tmpdir(), `video-chunk-source-${Date.now()}.mp4`)
+  fs.writeFileSync(tmpFile, data)
+
+  const chunkTmp = path.join(os.tmpdir(), `video-chunk-${Date.now()}.mp4`)
+  try {
+    await execFileAsync('ffmpeg', [
+      '-y',
+      '-i',
+      tmpFile,
+      '-ss',
+      params.startTime.toString(),
+      '-t',
+      (params.endTime - params.startTime).toString(),
+      '-c',
+      'copy',
+      chunkTmp,
+    ])
+
+    const chunkData = fs.readFileSync(chunkTmp)
+    fs.unlinkSync(chunkTmp)
+
+    const embVec = await generateMultimodalEmbedding(ai, chunkData, 'video/mp4')
+    return {
+      embedding: embVec,
+      usage,
+    }
+  } catch (err) {
+    throw ApplicationFailure.create({
+      message: `Failed to generate video chunk embedding for ${params.startTime}-${params.endTime}: ${err instanceof Error ? err.message : String(err)}`,
+      nonRetryable: false,
+    })
+  } finally {
+    if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile)
+    if (fs.existsSync(chunkTmp)) fs.unlinkSync(chunkTmp)
   }
 }

--- a/packages/agent/src/activities/ai.ts
+++ b/packages/agent/src/activities/ai.ts
@@ -310,7 +310,8 @@ export async function getEmbeddingContextActivity(params: { teamId: string; asse
   }
 
   const parsedDuration = parseFloat(process.env.EMBEDDING_CHUNK_DURATION || '')
-  const chunkDuration = Number.isFinite(parsedDuration) && parsedDuration > 0 ? parsedDuration : 60.0
+  const chunkDuration =
+    Number.isFinite(parsedDuration) && parsedDuration > 0 ? parsedDuration : 60.0
 
   return {
     agent,
@@ -386,9 +387,7 @@ export async function generateImageEmbeddingActivity(
 
 export interface GenerateVideoChunkEmbeddingParams {
   teamId: string
-  assetKey: string
-  startTime: number
-  endTime: number
+  chunkKey: string
 }
 
 export async function generateVideoChunkEmbeddingActivity(
@@ -414,44 +413,21 @@ export async function generateVideoChunkEmbeddingActivity(
     outputTokens: 0,
   }
 
-  const { buffer: data } = await s3Service.getObject(
-    process.env.S3_BUCKET || 'shumai',
-    params.assetKey,
-  )
-
-  const tmpFile = path.join(os.tmpdir(), `video-chunk-source-${Date.now()}.mp4`)
-  fs.writeFileSync(tmpFile, data)
-
-  const chunkTmp = path.join(os.tmpdir(), `video-chunk-${Date.now()}.mp4`)
   try {
-    await execFileAsync('ffmpeg', [
-      '-y',
-      '-i',
-      tmpFile,
-      '-ss',
-      params.startTime.toString(),
-      '-t',
-      (params.endTime - params.startTime).toString(),
-      '-c',
-      'copy',
-      chunkTmp,
-    ])
+    const { buffer: data } = await s3Service.getObject(
+      process.env.S3_BUCKET || 'shumai',
+      params.chunkKey,
+    )
 
-    const chunkData = fs.readFileSync(chunkTmp)
-    fs.unlinkSync(chunkTmp)
-
-    const embVec = await generateMultimodalEmbedding(ai, chunkData, 'video/mp4')
+    const embVec = await generateMultimodalEmbedding(ai, data, 'video/mp4')
     return {
       embedding: embVec,
       usage,
     }
   } catch (err) {
     throw ApplicationFailure.create({
-      message: `Failed to generate video chunk embedding for ${params.startTime}-${params.endTime}: ${err instanceof Error ? err.message : String(err)}`,
+      message: `Failed to generate video chunk embedding for key ${params.chunkKey}: ${err instanceof Error ? err.message : String(err)}`,
       nonRetryable: false,
     })
-  } finally {
-    if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile)
-    if (fs.existsSync(chunkTmp)) fs.unlinkSync(chunkTmp)
   }
 }

--- a/packages/agent/src/activities/ai.ts
+++ b/packages/agent/src/activities/ai.ts
@@ -309,7 +309,8 @@ export async function getEmbeddingContextActivity(params: { teamId: string; asse
     throw ApplicationFailure.create({ message: 'asset has no media type', nonRetryable: true })
   }
 
-  const chunkDuration = parseFloat(process.env.EMBEDDING_CHUNK_DURATION || '60.0') || 60.0
+  const parsedDuration = parseFloat(process.env.EMBEDDING_CHUNK_DURATION || '')
+  const chunkDuration = Number.isFinite(parsedDuration) && parsedDuration > 0 ? parsedDuration : 60.0
 
   return {
     agent,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -380,6 +380,8 @@ export {
   generateTextEmbeddingActivity,
   type ExtractAiMetadataParams,
   extractAiMetadataActivity,
+  generateImageEmbeddingActivity,
+  generateVideoChunkEmbeddingActivity,
 } from './activities/ai'
 export * from './workflows/agent-autofill'
 export * from './workflows/agent-chat'

--- a/packages/agent/src/workflows/agent-embedding.test.ts
+++ b/packages/agent/src/workflows/agent-embedding.test.ts
@@ -29,8 +29,11 @@ describe('Agent Embedding Workflow', () => {
       getEmbeddingContextActivity: Object.assign(vi.fn(), {
         _activityName: 'getEmbeddingContextActivity',
       }),
-      generateEmbeddingActivity: Object.assign(vi.fn(), {
-        _activityName: 'generateEmbeddingActivity',
+      generateImageEmbeddingActivity: Object.assign(vi.fn(), {
+        _activityName: 'generateImageEmbeddingActivity',
+      }),
+      generateVideoChunkEmbeddingActivity: Object.assign(vi.fn(), {
+        _activityName: 'generateVideoChunkEmbeddingActivity',
       }),
       saveAssetEmbeddingsActivity: Object.assign(vi.fn(), {
         _activityName: 'saveAssetEmbeddingsActivity',
@@ -48,12 +51,20 @@ describe('Agent Embedding Workflow', () => {
     mockActivities.createCommentActivity.mockResolvedValue({ id: 'comment-placeholder-id' })
     mockActivities.getEmbeddingContextActivity.mockResolvedValue({
       agent: { id: 'b1' },
-      asset: { id: 'a1' },
-      dbProvider: { name: 'google' },
+      asset: {
+        id: 'a1',
+        mediaType: 'image/png',
+        storageKey: { key: 'test.png' },
+      },
+      chunkDuration: 60.0,
     })
-    mockActivities.generateEmbeddingActivity.mockResolvedValue({
-      embeddings: [{ embedding: [0.1, 0.2] }],
+    mockActivities.generateImageEmbeddingActivity.mockResolvedValue({
+      embedding: [0.1, 0.2],
       usage: { inputTokens: 5, outputTokens: 5, model: 'gpt' },
+    })
+    mockActivities.generateVideoChunkEmbeddingActivity.mockResolvedValue({
+      embedding: [0.3, 0.4],
+      usage: { inputTokens: 3, outputTokens: 3, model: 'gpt' },
     })
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mockActivities contains vi.fn mock functions which are cast to expected activity proxy types
@@ -64,7 +75,7 @@ describe('Agent Embedding Workflow', () => {
     })
   })
 
-  it('should run agent embedding workflow successfully', async () => {
+  it('should run agent embedding workflow successfully for image', async () => {
     const task = await prisma.workflowTask.create({
       data: {
         type: 'ai_embedding',
@@ -103,15 +114,11 @@ describe('Agent Embedding Workflow', () => {
       assetId: 'a1',
     })
 
-    // Verify embedding generation
-    expect(mockActivities.generateEmbeddingActivity).toHaveBeenCalledWith({
+    // Verify image embedding generation
+    expect(mockActivities.generateImageEmbeddingActivity).toHaveBeenCalledWith({
       teamId: 't1',
-      assetId: 'a1',
-      context: {
-        agent: { id: 'b1' },
-        asset: { id: 'a1' },
-        dbProvider: { name: 'google' },
-      },
+      assetKey: 'test.png',
+      mediaType: 'image/png',
     })
 
     // Verify embeddings saved
@@ -125,7 +132,7 @@ describe('Agent Embedding Workflow', () => {
       taskId: task.id,
       inputTokens: 5,
       outputTokens: 5,
-      model: 'gpt',
+      model: 'gemini-embedding-2',
     })
 
     // Verify placeholder comment updated
@@ -138,6 +145,76 @@ describe('Agent Embedding Workflow', () => {
     expect(mockActivities.updateTaskStatusActivity).toHaveBeenCalledWith({
       taskId: task.id,
       status: 'completed',
+    })
+  })
+
+  it('should run agent embedding workflow successfully for video in chunks', async () => {
+    mockActivities.getEmbeddingContextActivity.mockResolvedValue({
+      agent: { id: 'b1' },
+      asset: {
+        id: 'a1',
+        mediaType: 'video/mp4',
+        storageKey: { key: 'test.mp4' },
+        media: {
+          duration: 150.0,
+          videoTranscodes: [{ key: 'test-transcoded.mp4', isRaw: false }],
+        },
+      },
+      chunkDuration: 60.0,
+    })
+
+    const task = await prisma.workflowTask.create({
+      data: {
+        type: 'ai_embedding',
+        status: 'pending',
+        assetId: 'a1',
+        teamId: 't1',
+        payload: {
+          projectId: 'p1',
+          agent: { sessionId: 's1', agentId: 'agent-1' },
+        },
+      },
+    })
+
+    await agentEmbeddingMedia(task)
+
+    // Verify video chunk embedding generation (3 chunks: 0-60, 60-120, 120-150)
+    expect(mockActivities.generateVideoChunkEmbeddingActivity).toHaveBeenCalledTimes(3)
+    expect(mockActivities.generateVideoChunkEmbeddingActivity).toHaveBeenNthCalledWith(1, {
+      teamId: 't1',
+      assetKey: 'test-transcoded.mp4',
+      startTime: 0,
+      endTime: 60,
+    })
+    expect(mockActivities.generateVideoChunkEmbeddingActivity).toHaveBeenNthCalledWith(2, {
+      teamId: 't1',
+      assetKey: 'test-transcoded.mp4',
+      startTime: 60,
+      endTime: 120,
+    })
+    expect(mockActivities.generateVideoChunkEmbeddingActivity).toHaveBeenNthCalledWith(3, {
+      teamId: 't1',
+      assetKey: 'test-transcoded.mp4',
+      startTime: 120,
+      endTime: 150,
+    })
+
+    // Verify usage update (3 chunks * 3 tokens = 9)
+    expect(mockActivities.updateTaskUsageActivity).toHaveBeenCalledWith({
+      taskId: task.id,
+      inputTokens: 9,
+      outputTokens: 9,
+      model: 'gemini-embedding-2',
+    })
+
+    // Verify embeddings saved
+    expect(mockActivities.saveAssetEmbeddingsActivity).toHaveBeenCalledWith({
+      assetId: 'a1',
+      embeddings: [
+        { embedding: [0.3, 0.4], startTime: 0, endTime: 60 },
+        { embedding: [0.3, 0.4], startTime: 60, endTime: 120 },
+        { embedding: [0.3, 0.4], startTime: 120, endTime: 150 },
+      ],
     })
   })
 
@@ -160,10 +237,18 @@ describe('Agent Embedding Workflow', () => {
     })
   })
 
-  it('should skip saving embeddings if none are returned', async () => {
-    mockActivities.generateEmbeddingActivity.mockResolvedValue({
-      embeddings: [],
-      usage: null,
+  it('should skip saving embeddings if none are returned (video duration 0)', async () => {
+    mockActivities.getEmbeddingContextActivity.mockResolvedValue({
+      agent: { id: 'b1' },
+      asset: {
+        id: 'a1',
+        mediaType: 'video/mp4',
+        storageKey: { key: 'test.mp4' },
+        media: {
+          duration: 0.0,
+        },
+      },
+      chunkDuration: 60.0,
     })
 
     const task = await prisma.workflowTask.create({
@@ -178,7 +263,6 @@ describe('Agent Embedding Workflow', () => {
     await agentEmbeddingMedia(task)
 
     expect(mockActivities.saveAssetEmbeddingsActivity).not.toHaveBeenCalled()
-    expect(mockActivities.updateTaskUsageActivity).not.toHaveBeenCalled()
     expect(mockActivities.updateTaskStatusActivity).toHaveBeenCalledWith({
       taskId: task.id,
       status: 'completed',
@@ -186,7 +270,9 @@ describe('Agent Embedding Workflow', () => {
   })
 
   it('should handle failures, update placeholder with error, and set status to failed', async () => {
-    mockActivities.generateEmbeddingActivity.mockRejectedValue(new Error('AI Service Unavailable'))
+    mockActivities.generateImageEmbeddingActivity.mockRejectedValue(
+      new Error('AI Service Unavailable'),
+    )
 
     const task = await prisma.workflowTask.create({
       data: {

--- a/packages/agent/src/workflows/agent-embedding.test.ts
+++ b/packages/agent/src/workflows/agent-embedding.test.ts
@@ -44,9 +44,25 @@ describe('Agent Embedding Workflow', () => {
       getAgentWorkerQueueActivity: Object.assign(vi.fn(), {
         _activityName: 'getAgentWorkerQueueActivity',
       }),
+      getTranscodeWorkerQueueActivity: Object.assign(vi.fn(), {
+        _activityName: 'getTranscodeWorkerQueueActivity',
+      }),
+      downloadMediaToTmpActivity: Object.assign(vi.fn(), {
+        _activityName: 'downloadMediaToTmpActivity',
+      }),
+      cleanupTmpDirActivity: Object.assign(vi.fn(), {
+        _activityName: 'cleanupTmpDirActivity',
+      }),
+      transcodeVideoChunkActivity: Object.assign(vi.fn(), {
+        _activityName: 'transcodeVideoChunkActivity',
+      }),
+      deleteS3ObjectActivity: Object.assign(vi.fn(), {
+        _activityName: 'deleteS3ObjectActivity',
+      }),
     }
 
     mockActivities.getAgentWorkerQueueActivity.mockResolvedValue('agent_queue')
+    mockActivities.getTranscodeWorkerQueueActivity.mockResolvedValue('transcode_queue')
     mockActivities.updateTaskStatusActivity.mockResolvedValue({})
     mockActivities.createCommentActivity.mockResolvedValue({ id: 'comment-placeholder-id' })
     mockActivities.getEmbeddingContextActivity.mockResolvedValue({
@@ -66,6 +82,19 @@ describe('Agent Embedding Workflow', () => {
       embedding: [0.3, 0.4],
       usage: { inputTokens: 3, outputTokens: 3, model: 'gpt' },
     })
+    mockActivities.downloadMediaToTmpActivity.mockResolvedValue({
+      filePath: '/tmp/test.mp4',
+      tmpDir: '/tmp/test-dir',
+    })
+    mockActivities.transcodeVideoChunkActivity.mockImplementation(
+      async (params: { assetId: string; startTime: number; endTime: number }) => {
+        return {
+          chunkKey: `files/${params.assetId}/tmp-embedding-chunks/chunk-${params.startTime}-${params.endTime}.mp4`,
+        }
+      },
+    )
+    mockActivities.deleteS3ObjectActivity.mockResolvedValue(undefined)
+    mockActivities.cleanupTmpDirActivity.mockResolvedValue(undefined)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mockActivities contains vi.fn mock functions which are cast to expected activity proxy types
     vi.mocked(workflowUtils.getActivities).mockReturnValue(mockActivities as any)
@@ -156,8 +185,8 @@ describe('Agent Embedding Workflow', () => {
         mediaType: 'image/png',
         storageKey: { key: 'test.png' },
         media: {
-          imageTranscodes: [{ key: 'test-transcoded.webp', isRaw: false, format: 'webp' }]
-        }
+          imageTranscodes: [{ key: 'test-transcoded.webp', isRaw: false, format: 'webp' }],
+        },
       },
       chunkDuration: 60.0,
     })
@@ -210,25 +239,57 @@ describe('Agent Embedding Workflow', () => {
 
     await agentEmbeddingMedia(task)
 
-    // Verify video chunk embedding generation (3 chunks: 0-60, 60-120, 120-150)
-    expect(mockActivities.generateVideoChunkEmbeddingActivity).toHaveBeenCalledTimes(3)
-    expect(mockActivities.generateVideoChunkEmbeddingActivity).toHaveBeenNthCalledWith(1, {
-      teamId: 't1',
+    // Verify video transcode queue discovery & download
+    expect(mockActivities.getTranscodeWorkerQueueActivity).toHaveBeenCalled()
+    expect(mockActivities.downloadMediaToTmpActivity).toHaveBeenCalledWith({
       assetKey: 'test-transcoded.mp4',
+    })
+
+    // Verify video chunk slicing activity called 3 times on transcode queue
+    expect(mockActivities.transcodeVideoChunkActivity).toHaveBeenCalledTimes(3)
+    expect(mockActivities.transcodeVideoChunkActivity).toHaveBeenNthCalledWith(1, {
+      assetId: 'a1',
+      filePath: '/tmp/test.mp4',
       startTime: 0,
       endTime: 60,
     })
-    expect(mockActivities.generateVideoChunkEmbeddingActivity).toHaveBeenNthCalledWith(2, {
-      teamId: 't1',
-      assetKey: 'test-transcoded.mp4',
+    expect(mockActivities.transcodeVideoChunkActivity).toHaveBeenNthCalledWith(2, {
+      assetId: 'a1',
+      filePath: '/tmp/test.mp4',
       startTime: 60,
       endTime: 120,
     })
-    expect(mockActivities.generateVideoChunkEmbeddingActivity).toHaveBeenNthCalledWith(3, {
-      teamId: 't1',
-      assetKey: 'test-transcoded.mp4',
+    expect(mockActivities.transcodeVideoChunkActivity).toHaveBeenNthCalledWith(3, {
+      assetId: 'a1',
+      filePath: '/tmp/test.mp4',
       startTime: 120,
       endTime: 150,
+    })
+
+    // Verify video chunk embedding generation (3 chunks) on agent queue
+    expect(mockActivities.generateVideoChunkEmbeddingActivity).toHaveBeenCalledTimes(3)
+    expect(mockActivities.generateVideoChunkEmbeddingActivity).toHaveBeenNthCalledWith(1, {
+      teamId: 't1',
+      chunkKey: 'files/a1/tmp-embedding-chunks/chunk-0-60.mp4',
+    })
+    expect(mockActivities.generateVideoChunkEmbeddingActivity).toHaveBeenNthCalledWith(2, {
+      teamId: 't1',
+      chunkKey: 'files/a1/tmp-embedding-chunks/chunk-60-120.mp4',
+    })
+    expect(mockActivities.generateVideoChunkEmbeddingActivity).toHaveBeenNthCalledWith(3, {
+      teamId: 't1',
+      chunkKey: 'files/a1/tmp-embedding-chunks/chunk-120-150.mp4',
+    })
+
+    // Verify deletion of temporary chunks from S3
+    expect(mockActivities.deleteS3ObjectActivity).toHaveBeenCalledTimes(3)
+    expect(mockActivities.deleteS3ObjectActivity).toHaveBeenNthCalledWith(1, {
+      key: 'files/a1/tmp-embedding-chunks/chunk-0-60.mp4',
+    })
+
+    // Verify temp directory cleanup on transcode queue
+    expect(mockActivities.cleanupTmpDirActivity).toHaveBeenCalledWith({
+      tmpDir: '/tmp/test-dir',
     })
 
     // Verify usage update (3 chunks * 3 tokens = 9)

--- a/packages/agent/src/workflows/agent-embedding.test.ts
+++ b/packages/agent/src/workflows/agent-embedding.test.ts
@@ -148,6 +148,38 @@ describe('Agent Embedding Workflow', () => {
     })
   })
 
+  it('should run agent embedding workflow successfully for image with transcoded format', async () => {
+    mockActivities.getEmbeddingContextActivity.mockResolvedValue({
+      agent: { id: 'b1' },
+      asset: {
+        id: 'a1',
+        mediaType: 'image/png',
+        storageKey: { key: 'test.png' },
+        media: {
+          imageTranscodes: [{ key: 'test-transcoded.webp', isRaw: false, format: 'webp' }]
+        }
+      },
+      chunkDuration: 60.0,
+    })
+
+    const task = await prisma.workflowTask.create({
+      data: {
+        type: 'ai_embedding',
+        status: 'pending',
+        assetId: 'a1',
+        teamId: 't1',
+      },
+    })
+
+    await agentEmbeddingMedia(task)
+
+    expect(mockActivities.generateImageEmbeddingActivity).toHaveBeenCalledWith({
+      teamId: 't1',
+      assetKey: 'test-transcoded.webp',
+      mediaType: 'image/webp',
+    })
+  })
+
   it('should run agent embedding workflow successfully for video in chunks', async () => {
     mockActivities.getEmbeddingContextActivity.mockResolvedValue({
       agent: { id: 'b1' },

--- a/packages/agent/src/workflows/agent-embedding.ts
+++ b/packages/agent/src/workflows/agent-embedding.ts
@@ -69,15 +69,15 @@ export async function agentEmbeddingMedia(task: WorkflowTask): Promise<void> {
 
     // Resolve the S3 key to use for embedding (preferring transcoded version)
     let embeddingKey = asset.storageKey?.key
+    let embeddingMediaType = asset.mediaType
     if (asset.media) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const media = asset.media as any
       if (isVideo) {
         if (media.videoTranscodes && media.videoTranscodes.length > 0) {
           // Find first non-raw transcode or fallback to first transcode
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const transcode =
-            media.videoTranscodes.find((t: any) => !t.isRaw) || media.videoTranscodes[0]
+            media.videoTranscodes.find((t: PrismaJson.VideoTranscode) => !t.isRaw) || media.videoTranscodes[0]
           if (transcode?.key) {
             embeddingKey = transcode.key
           }
@@ -85,11 +85,13 @@ export async function agentEmbeddingMedia(task: WorkflowTask): Promise<void> {
       } else if (isImage) {
         if (media.imageTranscodes && media.imageTranscodes.length > 0) {
           // Find first non-raw transcode or fallback to first transcode
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const transcode =
-            media.imageTranscodes.find((t: any) => !t.isRaw) || media.imageTranscodes[0]
+            media.imageTranscodes.find((t: PrismaJson.ImageTranscode) => !t.isRaw) || media.imageTranscodes[0]
           if (transcode?.key) {
             embeddingKey = transcode.key
+            if (transcode.format) {
+              embeddingMediaType = `image/${transcode.format}`
+            }
           }
         }
       }
@@ -110,7 +112,7 @@ export async function agentEmbeddingMedia(task: WorkflowTask): Promise<void> {
       const result = await executeActivity(agentWorkerQueue, generateImageEmbeddingActivity, {
         teamId: task.teamId,
         assetKey: embeddingKey,
-        mediaType: asset.mediaType,
+        mediaType: embeddingMediaType,
       })
       results.push({ embedding: result.embedding })
       if (result.usage) {

--- a/packages/agent/src/workflows/agent-embedding.ts
+++ b/packages/agent/src/workflows/agent-embedding.ts
@@ -2,11 +2,18 @@ import { ApplicationFailure } from '@temporalio/workflow'
 import type { WorkflowTask } from '@shumai/db'
 import { getActivities, executeActivity, TaskQueueAgent } from '@shumai/workflow-core'
 
+export interface GeneratedEmbedding {
+  embedding: number[]
+  startTime?: number
+  endTime?: number
+}
+
 export async function agentEmbeddingMedia(task: WorkflowTask): Promise<void> {
   const {
     updateTaskStatusActivity,
     getEmbeddingContextActivity,
-    generateEmbeddingActivity,
+    generateImageEmbeddingActivity,
+    generateVideoChunkEmbeddingActivity,
     saveAssetEmbeddingsActivity,
     updateTaskUsageActivity,
     createCommentActivity,
@@ -47,30 +54,118 @@ export async function agentEmbeddingMedia(task: WorkflowTask): Promise<void> {
       assetId: task.assetId,
     })
 
-    // Call the activity to generate embeddings
-    const result = await executeActivity(agentWorkerQueue, generateEmbeddingActivity, {
-      teamId: task.teamId,
-      assetId: task.assetId,
-      context,
-    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { asset, chunkDuration } = context as any
+
+    const isImage = asset.mediaType?.startsWith('image/')
+    const isVideo = asset.mediaType?.startsWith('video/')
+
+    if (!isImage && !isVideo) {
+      throw ApplicationFailure.create({
+        message: `unsupported media type for embeddings: ${asset.mediaType}`,
+        nonRetryable: true,
+      })
+    }
+
+    // Resolve the S3 key to use for embedding (preferring transcoded version)
+    let embeddingKey = asset.storageKey?.key
+    if (asset.media) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const media = asset.media as any
+      if (isVideo) {
+        if (media.videoTranscodes && media.videoTranscodes.length > 0) {
+          // Find first non-raw transcode or fallback to first transcode
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const transcode =
+            media.videoTranscodes.find((t: any) => !t.isRaw) || media.videoTranscodes[0]
+          if (transcode?.key) {
+            embeddingKey = transcode.key
+          }
+        }
+      } else if (isImage) {
+        if (media.imageTranscodes && media.imageTranscodes.length > 0) {
+          // Find first non-raw transcode or fallback to first transcode
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const transcode =
+            media.imageTranscodes.find((t: any) => !t.isRaw) || media.imageTranscodes[0]
+          if (transcode?.key) {
+            embeddingKey = transcode.key
+          }
+        }
+      }
+    }
+
+    if (!embeddingKey) {
+      throw ApplicationFailure.create({ message: 'asset has no key', nonRetryable: true })
+    }
+
+    const results: GeneratedEmbedding[] = []
+    const usage = {
+      model: 'gemini-embedding-2',
+      inputTokens: 0,
+      outputTokens: 0,
+    }
+
+    if (isImage) {
+      const result = await executeActivity(agentWorkerQueue, generateImageEmbeddingActivity, {
+        teamId: task.teamId,
+        assetKey: embeddingKey,
+        mediaType: asset.mediaType,
+      })
+      results.push({ embedding: result.embedding })
+      if (result.usage) {
+        usage.inputTokens += result.usage.inputTokens || 0
+        usage.outputTokens += result.usage.outputTokens || 0
+      }
+    } else if (isVideo) {
+      // Get video duration
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const duration = (asset.media as any)?.duration || 0
+      const limit = chunkDuration || 60.0
+
+      for (let start = 0.0; start < duration; start += limit) {
+        let end = start + limit
+        if (end > duration) end = duration
+
+        const chunkResult = await executeActivity(
+          agentWorkerQueue,
+          generateVideoChunkEmbeddingActivity,
+          {
+            teamId: task.teamId,
+            assetKey: embeddingKey,
+            startTime: start,
+            endTime: end,
+          },
+        )
+
+        results.push({
+          embedding: chunkResult.embedding,
+          startTime: start,
+          endTime: end,
+        })
+
+        if (chunkResult.usage) {
+          usage.inputTokens += chunkResult.usage.inputTokens || 0
+          usage.outputTokens += chunkResult.usage.outputTokens || 0
+        }
+      }
+    }
 
     // Save computed embeddings
-    if (result.embeddings.length > 0) {
+    if (results.length > 0) {
       await executeActivity(agentWorkerQueue, saveAssetEmbeddingsActivity, {
         assetId: task.assetId,
-        embeddings: result.embeddings,
+        embeddings: results,
       })
     }
 
     // Update Usage
-    if (result.usage) {
-      await executeActivity(agentWorkerQueue, updateTaskUsageActivity, {
-        taskId: task.id,
-        inputTokens: result.usage.inputTokens,
-        outputTokens: result.usage.outputTokens,
-        model: result.usage.model,
-      })
-    }
+    await executeActivity(agentWorkerQueue, updateTaskUsageActivity, {
+      taskId: task.id,
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      model: usage.model,
+    })
 
     // 7. Update Placeholder Comment
     if (placeholderCommentId) {

--- a/packages/agent/src/workflows/agent-embedding.ts
+++ b/packages/agent/src/workflows/agent-embedding.ts
@@ -1,6 +1,11 @@
 import { ApplicationFailure } from '@temporalio/workflow'
 import type { WorkflowTask } from '@shumai/db'
-import { getActivities, executeActivity, TaskQueueAgent } from '@shumai/workflow-core'
+import {
+  getActivities,
+  executeActivity,
+  TaskQueueAgent,
+  TaskQueueTranscode,
+} from '@shumai/workflow-core'
 
 export interface GeneratedEmbedding {
   embedding: number[]
@@ -19,14 +24,25 @@ export async function agentEmbeddingMedia(task: WorkflowTask): Promise<void> {
     createCommentActivity,
     updateCommentActivity,
     getAgentWorkerQueueActivity,
+    getTranscodeWorkerQueueActivity,
+    downloadMediaToTmpActivity,
+    cleanupTmpDirActivity,
+    transcodeVideoChunkActivity,
+    deleteS3ObjectActivity,
   } = getActivities()
 
   let placeholderCommentId: string | undefined
   let agentWorkerQueue = ''
+  let transcodeWorkerQueue = ''
+  let tmpDir: string | undefined
 
   try {
-    // 0. Discover queue
+    // 0. Discover queues
     agentWorkerQueue = await executeActivity(TaskQueueAgent, getAgentWorkerQueueActivity)
+    transcodeWorkerQueue = await executeActivity(
+      TaskQueueTranscode,
+      getTranscodeWorkerQueueActivity,
+    )
 
     // Update status to processing
     await executeActivity(agentWorkerQueue, updateTaskStatusActivity, {
@@ -77,7 +93,8 @@ export async function agentEmbeddingMedia(task: WorkflowTask): Promise<void> {
         if (media.videoTranscodes && media.videoTranscodes.length > 0) {
           // Find first non-raw transcode or fallback to first transcode
           const transcode =
-            media.videoTranscodes.find((t: PrismaJson.VideoTranscode) => !t.isRaw) || media.videoTranscodes[0]
+            media.videoTranscodes.find((t: PrismaJson.VideoTranscode) => !t.isRaw) ||
+            media.videoTranscodes[0]
           if (transcode?.key) {
             embeddingKey = transcode.key
           }
@@ -86,7 +103,8 @@ export async function agentEmbeddingMedia(task: WorkflowTask): Promise<void> {
         if (media.imageTranscodes && media.imageTranscodes.length > 0) {
           // Find first non-raw transcode or fallback to first transcode
           const transcode =
-            media.imageTranscodes.find((t: PrismaJson.ImageTranscode) => !t.isRaw) || media.imageTranscodes[0]
+            media.imageTranscodes.find((t: PrismaJson.ImageTranscode) => !t.isRaw) ||
+            media.imageTranscodes[0]
           if (transcode?.key) {
             embeddingKey = transcode.key
             if (transcode.format) {
@@ -120,6 +138,13 @@ export async function agentEmbeddingMedia(task: WorkflowTask): Promise<void> {
         usage.outputTokens += result.usage.outputTokens || 0
       }
     } else if (isVideo) {
+      // 1. Download full video to transcode worker temp space
+      const download = await executeActivity(transcodeWorkerQueue, downloadMediaToTmpActivity, {
+        assetKey: embeddingKey,
+      })
+      const { filePath } = download
+      tmpDir = download.tmpDir
+
       // Get video duration
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const duration = (asset.media as any)?.duration || 0
@@ -129,26 +154,41 @@ export async function agentEmbeddingMedia(task: WorkflowTask): Promise<void> {
         let end = start + limit
         if (end > duration) end = duration
 
-        const chunkResult = await executeActivity(
-          agentWorkerQueue,
-          generateVideoChunkEmbeddingActivity,
-          {
-            teamId: task.teamId,
-            assetKey: embeddingKey,
-            startTime: start,
-            endTime: end,
-          },
-        )
-
-        results.push({
-          embedding: chunkResult.embedding,
+        // Step A: Slice chunk on transcode worker and upload to S3
+        const chunkRes = await executeActivity(transcodeWorkerQueue, transcodeVideoChunkActivity, {
+          assetId: asset.id,
+          filePath,
           startTime: start,
           endTime: end,
         })
+        const { chunkKey } = chunkRes
 
-        if (chunkResult.usage) {
-          usage.inputTokens += chunkResult.usage.inputTokens || 0
-          usage.outputTokens += chunkResult.usage.outputTokens || 0
+        try {
+          // Step B: Generate embedding on agent worker
+          const chunkResult = await executeActivity(
+            agentWorkerQueue,
+            generateVideoChunkEmbeddingActivity,
+            {
+              teamId: task.teamId,
+              chunkKey,
+            },
+          )
+
+          results.push({
+            embedding: chunkResult.embedding,
+            startTime: start,
+            endTime: end,
+          })
+
+          if (chunkResult.usage) {
+            usage.inputTokens += chunkResult.usage.inputTokens || 0
+            usage.outputTokens += chunkResult.usage.outputTokens || 0
+          }
+        } finally {
+          // Step C: Delete temporary chunk from S3
+          await executeActivity(transcodeWorkerQueue, deleteS3ObjectActivity, {
+            key: chunkKey,
+          })
         }
       }
     }
@@ -206,6 +246,14 @@ export async function agentEmbeddingMedia(task: WorkflowTask): Promise<void> {
       })
     }
     throw err
+  } finally {
+    if (tmpDir && transcodeWorkerQueue) {
+      try {
+        await executeActivity(transcodeWorkerQueue, cleanupTmpDirActivity, { tmpDir })
+      } catch (cleanupErr) {
+        console.error('Failed to cleanup transcode worker tmp dir:', cleanupErr)
+      }
+    }
   }
 }
 

--- a/packages/core/src/transcode/transcode.ts
+++ b/packages/core/src/transcode/transcode.ts
@@ -154,7 +154,7 @@ export class TranscodeService {
 
     args.push('-movflags', '+faststart', '-max_muxing_queue_size', '1024', params.outputFile)
 
-    await execFileAsync('ffmpeg', ['-y', ...args])
+    await execFileAsync('ffmpeg', ['-y', '-loglevel', 'warning', ...args])
   }
 
   async transcodeImage(
@@ -222,12 +222,12 @@ export class TranscodeService {
       '1024',
       outputPoster,
     ]
-    await execFileAsync('ffmpeg', ['-y', ...args])
+    await execFileAsync('ffmpeg', ['-y', '-loglevel', 'warning', ...args])
   }
 
   async extractAudio(inputFile: string, outputFile: string, bitrate: string): Promise<void> {
     const args = ['-i', inputFile, '-vn', '-acodec', 'libmp3lame', '-b:a', bitrate, outputFile]
-    await execFileAsync('ffmpeg', ['-y', ...args])
+    await execFileAsync('ffmpeg', ['-y', '-loglevel', 'warning', ...args])
   }
 
   async extractVideoFrames(params: ExtractVideoFramesParams): Promise<string[]> {
@@ -252,7 +252,7 @@ export class TranscodeService {
       '80',
       outputPattern,
     ]
-    await execFileAsync('ffmpeg', ['-y', ...args])
+    await execFileAsync('ffmpeg', ['-y', '-loglevel', 'warning', ...args])
 
     const files = fs.readdirSync(params.outputDir)
     return files
@@ -370,7 +370,7 @@ export class TranscodeService {
           '80',
           localShotPath,
         ]
-        await execFileAsync('ffmpeg', ['-y', ...args])
+        await execFileAsync('ffmpeg', ['-y', '-loglevel', 'warning', ...args])
 
         // 5. Overlay annotations if timestamp matches commentTimestamp exactly
         if (

--- a/packages/core/src/upload/upload.ts
+++ b/packages/core/src/upload/upload.ts
@@ -294,33 +294,6 @@ export class UploadService {
       })
     }
 
-    // Ai Embedding if enabled via agent
-    const embeddingAgent = await tx.agent.findFirst({
-      where: {
-        type: 'embedding',
-        enabled: true,
-        user: { teamMembers: { some: { teamId: team.id } } },
-      },
-    })
-
-    if (embeddingAgent) {
-      if (asset.mediaType?.startsWith('video/') || asset.mediaType?.startsWith('image/')) {
-        await tx.workflowTask.create({
-          data: {
-            assetId: asset.id,
-            type: WorkflowTaskType.ai_embedding,
-            status: WorkflowTaskStatus.pending,
-            teamId: team.id,
-            projectId,
-            payload: {
-              projectId,
-              agent: { agentId: embeddingAgent.id },
-            },
-          },
-        })
-      }
-    }
-
     const isVideo = asset.mediaType?.startsWith('video/')
     const isImage = asset.mediaType?.startsWith('image/')
     if (!isVideo && !isImage) {

--- a/packages/transcode/src/activities/transcode.test.ts
+++ b/packages/transcode/src/activities/transcode.test.ts
@@ -4,6 +4,11 @@ import { prisma } from '@shumai/db'
 import { setupTestDbHooks } from '@shumai/db/test'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { transcodeService } from '@shumai/core'
+import * as child_process from 'child_process'
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+}))
 import {
   getMediaInfoActivity,
   overlayAnnotationsActivity,
@@ -13,6 +18,8 @@ import {
   downloadMediaToTmpActivity,
   transcodeImageActivity,
   generateSpriteActivity,
+  transcodeVideoChunkActivity,
+  deleteS3ObjectActivity,
 } from './transcode'
 
 vi.mock('@shumai/core/src/s3/s3', () => ({
@@ -22,6 +29,7 @@ vi.mock('@shumai/core/src/s3/s3', () => ({
     headObject: vi.fn(),
     presign: vi.fn(),
     downloadToFile: vi.fn(),
+    deleteObject: vi.fn(),
   },
 }))
 
@@ -363,6 +371,58 @@ describe('Transcode Activities', () => {
           annotations: [],
         }),
       ).rejects.toThrowError(/Overlay annotations failed/)
+    })
+  })
+
+  describe('Video Chunk Activities', () => {
+    it('should transcode video chunk using ffmpeg and upload to S3', async () => {
+      // Mock child_process.execFile to simulate ffmpeg succeeding
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(child_process.execFile as any).mockImplementation(
+        (file: string, args: string[], cb: any) => {
+          cb(null, { stdout: '', stderr: '' })
+        },
+      )
+
+      const res = await transcodeVideoChunkActivity({
+        assetId: 'asset-abc',
+        filePath: '/tmp/full-video.mp4',
+        startTime: 10,
+        endTime: 25,
+      })
+
+      // Verify ffmpeg command args
+      expect(child_process.execFile).toHaveBeenCalledWith(
+        'ffmpeg',
+        expect.arrayContaining([
+          '-y',
+          '-i',
+          '/tmp/full-video.mp4',
+          '-ss',
+          '10',
+          '-t',
+          '15',
+          '-c',
+          'copy',
+        ]),
+        expect.any(Function),
+      )
+
+      // Verify S3 upload
+      expect(s3Service.putObject).toHaveBeenCalledWith(
+        'shumai',
+        expect.stringMatching(/^files\/asset-abc\/tmp-embedding-chunks\/chunk-10-25-.*\.mp4$/),
+        expect.any(Buffer),
+        expect.any(Number),
+        'video/mp4',
+      )
+
+      expect(res.chunkKey).toMatch(/^files\/asset-abc\/tmp-embedding-chunks\/chunk-10-25-.*\.mp4$/)
+    })
+
+    it('should delete S3 object successfully', async () => {
+      await deleteS3ObjectActivity({ key: 'files/test-key.mp4' })
+      expect(s3Service.deleteObject).toHaveBeenCalledWith('shumai', 'files/test-key.mp4')
     })
   })
 })

--- a/packages/transcode/src/activities/transcode.test.ts
+++ b/packages/transcode/src/activities/transcode.test.ts
@@ -379,7 +379,11 @@ describe('Transcode Activities', () => {
       // Mock child_process.execFile to simulate ffmpeg succeeding
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ;(child_process.execFile as any).mockImplementation(
-        (file: string, args: string[], cb: any) => {
+        (
+          file: string,
+          args: string[],
+          cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+        ) => {
           cb(null, { stdout: '', stderr: '' })
         },
       )

--- a/packages/transcode/src/activities/transcode.ts
+++ b/packages/transcode/src/activities/transcode.ts
@@ -1,4 +1,4 @@
-import { prisma } from '@shumai/db'
+import { prisma, WorkflowTaskType, WorkflowTaskStatus } from '@shumai/db'
 import { s3Service } from '@shumai/core/src/s3/s3'
 import { transcodeService } from '@shumai/core'
 import { metadataService } from '@shumai/core/src/metadata/metadata'
@@ -467,4 +467,75 @@ export async function overlayAnnotationsActivity(params: {
     }
     throw err
   }
+}
+
+export interface CreateEmbeddingTaskIfEnabledParams {
+  assetId: string
+  teamId: string | null
+  projectId: string | null
+}
+
+export async function createEmbeddingTaskIfEnabledActivity(
+  params: CreateEmbeddingTaskIfEnabledParams,
+): Promise<void> {
+  let teamId = params.teamId
+  let projectId = params.projectId
+
+  // Resolve teamId and projectId from asset if missing
+  if (!teamId || !projectId) {
+    const asset = await prisma.asset.findUnique({
+      where: { id: params.assetId },
+      include: {
+        project: true,
+      },
+    })
+    if (asset) {
+      projectId = projectId || asset.projectId
+      teamId = teamId || asset.project?.teamId || null
+    }
+  }
+
+  if (!teamId) {
+    return
+  }
+
+  // Check if there is an active embedding agent for the team
+  const embeddingAgent = await prisma.agent.findFirst({
+    where: {
+      type: 'embedding',
+      enabled: true,
+      user: { teamMembers: { some: { teamId } } },
+    },
+  })
+
+  if (!embeddingAgent) {
+    return
+  }
+
+  // Check if a pending/processing embedding task already exists for this asset to avoid duplicates
+  const existing = await prisma.workflowTask.findFirst({
+    where: {
+      assetId: params.assetId,
+      type: WorkflowTaskType.ai_embedding,
+      status: { in: [WorkflowTaskStatus.pending, WorkflowTaskStatus.processing] },
+    },
+  })
+  if (existing) {
+    return
+  }
+
+  // Create embedding task
+  await prisma.workflowTask.create({
+    data: {
+      assetId: params.assetId,
+      type: WorkflowTaskType.ai_embedding,
+      status: WorkflowTaskStatus.pending,
+      teamId,
+      projectId,
+      payload: {
+        projectId: projectId ?? '',
+        agent: { agentId: embeddingAgent.id },
+      },
+    },
+  })
 }

--- a/packages/transcode/src/activities/transcode.ts
+++ b/packages/transcode/src/activities/transcode.ts
@@ -561,6 +561,8 @@ export async function transcodeVideoChunkActivity(
     // Slice video segment using ffmpeg
     await execFileAsync('ffmpeg', [
       '-y',
+      '-loglevel',
+      'warning',
       '-i',
       params.filePath,
       '-ss',

--- a/packages/transcode/src/activities/transcode.ts
+++ b/packages/transcode/src/activities/transcode.ts
@@ -5,6 +5,12 @@ import { metadataService } from '@shumai/core/src/metadata/metadata'
 import { ApplicationFailure } from '@temporalio/activity'
 import * as path from 'path'
 import * as fs from 'fs'
+import * as os from 'os'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { ulid } from 'ulid'
+
+const execFileAsync = promisify(execFile)
 
 export interface GetMediaInfoActivityParams {
   assetId: string
@@ -538,4 +544,60 @@ export async function createEmbeddingTaskIfEnabledActivity(
       },
     },
   })
+}
+
+export interface TranscodeVideoChunkParams {
+  assetId: string
+  filePath: string
+  startTime: number
+  endTime: number
+}
+
+export async function transcodeVideoChunkActivity(
+  params: TranscodeVideoChunkParams,
+): Promise<{ chunkKey: string }> {
+  const chunkTmp = path.join(os.tmpdir(), `video-chunk-${Date.now()}.mp4`)
+  try {
+    // Slice video segment using ffmpeg
+    await execFileAsync('ffmpeg', [
+      '-y',
+      '-i',
+      params.filePath,
+      '-ss',
+      params.startTime.toString(),
+      '-t',
+      (params.endTime - params.startTime).toString(),
+      '-c',
+      'copy',
+      chunkTmp,
+    ])
+
+    const chunkData = fs.readFileSync(chunkTmp)
+
+    // Upload to S3
+    const bucket = process.env.S3_BUCKET || 'shumai'
+    const key = `files/${params.assetId}/tmp-embedding-chunks/chunk-${params.startTime}-${params.endTime}-${ulid()}.mp4`
+
+    await s3Service.putObject(bucket, key, chunkData, chunkData.length, 'video/mp4')
+
+    return { chunkKey: key }
+  } catch (err) {
+    throw ApplicationFailure.create({
+      message: `Failed to transcode video chunk for ${params.startTime}-${params.endTime}: ${err instanceof Error ? err.message : String(err)}`,
+      nonRetryable: false,
+    })
+  } finally {
+    if (fs.existsSync(chunkTmp)) {
+      try {
+        fs.unlinkSync(chunkTmp)
+      } catch (e) {
+        console.error('Failed to cleanup local chunk file:', e)
+      }
+    }
+  }
+}
+
+export async function deleteS3ObjectActivity(params: { key: string }): Promise<void> {
+  const bucket = process.env.S3_BUCKET || 'shumai'
+  await s3Service.deleteObject(bucket, params.key)
 }

--- a/packages/transcode/src/workflows/transcode.test.ts
+++ b/packages/transcode/src/workflows/transcode.test.ts
@@ -41,6 +41,9 @@ describe('Transcode Workflow', () => {
     overlayAnnotationsActivity: Object.assign(vi.fn(), {
       _activityName: 'overlayAnnotationsActivity',
     }),
+    createEmbeddingTaskIfEnabledActivity: Object.assign(vi.fn(), {
+      _activityName: 'createEmbeddingTaskIfEnabledActivity',
+    }),
   }
 
   beforeEach(() => {
@@ -134,6 +137,12 @@ describe('Transcode Workflow', () => {
       status: AssetStatus.processed,
     })
 
+    expect(mockActivities.createEmbeddingTaskIfEnabledActivity).toHaveBeenCalledWith({
+      assetId: 'asset-1',
+      teamId: 'team-1',
+      projectId: 'proj-1',
+    })
+
     expect(mockActivities.updateTaskStatusActivity).toHaveBeenCalledWith({
       taskId: 'task-1',
       status: WorkflowTaskStatus.completed,
@@ -204,6 +213,12 @@ describe('Transcode Workflow', () => {
     expect(mockActivities.updateAssetStatusActivity).toHaveBeenCalledWith({
       assetId: 'asset-image',
       status: AssetStatus.processed,
+    })
+
+    expect(mockActivities.createEmbeddingTaskIfEnabledActivity).toHaveBeenCalledWith({
+      assetId: 'asset-image',
+      teamId: 'team-1',
+      projectId: 'proj-1',
     })
   })
 

--- a/packages/transcode/src/workflows/transcode.ts
+++ b/packages/transcode/src/workflows/transcode.ts
@@ -18,6 +18,7 @@ export async function transcodeMedia(task: WorkflowTask): Promise<void> {
     cleanupTmpDirActivity,
     takeScreenshotsActivity,
     overlayAnnotationsActivity,
+    createEmbeddingTaskIfEnabledActivity,
   } = getActivities()
 
   let tmpDir: string | undefined
@@ -243,6 +244,13 @@ export async function transcodeMedia(task: WorkflowTask): Promise<void> {
     await executeActivity(workerQueue, updateAssetStatusActivity, {
       assetId: asset.id,
       status: 'processed',
+    })
+
+    // 11.5 Create AI embedding task if enabled
+    await executeActivity(workerQueue, createEmbeddingTaskIfEnabledActivity, {
+      assetId: asset.id,
+      teamId: task.teamId,
+      projectId: task.projectId,
     })
 
     // 12. Update Task Status


### PR DESCRIPTION
## Summary

This PR improves the robustness, speed, and reliability of the vector embedding workflow for uploaded media (videos and images).

## Changes

- **Deferred Embedding Execution**: Removed the `WorkflowTaskType.ai_embedding` generation from the upload confirm layer (`packages/core/src/upload/upload.ts`) and deferred it to a new activity (`createEmbeddingTaskIfEnabledActivity`) executed at the very end of the transcode workflow (`packages/transcode/src/workflows/transcode.ts`).
- **Use Transcoded Assets**: Modified the `agentEmbeddingMedia` workflow (`packages/agent/src/workflows/agent-embedding.ts`) to fetch and download the first non-raw transcode for both images and videos (rather than original files) to speed up S3 fetching and Gemini API processing.
- **Separate Chunk Embedding Activities**: Refactored video chunk embedding (`packages/agent/src/activities/ai.ts`) to invoke a separate activity execution (`generateVideoChunkEmbeddingActivity`) per chunk. This ensures Temporal rate limit retries and failures do not restart the entire video indexing.
- **Configurable Chunk Duration**: Introduced support for the `EMBEDDING_CHUNK_DURATION` environment variable (default: 60.0), safely retrieved via `getEmbeddingContextActivity` to respect Temporal determinism.
- **Documentation**: Updated environment variables documentation and embedding agent guides.

## Verification

- **Tests Run**: Checked that all unit and integration tests compile and run successfully (`bun run test`). Updated existing embedding and transcode tests to assert correct mocks and calls for the new activity boundaries.
- **Type Checking**: Validated type safety with zero errors (`bun run typecheck`).
- **Linter & Formatter**: Ran linter (`bun run lint`) and formatted the codebase (`bun run format`).

## Notes

- Deprecated `generateEmbeddingActivity` to support standard fallback options if needed, but transitioned the default workflow path to the new image/video chunk specific activities.
