### PR TITLE
feat(webui): support jumping to video timestamp from search results

### DIFF
--- a/docs/using-shumai/semantic-search.mdx
+++ b/docs/using-shumai/semantic-search.mdx
@@ -20,6 +20,14 @@ Semantic search translates text queries and file contents into conceptual profil
 2.  **Concept Matching**: When you search with the "Semantic" toggle enabled, Shumai matches the conceptual meaning of your query against your assets.
 3.  **Result**: Searching "sunset at the beach" will successfully find a video file of ocean waves at dusk, even if the filename is `IMG_4029.mp4`.
 
+### Understanding Search Results
+
+Semantic search works differently than traditional keyword filtering:
+
+- **Sort vs. Filter**: Semantic search acts more like a **sort** than a strict filter. While the most relevant results will appear at the top, less related content may still be present further down the list, ranked lower. If you need to exclude specific types of files, use the **Filter** panel in conjunction with semantic search.
+- **Video Chunks**: Because Shumai indexes videos in chunks, a single long video may appear multiple times in your search results. Each result corresponds to a specific segment of the video where the match was found.
+- **Match Timestamps**: When a search result comes from a video chunk, Shumai displays the matching start and end time. Clicking on these results will open the video and automatically jump to the relevant timestamp.
+
 ---
 
 ## Activating Semantic Search

--- a/packages/webui/components/file-viewer.tsx
+++ b/packages/webui/components/file-viewer.tsx
@@ -18,6 +18,7 @@ type FileViewerProps = {
   onPause?: () => void
   onTimeUpdate?: (time: number) => void
   annotations?: Annotation[]
+  startTime?: number
   children?: ReactNode
 }
 
@@ -28,6 +29,7 @@ export function FileViewer({
   onPause,
   onTimeUpdate,
   annotations,
+  startTime,
   children,
 }: FileViewerProps) {
   const { width: screenWidth } = useScreenSize()
@@ -308,6 +310,7 @@ export function FileViewer({
           onPause={onPause}
           onTimeUpdate={onTimeUpdate}
           annotations={displayAnnotations}
+          startTime={startTime}
         >
           {children}
         </VideoPlayer>

--- a/packages/webui/components/public-share-manager.tsx
+++ b/packages/webui/components/public-share-manager.tsx
@@ -33,12 +33,14 @@ interface PublicShareManagerProps {
   }
   initialFolderId?: string
   initialFileId?: string
+  startTime?: number
 }
 
 export function PublicShareManager({
   shareInfo,
   initialFolderId,
   initialFileId,
+  startTime,
 }: PublicShareManagerProps) {
   const navigate = useNavigate()
   const [password, setPassword] = useState(() => {
@@ -387,6 +389,7 @@ export function PublicShareManager({
                 onPlay={handlePlay}
                 onTimeUpdate={setCurrentTime}
                 annotations={annotations}
+                startTime={startTime}
               />
             )}
           </div>

--- a/packages/webui/components/search/search-filter-dialog.tsx
+++ b/packages/webui/components/search/search-filter-dialog.tsx
@@ -242,7 +242,10 @@ export function SearchFilterDialog({
       navigate({
         to: '/projects/$projectId/files/$fileId',
         params: { projectId, fileId: item.versionStack ? item.versionStack.id : item.id! },
-        search: { version: undefined },
+        search: {
+          version: undefined,
+          start: item.startTime && item.startTime > 0 ? item.startTime : undefined,
+        },
       })
     }
     onOpenChange(false)

--- a/packages/webui/components/viewers/video-player.tsx
+++ b/packages/webui/components/viewers/video-player.tsx
@@ -53,6 +53,7 @@ interface VideoPlayerProps {
   onPause?: () => void
   onTimeUpdate?: (time: number) => void
   annotations?: Annotation[]
+  startTime?: number
   children?: React.ReactNode
 }
 
@@ -311,6 +312,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   onPause,
   onTimeUpdate,
   annotations,
+  startTime,
   children,
 }) => {
   const localPlayerRef = useRef<Player | null>(null)
@@ -550,6 +552,13 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     // Set initial state
     player.volume(state.volume)
 
+    // Seek to startTime if provided
+    if (startTime && startTime > 0) {
+      player.ready(() => {
+        player.currentTime(startTime)
+      })
+    }
+
     // 4. Cleanup
     return () => {
       if (player && !player.isDisposed()) {
@@ -558,6 +567,18 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       }
     }
   }, [data])
+
+  // Handle changes to startTime (e.g., clicking different chunks in search results)
+  useEffect(() => {
+    const player = playerRef.current
+    if (player && startTime !== undefined && startTime !== null && startTime > 0) {
+      // Only seek if the difference is significant (e.g., > 1s) to avoid jumping due to small precision differences
+      const current = player.currentTime() || 0
+      if (Math.abs(current - startTime) > 1) {
+        player.currentTime(startTime)
+      }
+    }
+  }, [startTime, playerRef])
 
   // Smooth progress updates using requestAnimationFrame when playing
   useEffect(() => {

--- a/packages/webui/routes/projects/$projectId/files/$fileId.tsx
+++ b/packages/webui/routes/projects/$projectId/files/$fileId.tsx
@@ -21,7 +21,8 @@ import type Player from 'video.js/dist/types/player'
 function FileViewPage() {
   const { projectId, fileId } = Route.useParams()
   const search = Route.useSearch()
-  const versionAssetId = (search as { version?: string }).version
+  const versionAssetId = search.version
+  const startTime = search.start
   const activeFileId = versionAssetId || fileId
 
   const videoRef = useRef<Player | null>(null)
@@ -328,6 +329,7 @@ function FileViewPage() {
             onPlay={handlePlay}
             onTimeUpdate={setCurrentTime}
             annotations={annotations}
+            startTime={startTime}
           >
             {carouselState.show && (
               <FileViewerLeftSidebar
@@ -373,6 +375,7 @@ export const Route = createFileRoute('/projects/$projectId/files/$fileId')({
   validateSearch: (search: Record<string, unknown>) => {
     return {
       version: (search.version as string) || undefined,
-    }
+      start: search.start ? Number(search.start) : undefined,
+    } as { version?: string; start?: number }
   },
 })

--- a/packages/webui/routes/share/$shareId/files/$fileId.tsx
+++ b/packages/webui/routes/share/$shareId/files/$fileId.tsx
@@ -5,6 +5,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 function PublicShareFilePage() {
   const { shareId, fileId } = Route.useParams()
+  const { start } = Route.useSearch()
 
   const { data: shareInfo } = useQuery({
     queryKey: ['share-info', shareId],
@@ -27,10 +28,16 @@ function PublicShareFilePage() {
         isDisabled: shareInfo.isDisabled ?? false,
       }}
       initialFileId={fileId}
+      startTime={start}
     />
   )
 }
 
 export const Route = createFileRoute('/share/$shareId/files/$fileId')({
   component: PublicShareFilePage,
+  validateSearch: (search: Record<string, unknown>) => {
+    return {
+      start: search.start ? Number(search.start) : undefined,
+    } as { start?: number }
+  },
 })


### PR DESCRIPTION
## Summary
This PR adds support for jumping to a specific timestamp in a video when navigating from a semantic search result.

## Changes
- Added `start` parameter to file detail routes (`/projects//files/` and `/share//files/`).
- Propagated the `start` parameter through `FileViewer` to `VideoPlayer`.
- Implemented jump logic in `VideoPlayer` to seek to the specified timestamp on load and on parameter changes.
- Updated `SearchFilterDialog` to include the `start` parameter when clicking on video search results with match timestamps.
- Updated semantic search documentation to clarify behavior and video chunk results.

## Verification
- Ran `bun run lint` and `bun run typecheck` to ensure code quality and type safety.
- Verified changes in the browser by performing semantic searches and clicking on results with timestamps.