### PR TITLE
fix(db): automatically update project updatedAt on asset modification

### DIFF
--- a/docs/using-shumai/semantic-search.mdx
+++ b/docs/using-shumai/semantic-search.mdx
@@ -12,11 +12,11 @@ Traditional search relies on matching exact characters (e.g., searching "dog" wi
 Semantic search translates text queries and file contents into conceptual profiles. Similar ideas and visuals are mapped near each other.
 
 1.  **Index Generation**: When you upload an asset, Shumai's background agent scans the file's visual elements, text contents, or descriptions, translating them into a concept profile.
-    -   **Video Processing**: Shumai uses **gemini-embedding-2** for video indexing. 
-        -   **Chunking**: For long videos, Shumai breaks them into chunks to ensure high-quality indexing. By default, chunks are **60 seconds** long with a **5-second overlap** to ensure no context is lost at the boundaries.
-        -   **Sampling**: The model processes a maximum of 32 frames per chunk: short chunks (≤32s) are sampled at 1 fps, while longer chunks are uniformly sampled to 32 frames. 
-        -   **Optimization**: To optimize processing, Shumai automatically transcodes each chunk to **1 FPS** and **removes the audio track** before sending it to the embedding agent.
-        -   **Configuration**: Administrators can customize these settings using the `EMBEDDING_CHUNK_DURATION` and `EMBEDDING_CHUNK_OVERLAP` environment variables.
+    - **Video Processing**: Shumai uses **gemini-embedding-2** for video indexing.
+      - **Chunking**: For long videos, Shumai breaks them into chunks to ensure high-quality indexing. By default, chunks are **60 seconds** long with a **5-second overlap** to ensure no context is lost at the boundaries.
+      - **Sampling**: The model processes a maximum of 32 frames per chunk: short chunks (≤32s) are sampled at 1 fps, while longer chunks are uniformly sampled to 32 frames.
+      - **Optimization**: To optimize processing, Shumai automatically transcodes each chunk to **1 FPS** and **removes the audio track** before sending it to the embedding agent.
+      - **Configuration**: Administrators can customize these settings using the `EMBEDDING_CHUNK_DURATION` and `EMBEDDING_CHUNK_OVERLAP` environment variables.
 2.  **Concept Matching**: When you search with the "Semantic" toggle enabled, Shumai matches the conceptual meaning of your query against your assets.
 3.  **Result**: Searching "sunset at the beach" will successfully find a video file of ocean waves at dusk, even if the filename is `IMG_4029.mp4`.
 

--- a/packages/agent/src/activities/ai.ts
+++ b/packages/agent/src/activities/ai.ts
@@ -316,8 +316,7 @@ export async function getEmbeddingContextActivity(params: { teamId: string; asse
     Number.isFinite(parsedDuration) && parsedDuration > 0 ? parsedDuration : 60.0
 
   const parsedOverlap = parseFloat(process.env.EMBEDDING_CHUNK_OVERLAP || '')
-  const chunkOverlap =
-    Number.isFinite(parsedOverlap) && parsedOverlap >= 0 ? parsedOverlap : 5.0
+  const chunkOverlap = Number.isFinite(parsedOverlap) && parsedOverlap >= 0 ? parsedOverlap : 5.0
 
   return {
     agent,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,7 +1,7 @@
-import { PrismaClient, WorkflowTask } from './generated/prisma/client'
-import { PrismaTestingHelper } from './prisma-testing-helper'
 import { PrismaPg } from '@prisma/adapter-pg'
 import { Pool } from 'pg'
+import { PrismaClient, WorkflowTask } from './generated/prisma/client'
+import { PrismaTestingHelper } from './prisma-testing-helper'
 import { generateNgrams } from './utils/ngram'
 
 // Global callback for workflow task creation (decouples db package from workflow engine)
@@ -27,27 +27,6 @@ function createPrismaClient() {
   const adapter = new PrismaPg(pool)
   const client = new PrismaClient({ adapter, log: ['error'] })
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function touchProjectsByAssetWhere(assetWhere: any) {
-    if (!assetWhere) return
-    client.project
-      .updateMany({
-        where: { assets: { some: assetWhere } },
-        data: { updatedAt: new Date() },
-      })
-      .catch((e) => console.error('Failed to touch project updatedAt by asset where', e))
-  }
-
-  function touchProjectById(projectId: string) {
-    if (!projectId) return
-    client.project
-      .updateMany({
-        where: { id: projectId },
-        data: { updatedAt: new Date() },
-      })
-      .catch((e) => console.error('Failed to touch project updatedAt by id', e))
-  }
-
   return client.$extends({
     query: {
       workflowTask: {
@@ -64,24 +43,7 @@ function createPrismaClient() {
           if (typeof args.data.name === 'string') {
             args.data.nameNgram = generateNgrams(args.data.name)
           }
-          const result = await query(args)
-          // Use any here because result and args.data are complex Prisma types in extensions
-          const projectId =
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (result as any)?.projectId ||
-            args.data?.projectId ||
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (args.data?.project as any)?.connect?.id
-          if (projectId) {
-            touchProjectById(projectId)
-          } else if (
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (result as any)?.id
-          ) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            touchProjectsByAssetWhere({ id: (result as any).id })
-          }
-          return result
+          return query(args)
         },
         async update({ args, query }) {
           if (typeof args.data.name === 'string') {
@@ -89,7 +51,10 @@ function createPrismaClient() {
           }
           const result = await query(args)
           if (args.where) {
-            touchProjectsByAssetWhere(args.where)
+            await client.project.updateMany({
+              where: { assets: { some: args.where } },
+              data: { updatedAt: new Date() },
+            })
           }
           return result
         },
@@ -100,21 +65,13 @@ function createPrismaClient() {
           if (typeof args.update.name === 'string') {
             args.update.nameNgram = generateNgrams(args.update.name)
           }
-          const result = await query(args)
-          if (args.where) {
-            touchProjectsByAssetWhere(args.where)
-          }
-          return result
+          return query(args)
         },
         async updateMany({ args, query }) {
           if (typeof args.data.name === 'string') {
             args.data.nameNgram = generateNgrams(args.data.name)
           }
-          const result = await query(args)
-          if (args.where) {
-            touchProjectsByAssetWhere(args.where)
-          }
-          return result
+          return query(args)
         },
         async createMany({ args, query }) {
           if (Array.isArray(args.data)) {
@@ -124,27 +81,7 @@ function createPrismaClient() {
               }
             }
           }
-          const result = await query(args)
-          const projectIds = new Set<string>()
-          if (Array.isArray(args.data)) {
-            for (const item of args.data) {
-              if (item.projectId) projectIds.add(item.projectId)
-            }
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          } else if ((args.data as any)?.projectId) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            projectIds.add((args.data as any).projectId)
-          }
-
-          if (projectIds.size > 0) {
-            client.project
-              .updateMany({
-                where: { id: { in: Array.from(projectIds) } },
-                data: { updatedAt: new Date() },
-              })
-              .catch((e) => console.error('Failed to touch projects by createMany', e))
-          }
-          return result
+          return query(args)
         },
       },
     },
@@ -166,5 +103,5 @@ export function getPrismaTestingHelper() {
   return prismaTestingHelper
 }
 
-export * from './utils/ngram'
 export * from './generated/prisma/client'
+export * from './utils/ngram'

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -26,6 +26,28 @@ function createPrismaClient() {
   const pool = new Pool({ connectionString })
   const adapter = new PrismaPg(pool)
   const client = new PrismaClient({ adapter, log: ['error'] })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function touchProjectsByAssetWhere(assetWhere: any) {
+    if (!assetWhere) return
+    client.project
+      .updateMany({
+        where: { assets: { some: assetWhere } },
+        data: { updatedAt: new Date() },
+      })
+      .catch((e) => console.error('Failed to touch project updatedAt by asset where', e))
+  }
+
+  function touchProjectById(projectId: string) {
+    if (!projectId) return
+    client.project
+      .updateMany({
+        where: { id: projectId },
+        data: { updatedAt: new Date() },
+      })
+      .catch((e) => console.error('Failed to touch project updatedAt by id', e))
+  }
+
   return client.$extends({
     query: {
       workflowTask: {
@@ -42,13 +64,34 @@ function createPrismaClient() {
           if (typeof args.data.name === 'string') {
             args.data.nameNgram = generateNgrams(args.data.name)
           }
-          return query(args)
+          const result = await query(args)
+          // Use any here because result and args.data are complex Prisma types in extensions
+          const projectId =
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (result as any)?.projectId ||
+            args.data?.projectId ||
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (args.data?.project as any)?.connect?.id
+          if (projectId) {
+            touchProjectById(projectId)
+          } else if (
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (result as any)?.id
+          ) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            touchProjectsByAssetWhere({ id: (result as any).id })
+          }
+          return result
         },
         async update({ args, query }) {
           if (typeof args.data.name === 'string') {
             args.data.nameNgram = generateNgrams(args.data.name)
           }
-          return query(args)
+          const result = await query(args)
+          if (args.where) {
+            touchProjectsByAssetWhere(args.where)
+          }
+          return result
         },
         async upsert({ args, query }) {
           if (typeof args.create.name === 'string') {
@@ -57,13 +100,21 @@ function createPrismaClient() {
           if (typeof args.update.name === 'string') {
             args.update.nameNgram = generateNgrams(args.update.name)
           }
-          return query(args)
+          const result = await query(args)
+          if (args.where) {
+            touchProjectsByAssetWhere(args.where)
+          }
+          return result
         },
         async updateMany({ args, query }) {
           if (typeof args.data.name === 'string') {
             args.data.nameNgram = generateNgrams(args.data.name)
           }
-          return query(args)
+          const result = await query(args)
+          if (args.where) {
+            touchProjectsByAssetWhere(args.where)
+          }
+          return result
         },
         async createMany({ args, query }) {
           if (Array.isArray(args.data)) {
@@ -73,7 +124,27 @@ function createPrismaClient() {
               }
             }
           }
-          return query(args)
+          const result = await query(args)
+          const projectIds = new Set<string>()
+          if (Array.isArray(args.data)) {
+            for (const item of args.data) {
+              if (item.projectId) projectIds.add(item.projectId)
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } else if ((args.data as any)?.projectId) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            projectIds.add((args.data as any).projectId)
+          }
+
+          if (projectIds.size > 0) {
+            client.project
+              .updateMany({
+                where: { id: { in: Array.from(projectIds) } },
+                data: { updatedAt: new Date() },
+              })
+              .catch((e) => console.error('Failed to touch projects by createMany', e))
+          }
+          return result
         },
       },
     },


### PR DESCRIPTION
## Summary
This PR fixes a bug where the project's updatedAt field was not updated when an asset was created or modified within that project.

## Changes
- Added a Prisma client extension for the Asset model in packages/db/src/index.ts.
- Implemented touchProject helpers that update the updatedAt field of projects associated with the modified assets.
- Intercepted create, update, upsert, updateMany, and createMany operations on assets to trigger the project touch.
- The project update is performed asynchronously (fire-and-forget) to avoid blocking the main asset operation and to prevent deadlocks in transactional test environments.

## Verification
- Created a temporary test case packages/core/src/asset/project-updated-at.test.ts using a real database connection to verify the behavior.
- Confirmed that creating and updating assets successfully updates the project's updatedAt field.
- Ran all existing asset and project tests to ensure no regressions.
- Verified that bun run lint, bun run format, and bun run typecheck pass.

## Notes
- The touch operation uses updateMany to avoid errors if a project is not found (e.g., orphaned assets).
- eslint-disable comments were added for necessary any casts in the Prisma extension logic, with appropriate explanations.