### PR TITLE
feat(webui): add external drag-and-drop file and folder upload support

### DIFF
--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -14,8 +14,9 @@ import { useFieldStore } from '@/ui/stores/fields'
 import { useUploadStore } from '@/ui/stores/upload'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
-import { Download, AlertTriangle, Loader2 } from 'lucide-react'
+import { Download, AlertTriangle, Loader2, UploadCloud } from 'lucide-react'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { getAllFilesFromEntries } from '@/ui/lib/dnd-utils'
 import { toast } from 'sonner'
 import type { DragState } from '../dnd-types'
 import { MoveCopyDialog } from '../move-copy-dialog'
@@ -137,6 +138,66 @@ export function FileBrowser({
   const [itemsToMoveCopy, setItemsToMoveCopy] = useState<AssetInfo[]>([])
   const queryClient = useQueryClient()
   const navigate = useNavigate()
+
+  const [isExternalDragging, setIsExternalDragging] = useState(false)
+  const [externalOverFolderId, setExternalOverFolderId] = useState<string | null>(null)
+  const dragCounter = useRef(0)
+
+  // Prevent default window behavior to avoid browser replacing page on accidental drops
+  useEffect(() => {
+    const preventDefault = (e: DragEvent) => {
+      e.preventDefault()
+    }
+    window.addEventListener('dragover', preventDefault)
+    window.addEventListener('drop', preventDefault)
+    return () => {
+      window.removeEventListener('dragover', preventDefault)
+      window.removeEventListener('drop', preventDefault)
+    }
+  }, [])
+
+  const handleGlobalDragEnter = (e: React.DragEvent) => {
+    if (!canEdit || isRecentlyDeleted) return
+    e.preventDefault()
+    if (e.dataTransfer.types.includes('Files')) {
+      dragCounter.current++
+      setIsExternalDragging(true)
+    }
+  }
+
+  const handleGlobalDragLeave = (e: React.DragEvent) => {
+    if (!canEdit || isRecentlyDeleted) return
+    e.preventDefault()
+    if (e.dataTransfer.types.includes('Files')) {
+      dragCounter.current--
+      if (dragCounter.current <= 0) {
+        dragCounter.current = 0
+        setIsExternalDragging(false)
+        setExternalOverFolderId(null)
+      }
+    }
+  }
+
+  const handleGlobalDragOver = (e: React.DragEvent) => {
+    if (!canEdit || isRecentlyDeleted) return
+    e.preventDefault()
+  }
+
+  const handleGlobalDrop = async (e: React.DragEvent) => {
+    if (!canEdit || isRecentlyDeleted) return
+    e.preventDefault()
+    e.stopPropagation()
+
+    const files = await getAllFilesFromEntries(e.dataTransfer)
+
+    setIsExternalDragging(false)
+    setExternalOverFolderId(null)
+    dragCounter.current = 0
+
+    if (files.length > 0) {
+      processAndUploadFiles(files)
+    }
+  }
 
   const [localUploadingFiles, setLocalUploadingFiles] = useState<AssetInfo[]>([])
 
@@ -550,6 +611,12 @@ export function FileBrowser({
       isShareView,
       fields: displayedFields,
       canEdit,
+      isExternalDragging,
+      externalOverFolderId,
+      setExternalOverFolderId,
+      onExternalDrop: (files: File[], folderId: string) => {
+        processAndUploadFiles(files, folderId)
+      },
     }
     if (displayStyle === 'card') {
       if (effectiveType === 'folder') return <FolderCard key={item.id} {...props} />
@@ -812,6 +879,10 @@ export function FileBrowser({
           <div
             className="flex-1 bg-background relative flex flex-col min-h-0 overflow-hidden"
             onContextMenu={(e) => onContextMenu(e)}
+            onDragEnter={handleGlobalDragEnter}
+            onDragLeave={handleGlobalDragLeave}
+            onDragOver={handleGlobalDragOver}
+            onDrop={handleGlobalDrop}
           >
             {!isShareView && !isPublic && onFilterChange && onSortChange && (
               <FileBrowserToolbar
@@ -886,6 +957,10 @@ export function FileBrowser({
                   handleEmptyAreaClick={handleEmptyAreaClick}
                   dragState={dragState}
                   sort={sort}
+                  isExternalDragging={isExternalDragging}
+                  externalOverFolderId={externalOverFolderId}
+                  setExternalOverFolderId={setExternalOverFolderId}
+                  onExternalDrop={(files, folderId) => processAndUploadFiles(files, folderId)}
                 />
               ) : (
                 <FileBrowserGridView
@@ -968,6 +1043,16 @@ export function FileBrowser({
                   <Download className="h-4 w-4" />
                   Download
                 </Button>
+              </div>
+            )}
+            {isExternalDragging && !externalOverFolderId && (
+              <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-50 pointer-events-none animate-in fade-in slide-in-from-bottom-4 duration-300">
+                <div className="flex items-center gap-3 px-6 py-3 rounded-full bg-primary text-primary-foreground shadow-lg shadow-primary/20 border border-primary/20 backdrop-blur-md">
+                  <UploadCloud className="h-5 w-5 animate-bounce" />
+                  <span className="font-medium text-sm">
+                    Drop here to upload files to the current folder
+                  </span>
+                </div>
               </div>
             )}
           </div>

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -8,12 +8,12 @@ import { formatSize } from '@/ui/lib/format'
 import { useFieldStore } from '@/ui/stores/fields'
 import { useUploadStore } from '@/ui/stores/upload'
 import type {
-    AssetInfo,
-    CollectionInfo,
-    CreateUploadTaskRequest,
-    SearchCondition,
-    SearchSort,
-    ShareLinkInfo,
+  AssetInfo,
+  CollectionInfo,
+  CreateUploadTaskRequest,
+  SearchCondition,
+  SearchSort,
+  ShareLinkInfo,
 } from '@shumai/dtos'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
@@ -26,24 +26,24 @@ import { MoveCopyDialog } from '../move-copy-dialog'
 import { FileBrowserContextMenu } from './context-menu'
 
 import {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
 } from '../ui/alert-dialog'
 import { Button } from '../ui/button'
 import { ContextMenu, ContextMenuTrigger } from '../ui/context-menu'
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
 } from '../ui/dialog'
 import { FileCard } from './file-card'
 import { FileListItem } from './file-list-item'
@@ -166,7 +166,7 @@ export function FileBrowser({
   }, [])
 
   const handleGlobalDragEnter = (e: React.DragEvent) => {
-    if (!canEdit || isRecentlyDeleted) return
+    if (!canEdit || isRecentlyDeleted || isShareView || isPublic || !!collection) return
     e.preventDefault()
     if (e.dataTransfer.types.includes('Files')) {
       dragCounter.current++
@@ -175,7 +175,7 @@ export function FileBrowser({
   }
 
   const handleGlobalDragLeave = (e: React.DragEvent) => {
-    if (!canEdit || isRecentlyDeleted) return
+    if (!canEdit || isRecentlyDeleted || isShareView || isPublic || !!collection) return
     e.preventDefault()
     if (e.dataTransfer.types.includes('Files')) {
       dragCounter.current--
@@ -188,12 +188,12 @@ export function FileBrowser({
   }
 
   const handleGlobalDragOver = (e: React.DragEvent) => {
-    if (!canEdit || isRecentlyDeleted) return
+    if (!canEdit || isRecentlyDeleted || isShareView || isPublic || !!collection) return
     e.preventDefault()
   }
 
   const handleGlobalDrop = async (e: React.DragEvent) => {
-    if (!canEdit || isRecentlyDeleted) return
+    if (!canEdit || isRecentlyDeleted || isShareView || isPublic || !!collection) return
     e.preventDefault()
     e.stopPropagation()
 

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -2,46 +2,49 @@
 import { client } from '@/ui/api/client'
 import type { InferRequestType, InferResponseType } from 'hono/client'
 
-import type { AssetInfo } from '@shumai/dtos'
-import type { CollectionInfo } from '@shumai/dtos'
-import type { SearchCondition, SearchSort } from '@shumai/dtos'
-import type { ShareLinkInfo } from '@shumai/dtos'
-import type { CreateUploadTaskRequest } from '@shumai/dtos'
-import { formatSize } from '@/ui/lib/format'
-import { ulid } from 'ulid'
 import { usePermissions } from '@/ui/hooks/use-permissions'
+import { getAllFilesFromEntries } from '@/ui/lib/dnd-utils'
+import { formatSize } from '@/ui/lib/format'
 import { useFieldStore } from '@/ui/stores/fields'
 import { useUploadStore } from '@/ui/stores/upload'
+import type {
+    AssetInfo,
+    CollectionInfo,
+    CreateUploadTaskRequest,
+    SearchCondition,
+    SearchSort,
+    ShareLinkInfo,
+} from '@shumai/dtos'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
-import { Download, AlertTriangle, Loader2, UploadCloud } from 'lucide-react'
+import { AlertTriangle, Download, Loader2 } from 'lucide-react'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { getAllFilesFromEntries } from '@/ui/lib/dnd-utils'
 import { toast } from 'sonner'
+import { ulid } from 'ulid'
 import type { DragState } from '../dnd-types'
 import { MoveCopyDialog } from '../move-copy-dialog'
 import { FileBrowserContextMenu } from './context-menu'
 
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
 } from '../ui/alert-dialog'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '../ui/dialog'
 import { Button } from '../ui/button'
 import { ContextMenu, ContextMenuTrigger } from '../ui/context-menu'
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '../ui/dialog'
 import { FileCard } from './file-card'
 import { FileListItem } from './file-list-item'
 import { FolderCard } from './folder-card'
@@ -143,6 +146,12 @@ export function FileBrowser({
   const [externalOverFolderId, setExternalOverFolderId] = useState<string | null>(null)
   const dragCounter = useRef(0)
 
+  const resetExternalDragState = useCallback(() => {
+    setIsExternalDragging(false)
+    setExternalOverFolderId(null)
+    dragCounter.current = 0
+  }, [])
+
   // Prevent default window behavior to avoid browser replacing page on accidental drops
   useEffect(() => {
     const preventDefault = (e: DragEvent) => {
@@ -190,9 +199,7 @@ export function FileBrowser({
 
     const files = await getAllFilesFromEntries(e.dataTransfer)
 
-    setIsExternalDragging(false)
-    setExternalOverFolderId(null)
-    dragCounter.current = 0
+    resetExternalDragState()
 
     if (files.length > 0) {
       processAndUploadFiles(files)
@@ -614,6 +621,7 @@ export function FileBrowser({
       isExternalDragging,
       externalOverFolderId,
       setExternalOverFolderId,
+      resetExternalDragState,
       onExternalDrop: (files: File[], folderId: string) => {
         processAndUploadFiles(files, folderId)
       },
@@ -960,6 +968,7 @@ export function FileBrowser({
                   isExternalDragging={isExternalDragging}
                   externalOverFolderId={externalOverFolderId}
                   setExternalOverFolderId={setExternalOverFolderId}
+                  resetExternalDragState={resetExternalDragState}
                   onExternalDrop={(files, folderId) => processAndUploadFiles(files, folderId)}
                 />
               ) : (
@@ -1047,11 +1056,8 @@ export function FileBrowser({
             )}
             {isExternalDragging && !externalOverFolderId && (
               <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-50 pointer-events-none animate-in fade-in slide-in-from-bottom-4 duration-300">
-                <div className="flex items-center gap-3 px-6 py-3 rounded-full bg-primary text-primary-foreground shadow-lg shadow-primary/20 border border-primary/20 backdrop-blur-md">
-                  <UploadCloud className="h-5 w-5 animate-bounce" />
-                  <span className="font-medium text-sm">
-                    Drop here to upload files to the current folder
-                  </span>
+                <div className="flex items-center gap-3 px-6 py-3 rounded-full bg-primary/80 text-primary-foreground shadow-lg shadow-primary/20 border border-primary/20 backdrop-blur-md">
+                  <span className="font-medium text-sm">Drop files here to upload</span>
                 </div>
               </div>
             )}

--- a/packages/webui/components/file-browser/folder-card.tsx
+++ b/packages/webui/components/file-browser/folder-card.tsx
@@ -42,6 +42,7 @@ interface FolderCardProps {
   isExternalDragging?: boolean
   externalOverFolderId?: string | null
   setExternalOverFolderId?: (id: string | null) => void
+  resetExternalDragState?: () => void
   onExternalDrop?: (files: File[], folderId: string) => void
 }
 
@@ -122,6 +123,7 @@ export function FolderCard({
   isExternalDragging,
   externalOverFolderId,
   setExternalOverFolderId,
+  resetExternalDragState,
   onExternalDrop,
 }: FolderCardProps) {
   const [name, setName] = useState(item.name || '')
@@ -262,7 +264,7 @@ export function FolderCard({
           ? async (e) => {
               e.preventDefault()
               e.stopPropagation()
-              setExternalOverFolderId?.(null)
+              resetExternalDragState?.()
               const files = await getAllFilesFromEntries(e.dataTransfer)
               onExternalDrop?.(files, item.id!)
             }

--- a/packages/webui/components/file-browser/folder-card.tsx
+++ b/packages/webui/components/file-browser/folder-card.tsx
@@ -14,6 +14,7 @@ import { Download, Edit, History, MoreHorizontal, Trash2 } from 'lucide-react'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import type { DragState } from '../dnd-types'
 import { FilePreview } from './file-preview'
+import { getAllFilesFromEntries } from '@/ui/lib/dnd-utils'
 
 interface FolderCardProps {
   item: AssetInfo
@@ -38,6 +39,10 @@ interface FolderCardProps {
   selectedCount?: number
   canEdit?: boolean
   isShareView?: boolean
+  isExternalDragging?: boolean
+  externalOverFolderId?: string | null
+  setExternalOverFolderId?: (id: string | null) => void
+  onExternalDrop?: (files: File[], folderId: string) => void
 }
 
 const FolderPreviewGrid = ({ items }: { items: ChildPreview[] }) => {
@@ -114,6 +119,10 @@ export function FolderCard({
   selectedCount,
   canEdit = true,
   isShareView,
+  isExternalDragging,
+  externalOverFolderId,
+  setExternalOverFolderId,
+  onExternalDrop,
 }: FolderCardProps) {
   const [name, setName] = useState(item.name || '')
   const inputRef = useRef<HTMLInputElement>(null)
@@ -153,7 +162,8 @@ export function FolderCard({
     return true
   }, [dragState, item.id])
 
-  const showDropFeedback = isOver && isValidDropTarget
+  const isExternalOver = isExternalDragging && externalOverFolderId === item.id
+  const showDropFeedback = (isOver && isValidDropTarget) || isExternalOver
   const opacity = isBeingDragged ? 0.5 : 1
 
   useEffect(() => {
@@ -224,6 +234,40 @@ export function FolderCard({
           e.preventDefault()
         }
       }}
+      onDragEnter={
+        isExternalDragging
+          ? () => {
+              setExternalOverFolderId?.(item.id!)
+            }
+          : undefined
+      }
+      onDragLeave={
+        isExternalDragging
+          ? (e) => {
+              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                setExternalOverFolderId?.(null)
+              }
+            }
+          : undefined
+      }
+      onDragOver={
+        isExternalDragging
+          ? (e) => {
+              e.preventDefault()
+            }
+          : undefined
+      }
+      onDrop={
+        isExternalDragging
+          ? async (e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              setExternalOverFolderId?.(null)
+              const files = await getAllFilesFromEntries(e.dataTransfer)
+              onExternalDrop?.(files, item.id!)
+            }
+          : undefined
+      }
       className={cn(
         'group relative w-full max-w-[340px] select-none cursor-pointer isolate flex flex-col items-center h-full',
       )}

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -13,6 +13,7 @@ import React, { useMemo, useState, useEffect } from 'react'
 import { cn } from '../../lib/utils'
 import type { DragState } from '../dnd-types'
 import { Checkbox } from '../ui/checkbox'
+import { getAllFilesFromEntries } from '@/ui/lib/dnd-utils'
 
 interface ListRowProps {
   item: AssetInfo
@@ -23,6 +24,10 @@ interface ListRowProps {
   columnSizing?: Record<string, number>
   virtualRow: { start: number; index: number }
   measureElement: (el: HTMLElement | null) => void
+  isExternalDragging?: boolean
+  externalOverFolderId?: string | null
+  setExternalOverFolderId?: (id: string | null) => void
+  onExternalDrop?: (files: File[], folderId: string) => void
 }
 
 function ListRow({
@@ -34,6 +39,10 @@ function ListRow({
   columnSizing,
   virtualRow,
   measureElement,
+  isExternalDragging,
+  externalOverFolderId,
+  setExternalOverFolderId,
+  onExternalDrop,
 }: ListRowProps) {
   const isDraggingItem = dragState?.draggedIds.has(item.id!)
   const isDraggingAny = dragState?.isActive
@@ -83,7 +92,8 @@ function ListRow({
     return false
   }, [dragState, item.id, item.type])
 
-  const showDropFeedback = isRowOver && isValidDropTarget
+  const isExternalOver = isExternalDragging && externalOverFolderId === item.id
+  const showDropFeedback = (isRowOver && isValidDropTarget) || isExternalOver
 
   return (
     <div
@@ -92,6 +102,40 @@ function ListRow({
         measureElement(node)
       }}
       data-index={virtualRow.index}
+      onDragEnter={
+        isExternalDragging && item.type === 'folder'
+          ? () => {
+              setExternalOverFolderId?.(item.id!)
+            }
+          : undefined
+      }
+      onDragLeave={
+        isExternalDragging && item.type === 'folder'
+          ? (e) => {
+              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                setExternalOverFolderId?.(null)
+              }
+            }
+          : undefined
+      }
+      onDragOver={
+        isExternalDragging && item.type === 'folder'
+          ? (e) => {
+              e.preventDefault()
+            }
+          : undefined
+      }
+      onDrop={
+        isExternalDragging && item.type === 'folder'
+          ? async (e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              setExternalOverFolderId?.(null)
+              const files = await getAllFilesFromEntries(e.dataTransfer)
+              onExternalDrop?.(files, item.id!)
+            }
+          : undefined
+      }
       className={cn(
         'group border-b border-border transition-colors hover:bg-primary/20 absolute top-0 left-0 w-full flex flex-col',
         isSelected && 'bg-primary/10',
@@ -146,6 +190,10 @@ interface FileBrowserListViewProps {
   handleEmptyAreaClick: (e: React.MouseEvent) => void
   dragState?: DragState
   sort?: SearchSort
+  isExternalDragging?: boolean
+  externalOverFolderId?: string | null
+  setExternalOverFolderId?: (id: string | null) => void
+  onExternalDrop?: (files: File[], folderId: string) => void
 }
 
 export function FileBrowserListView({
@@ -174,6 +222,10 @@ export function FileBrowserListView({
   handleEmptyAreaClick,
   dragState,
   sort,
+  isExternalDragging,
+  externalOverFolderId,
+  setExternalOverFolderId,
+  onExternalDrop,
 }: FileBrowserListViewProps) {
   const [columnSizing, setColumnSizing] = useState<Record<string, number>>({})
 
@@ -459,6 +511,10 @@ export function FileBrowserListView({
                 columnSizing={columnSizing}
                 virtualRow={virtualRow}
                 measureElement={rowVirtualizer.measureElement}
+                isExternalDragging={isExternalDragging}
+                externalOverFolderId={externalOverFolderId}
+                setExternalOverFolderId={setExternalOverFolderId}
+                onExternalDrop={onExternalDrop}
               />
             )
           })}

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -27,6 +27,7 @@ interface ListRowProps {
   isExternalDragging?: boolean
   externalOverFolderId?: string | null
   setExternalOverFolderId?: (id: string | null) => void
+  resetExternalDragState?: () => void
   onExternalDrop?: (files: File[], folderId: string) => void
 }
 
@@ -42,6 +43,7 @@ function ListRow({
   isExternalDragging,
   externalOverFolderId,
   setExternalOverFolderId,
+  resetExternalDragState,
   onExternalDrop,
 }: ListRowProps) {
   const isDraggingItem = dragState?.draggedIds.has(item.id!)
@@ -130,7 +132,7 @@ function ListRow({
           ? async (e) => {
               e.preventDefault()
               e.stopPropagation()
-              setExternalOverFolderId?.(null)
+              resetExternalDragState?.()
               const files = await getAllFilesFromEntries(e.dataTransfer)
               onExternalDrop?.(files, item.id!)
             }
@@ -193,6 +195,7 @@ interface FileBrowserListViewProps {
   isExternalDragging?: boolean
   externalOverFolderId?: string | null
   setExternalOverFolderId?: (id: string | null) => void
+  resetExternalDragState?: () => void
   onExternalDrop?: (files: File[], folderId: string) => void
 }
 
@@ -225,6 +228,7 @@ export function FileBrowserListView({
   isExternalDragging,
   externalOverFolderId,
   setExternalOverFolderId,
+  resetExternalDragState,
   onExternalDrop,
 }: FileBrowserListViewProps) {
   const [columnSizing, setColumnSizing] = useState<Record<string, number>>({})
@@ -514,6 +518,7 @@ export function FileBrowserListView({
                 isExternalDragging={isExternalDragging}
                 externalOverFolderId={externalOverFolderId}
                 setExternalOverFolderId={setExternalOverFolderId}
+                resetExternalDragState={resetExternalDragState}
                 onExternalDrop={onExternalDrop}
               />
             )

--- a/packages/webui/lib/dnd-utils.ts
+++ b/packages/webui/lib/dnd-utils.ts
@@ -3,3 +3,114 @@ export function arrayMove<T>(array: T[], from: number, to: number): T[] {
   newArray.splice(to, 0, newArray.splice(from, 1)[0])
   return newArray
 }
+
+interface SafeFileSystemEntry {
+  name: string
+  isFile: boolean
+  isDirectory: boolean
+}
+
+interface SafeFileSystemFileEntry extends SafeFileSystemEntry {
+  file(successCallback: (file: File) => void, errorCallback?: (err: unknown) => void): void
+}
+
+interface SafeFileSystemDirectoryEntry extends SafeFileSystemEntry {
+  createReader(): SafeFileSystemDirectoryReader
+}
+
+interface SafeFileSystemDirectoryReader {
+  readEntries(
+    successCallback: (entries: SafeFileSystemEntry[]) => void,
+    errorCallback?: (err: unknown) => void,
+  ): void
+}
+
+/**
+ * Recursively retrieves all files from a DataTransfer object, traversing directories.
+ * Preserves the directory structure using the non-standard `webkitRelativePath` property on File objects.
+ */
+export async function getAllFilesFromEntries(dataTransfer: DataTransfer): Promise<File[]> {
+  const files: File[] = []
+
+  interface QueueItem {
+    entry: SafeFileSystemEntry
+    path: string
+  }
+
+  const queue: QueueItem[] = []
+  const items = dataTransfer.items
+
+  if (items) {
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]
+      if (item.kind === 'file') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const entry = (item as any).webkitGetAsEntry?.() as SafeFileSystemEntry | null
+        if (entry) {
+          queue.push({ entry, path: '' })
+        }
+      }
+    }
+  } else {
+    // Fallback if dataTransfer.items is not supported (only dataTransfer.files is available)
+    return Array.from(dataTransfer.files)
+  }
+
+  const readEntries = (
+    dirReader: SafeFileSystemDirectoryReader,
+  ): Promise<SafeFileSystemEntry[]> => {
+    return new Promise((resolve) => {
+      dirReader.readEntries(
+        (entries) => resolve(entries),
+        () => resolve([]),
+      )
+    })
+  }
+
+  const getFile = (fileEntry: SafeFileSystemFileEntry): Promise<File> => {
+    return new Promise((resolve, reject) => {
+      fileEntry.file(
+        (file) => resolve(file),
+        (err) => reject(err),
+      )
+    })
+  }
+
+  while (queue.length > 0) {
+    const next = queue.shift()
+    if (!next) continue
+    const { entry, path } = next
+
+    if (entry.isFile) {
+      try {
+        const file = await getFile(entry as SafeFileSystemFileEntry)
+        const relativePath = path ? `${path}/${file.name}` : file.name
+
+        // Define webkitRelativePath dynamically so processAndUploadFiles can read the structure
+        Object.defineProperty(file, 'webkitRelativePath', {
+          value: relativePath,
+          writable: false,
+          configurable: true,
+        })
+        files.push(file)
+      } catch (e) {
+        console.error('Error reading file entry:', e)
+      }
+    } else if (entry.isDirectory) {
+      const dirReader = (entry as SafeFileSystemDirectoryEntry).createReader()
+      let entries: SafeFileSystemEntry[] = []
+      let readBatch = await readEntries(dirReader)
+      while (readBatch.length > 0) {
+        entries = entries.concat(readBatch)
+        readBatch = await readEntries(dirReader)
+      }
+
+      const newPath = path ? `${path}/${entry.name}` : entry.name
+      for (const childEntry of entries) {
+        queue.push({ entry: childEntry, path: newPath })
+      }
+    }
+  }
+
+  return files
+}


### PR DESCRIPTION
## Summary

Allow users to drag and drop files and folders directly from their machine (external files) into the file list page.

## Changes

- Added `getAllFilesFromEntries` to recursively traverse dropped directories, read all nested files, and dynamically assign `webkitRelativePath` to preserve directory structure.
- Handled global dragenter, dragleave, dragover, and drop events in `FileBrowser` using a counter to prevent flickering.
- Prevented default window behavior on dragover and drop events to stop browser navigating away on accidental drops.
- Updated `FolderCard` (grid view) and `ListRow` (list view) to support highlighting and drop interactions when external drag is active.
- Added a high-fidelity glassmorphic bottom floating banner showing upload prompts when external files are dragged over non-folder areas.

## Verification

- Formatted the codebase: `bun run format` (passed)
- Clean lint checks: `bun run lint` (passed)
- Clean type checks: `bun run typecheck` (passed)
- Passed the Vitest test suite: `bun run test` (passed)

## Notes
None