### PR TITLE
feat(auth): refine demo mode support

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,4 @@
 [serve.static]
-env = "PUBLIC_*"
 plugins = ["bun-plugin-tailwind"]
 
 [install]

--- a/packages/api/src/authn.test.ts
+++ b/packages/api/src/authn.test.ts
@@ -17,7 +17,8 @@ describe('authn api', () => {
 
   it('GET /signup-info', async () => {
     mockGetSignupInfo.mockResolvedValue({
-      userCount: 5,
+      initialized: true,
+      demoMode: false,
     })
 
     const app = new Hono().route('/', authnRoute)
@@ -25,7 +26,8 @@ describe('authn api', () => {
 
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({
-      userCount: 5,
+      initialized: true,
+      demoMode: false,
     })
   })
 })

--- a/packages/api/src/authn.ts
+++ b/packages/api/src/authn.ts
@@ -17,7 +17,8 @@ const route = app
   .get('/signup-info', async (c) => {
     const info = await teamService.getSignupInfo()
     return c.json({
-      userCount: info.userCount,
+      initialized: info.initialized,
+      demoMode: info.demoMode,
     })
   })
   .get('/me', async (c) => {

--- a/packages/api/src/middleware/auth.test.ts
+++ b/packages/api/src/middleware/auth.test.ts
@@ -32,7 +32,7 @@ describe('authMiddleware', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
-    delete process.env.PUBLIC_DEMO_MODE
+    delete process.env.SHUMAI_DEMO_MODE
   })
 
   it('allows access when authenticated', async () => {
@@ -54,7 +54,7 @@ describe('authMiddleware', () => {
 
   describe('read-only mode', () => {
     beforeEach(() => {
-      process.env.PUBLIC_DEMO_MODE = '1'
+      process.env.SHUMAI_DEMO_MODE = '1'
     })
 
     it('allows GET for reviewer', async () => {

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -29,7 +29,7 @@ export const authMiddleware = createMiddleware<{
 
     c.set('user', user)
 
-    if (process.env.PUBLIC_DEMO_MODE === '1') {
+    if (process.env.SHUMAI_DEMO_MODE === '1') {
       const method = c.req.method.toUpperCase()
       const path = c.req.path
       if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method) && !path.endsWith('/search')) {

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -34,7 +34,7 @@ export const auth = betterAuth({
 
         const info = await teamService.getSignupInfo()
 
-        if (info.userCount > 0) {
+        if (info.initialized) {
           if (!inviteCode) {
             console.log('[Better Auth Hook] Public signup is disabled')
             return ctx.json(

--- a/packages/core/src/team/team.ts
+++ b/packages/core/src/team/team.ts
@@ -349,7 +349,9 @@ export class TeamService {
     const count = await prisma.user.count()
 
     return {
+      initialized: count > 0,
       userCount: count,
+      demoMode: process.env.SHUMAI_DEMO_MODE === '1',
     }
   }
 

--- a/packages/webui/routes/login.tsx
+++ b/packages/webui/routes/login.tsx
@@ -27,13 +27,6 @@ function LoginPage() {
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
-  let isDemoEnv
-  try {
-    isDemoEnv = process.env.PUBLIC_DEMO_MODE === '1'
-  } catch {
-    isDemoEnv = false
-  }
-
   const { data: signupInfo, isLoading: isSignupInfoLoading } = useQuery({
     queryKey: ['/signup-info'],
     queryFn: async () => {
@@ -44,10 +37,12 @@ function LoginPage() {
   })
 
   useEffect(() => {
-    if (signupInfo?.userCount === 0) {
+    if (signupInfo && !signupInfo.initialized) {
       navigate({ to: '/signup', search: { inviteCode: '' } })
     }
   }, [signupInfo, navigate])
+
+  const isDemoEnv = signupInfo?.demoMode === true
 
   const form = useForm<LoginSchema>({
     resolver: zodResolver(loginSchema),

--- a/packages/webui/routes/signup.tsx
+++ b/packages/webui/routes/signup.tsx
@@ -96,7 +96,7 @@ function SignupPage() {
     )
   }
 
-  const isFirstUser = signupInfo?.userCount === 0
+  const isFirstUser = !signupInfo?.initialized
   const isPublicSignupDisabled = !isFirstUser && !inviteCode
 
   if (isPublicSignupDisabled) {

--- a/packages/webui/routes/signup.tsx
+++ b/packages/webui/routes/signup.tsx
@@ -96,7 +96,7 @@ function SignupPage() {
     )
   }
 
-  const isFirstUser = !signupInfo?.initialized
+  const isFirstUser = signupInfo?.initialized === false
   const isPublicSignupDisabled = !isFirstUser && !inviteCode
 
   if (isPublicSignupDisabled) {


### PR DESCRIPTION
## Summary
Refine demo mode support to use a runtime API instead of build-time environment variable inlining.

## Changes
- **Backend API**: Updated `/signup-info` to return `demoMode` and `initialized` (boolean) instead of `userCount`.
- **Backend Middleware**: Renamed environment variable to `SHUMAI_DEMO_MODE`.
- **Frontend**: Updated login and signup pages to use the new `/signup-info` response format.
- **Bun Config**: Reverted build-time environment variable inlining.

## Verification
- All checks (lint, format, typecheck, tests) pass.