### PR TITLE
fix(search): fix hasAny and hasNone operators on metadata filter

### DIFF
--- a/packages/core/src/search/search.test.ts
+++ b/packages/core/src/search/search.test.ts
@@ -303,6 +303,7 @@ describe('SearchService', () => {
       // SelectMulti Metadata
       { field: 'multi', op: 'hasAny', val: ['a'], expected: ['multi-a-b'] },
       { field: 'multi', op: 'hasAny', val: ['b'], expected: ['multi-a-b', 'multi-b-c'] },
+      { field: 'multi', op: 'hasAny', val: ['a', 'c'], expected: ['multi-a-b', 'multi-b-c'] },
       { field: 'multi', op: 'hasAll', val: ['a', 'b'], expected: ['multi-a-b'] },
       { field: 'multi', op: 'hasAll', val: ['a', 'c'], expected: [] },
       {
@@ -317,6 +318,23 @@ describe('SearchService', () => {
           'bool-true',
           'bool-false',
           'multi-b-c',
+          'date-today',
+          'date-yesterday',
+          'name-contains-test',
+          'nothing',
+        ],
+      },
+      {
+        field: 'multi',
+        op: 'hasNone',
+        val: ['a', 'c'],
+        expected: [
+          'str-apple',
+          'str-banana',
+          'num-10',
+          'num-20',
+          'bool-true',
+          'bool-false',
           'date-today',
           'date-yesterday',
           'name-contains-test',

--- a/packages/core/src/search/sql-query-builder.ts
+++ b/packages/core/src/search/sql-query-builder.ts
@@ -355,11 +355,16 @@ export class SqlQueryBuilder {
         const valNumArr = valArr.map((v) => Number(v)).filter((v) => !isNaN(v))
         return Prisma.sql`a.id NOT IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND (string_value = ANY(${valArr}) OR number_value = ANY(${valNumArr}::double precision[])))`
       }
-      case 'hasAny':
       case 'hasAll':
         return Prisma.sql`a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND json_value @> ${JSON.stringify(value)}::jsonb)`
-      case 'hasNone':
-        return Prisma.sql`a.id NOT IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND json_value @> ${JSON.stringify(value)}::jsonb)`
+      case 'hasAny': {
+        const valArr = (Array.isArray(value) ? value : [value]).map(String)
+        return Prisma.sql`a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND jsonb_exists_any(json_value, ${valArr}::text[]))`
+      }
+      case 'hasNone': {
+        const valArr = (Array.isArray(value) ? value : [value]).map(String)
+        return Prisma.sql`a.id NOT IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND jsonb_exists_any(json_value, ${valArr}::text[]))`
+      }
       case 'isWithin': {
         const range = this.parseDateRange(value)
         return Prisma.sql`a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND date_value >= ${range.start} AND date_value <= ${range.end})`


### PR DESCRIPTION
## Summary

This PR fixes a bug in the metadata search query builder where the `hasAny` and `hasNone` operators behaved identically to `hasAll`.

## Changes

- Updated sql-query-builder.ts to separate the SQL compilation of `hasAll`, `hasAny`, and `hasNone`.
- Implemented `hasAny` using PostgreSQL's `jsonb_exists_any` function to verify if any elements in the search criteria array overlap with the stored array.
- Implemented `hasNone` using the negation of `jsonb_exists_any`.
- Added test cases in search.test.ts to verify multi-value matching using both `hasAny` and `hasNone`.

## Verification

- Added tests reproducing the failure which now pass successfully.
- Ran all repository checks simultaneously:
  - `bun run lint` (Passed)
  - `bun run format` (Passed)
  - `bun run typecheck` (Passed)
  - `bun run test` (All 499 tests passed)

## Notes

None.