### PR TITLE
feat(auth): add demo mode support

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,5 @@
 [serve.static]
+env = "PUBLIC_*"
 plugins = ["bun-plugin-tailwind"]
 
 [install]

--- a/packages/api/src/middleware/auth.test.ts
+++ b/packages/api/src/middleware/auth.test.ts
@@ -32,7 +32,7 @@ describe('authMiddleware', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
-    delete process.env.REVIEWER_READ_ONLY
+    delete process.env.PUBLIC_DEMO_MODE
   })
 
   it('allows access when authenticated', async () => {
@@ -54,7 +54,7 @@ describe('authMiddleware', () => {
 
   describe('read-only mode', () => {
     beforeEach(() => {
-      process.env.REVIEWER_READ_ONLY = '1'
+      process.env.PUBLIC_DEMO_MODE = '1'
     })
 
     it('allows GET for reviewer', async () => {

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -29,7 +29,7 @@ export const authMiddleware = createMiddleware<{
 
     c.set('user', user)
 
-    if (process.env.REVIEWER_READ_ONLY === '1') {
+    if (process.env.PUBLIC_DEMO_MODE === '1') {
       const method = c.req.method.toUpperCase()
       const path = c.req.path
       if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method) && !path.endsWith('/search')) {

--- a/packages/webui/routes/login.tsx
+++ b/packages/webui/routes/login.tsx
@@ -1,18 +1,18 @@
 import { client } from '@/ui/api/client'
-import { useQuery } from '@tanstack/react-query'
+import { AuthLayout } from '@/ui/components/auth-layout'
 import { Button } from '@/ui/components/ui/button'
+import { ShumaiLogo } from '@/ui/components/ui/icons'
 import { Input } from '@/ui/components/ui/input'
 import { Label } from '@/ui/components/ui/label'
+import { signIn } from '@/ui/lib/auth-client'
 import { useAuthStore } from '@/ui/stores/auth'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
+import { ArrowRight, Loader2, Lock, LogIn, Mail } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
-import { signIn } from '@/ui/lib/auth-client'
-import { Loader2, Mail, Lock, ArrowRight, LogIn } from 'lucide-react'
-import { ShumaiLogo } from '@/ui/components/ui/icons'
-import { AuthLayout } from '@/ui/components/auth-layout'
 
 const loginSchema = z.object({
   email: z.string().email('Invalid email address'),
@@ -26,6 +26,13 @@ function LoginPage() {
   const setUser = useAuthStore((state) => state.setUser)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+
+  let isDemoEnv
+  try {
+    isDemoEnv = process.env.PUBLIC_DEMO_MODE === '1'
+  } catch {
+    isDemoEnv = false
+  }
 
   const { data: signupInfo, isLoading: isSignupInfoLoading } = useQuery({
     queryKey: ['/signup-info'],
@@ -87,6 +94,15 @@ function LoginPage() {
           Enter your credentials to access your account.
         </p>
       </div>
+
+      {isDemoEnv && (
+        <div className="mb-6 p-4 bg-blue-500/10 border border-blue-500/20 text-blue-700 dark:text-blue-400 rounded-xl text-sm leading-relaxed">
+          <p>
+            <strong>Demo Access:</strong> Use <strong>"foo@bar.com"</strong> as the email and{' '}
+            <strong>"foo"</strong> as the password to login.
+          </p>
+        </div>
+      )}
 
       {error && (
         <div className="mb-6 p-3 bg-red-500/10 border border-red-500/20 text-red-600 dark:text-red-400 rounded-xl text-sm text-center font-medium">


### PR DESCRIPTION
## Summary
Add support for a demo mode via the `PUBLIC_DEMO_MODE` environment variable.

## Changes
- **Bun Config**: Enabled environment variable inlining for `PUBLIC_*` variables in `bunfig.toml`.
- **Frontend**: Updated the login page to show demo credentials when `PUBLIC_DEMO_MODE=1`.
- **Backend**: Replaced `REVIEWER_READ_ONLY` with `PUBLIC_DEMO_MODE` in the authentication middleware to enforce read-only access for reviewers in demo mode.
- **Tests**: Updated backend tests to use the new environment variable.

## Verification
- Ran `bun run lint`, `bun run format`, `bun run typecheck`, and backend tests. All passed simultaneously.