### PR TITLE
feat(cli): add background daemonization and subcommands

### DIFF
--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -4,6 +4,7 @@ loadEnvConfig(process.cwd(), process.env.NODE_ENV !== 'production')
 import { workflowService } from '@shumai/workflow-core'
 import { TaskQueueAgent } from '@shumai/workflow-core'
 import { initAgentWorkflows } from '@shumai/agent'
+import { handleDaemonCommands } from '@shumai/core/src/utils/daemon'
 
 if (process.argv.includes('--check')) {
   console.log('✅ Agent worker evaluated successfully!')
@@ -28,7 +29,7 @@ async function run() {
   await workflowService.startWorkers(TaskQueueAgent, options)
 }
 
-run().catch((err) => {
+handleDaemonCommands('shumai-agent', run).catch((err) => {
   console.error(err)
   process.exit(1)
 })

--- a/apps/transcode/src/index.ts
+++ b/apps/transcode/src/index.ts
@@ -3,6 +3,7 @@ loadEnvConfig(process.cwd(), process.env.NODE_ENV !== 'production')
 
 import { initTranscodeWorkflows } from '@shumai/transcode'
 import { TaskQueueTranscode, workflowService } from '@shumai/workflow-core'
+import { handleDaemonCommands } from '@shumai/core/src/utils/daemon'
 
 if (process.argv.includes('--check')) {
   console.log('✅ Transcode worker evaluated successfully!')
@@ -27,7 +28,7 @@ async function run() {
   await workflowService.startWorkers(TaskQueueTranscode, options)
 }
 
-run().catch((err) => {
+handleDaemonCommands('shumai-transcode', run).catch((err) => {
   console.error(err)
   process.exit(1)
 })

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -11,118 +11,127 @@ import { initTranscodeWorkflows } from '@shumai/transcode'
 import { workflowService } from '@shumai/workflow-core'
 import { app } from '@shumai/api'
 
+import { handleDaemonCommands } from '@shumai/core/src/utils/daemon'
+
 if (process.argv.includes('--check')) {
   console.log('✅ Web app evaluated successfully!')
   process.exit(0)
 }
 
-// Initialize workflows and activities for local executor mode
-initAgentWorkflows()
-initTranscodeWorkflows()
+async function run() {
+  // Initialize workflows and activities for local executor mode
+  initAgentWorkflows()
+  initTranscodeWorkflows()
 
-// Start services
-await metadataService.syncSystemFields().catch(console.error)
-assetService.startCleanupJob()
-workflowService.start()
-if (process.env.WORKFLOW_EXECUTOR === 'temporal') {
-  const args = process.argv.slice(2)
-  let workersOption = ''
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--workers') {
-      workersOption = args[i + 1] || ''
-    } else if (args[i].startsWith('--workers=')) {
-      workersOption = args[i].split('=')[1]
+  // Start services
+  await metadataService.syncSystemFields().catch(console.error)
+  assetService.startCleanupJob()
+  workflowService.start()
+  if (process.env.WORKFLOW_EXECUTOR === 'temporal') {
+    const args = process.argv.slice(2)
+    let workersOption = ''
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === '--workers') {
+        workersOption = args[i + 1] || ''
+      } else if (args[i].startsWith('--workers=')) {
+        workersOption = args[i].split('=')[1]
+      }
     }
+
+    const queuesToStart: string[] = []
+    if (workersOption === 'agent' || workersOption === 'ai') {
+      queuesToStart.push('agent_queue')
+    } else if (workersOption === 'transcode') {
+      queuesToStart.push('transcode_queue')
+    } else if (workersOption === 'all') {
+      queuesToStart.push('agent_queue', 'transcode_queue')
+    }
+
+    Promise.all(queuesToStart.map((q) => workflowService.startWorkers(q))).catch(console.error)
   }
 
-  const queuesToStart: string[] = []
-  if (workersOption === 'agent' || workersOption === 'ai') {
-    queuesToStart.push('agent_queue')
-  } else if (workersOption === 'transcode') {
-    queuesToStart.push('transcode_queue')
-  } else if (workersOption === 'all') {
-    queuesToStart.push('agent_queue', 'transcode_queue')
-  }
+  const isProd = process.env.NODE_ENV === 'production'
 
-  Promise.all(queuesToStart.map((q) => workflowService.startWorkers(q))).catch(console.error)
-}
+  const port = process.env.SHUMAI_SERVER_PORT ? parseInt(process.env.SHUMAI_SERVER_PORT) : 3000
 
-const isProd = process.env.NODE_ENV === 'production'
+  const server = Bun.serve(
+    isProd
+      ? {
+          port,
+          maxRequestBodySize: process.env.MAX_REQUEST_BODY_SIZE
+            ? parseInt(process.env.MAX_REQUEST_BODY_SIZE)
+            : 1024 * 1024 * 1024 * 10, // Default 10GB
+          development: false,
+          async fetch(req) {
+            const url = new URL(req.url)
 
-const port = process.env.SHUMAI_SERVER_PORT ? parseInt(process.env.SHUMAI_SERVER_PORT) : 3000
-
-const server = Bun.serve(
-  isProd
-    ? {
-        port,
-        maxRequestBodySize: process.env.MAX_REQUEST_BODY_SIZE
-          ? parseInt(process.env.MAX_REQUEST_BODY_SIZE)
-          : 1024 * 1024 * 1024 * 10, // Default 10GB
-        development: false,
-        async fetch(req) {
-          const url = new URL(req.url)
-
-          if (!url.pathname.startsWith('/api/') && !url.pathname.startsWith('/files/')) {
-            const filepath = join(import.meta.dir, url.pathname)
-            const file = Bun.file(filepath)
-            if (await file.exists()) {
-              try {
-                const stat = await file.stat()
-                if (stat.isFile()) {
-                  return new Response(file)
+            if (!url.pathname.startsWith('/api/') && !url.pathname.startsWith('/files/')) {
+              const filepath = join(import.meta.dir, url.pathname)
+              const file = Bun.file(filepath)
+              if (await file.exists()) {
+                try {
+                  const stat = await file.stat()
+                  if (stat.isFile()) {
+                    return new Response(file)
+                  }
+                } catch {
+                  // ignore stat errors
                 }
-              } catch {
-                // ignore stat errors
+              }
+
+              const htmlFile = Bun.file(join(import.meta.dir, 'index.html'))
+              if (await htmlFile.exists()) {
+                return new Response(htmlFile, {
+                  headers: { 'Content-Type': 'text/html' },
+                })
+              }
+
+              const htmlFileNpm = Bun.file(join(import.meta.dir, 'shumai-app.html'))
+              if (await htmlFileNpm.exists()) {
+                return new Response(htmlFileNpm, {
+                  headers: { 'Content-Type': 'text/html' },
+                })
               }
             }
 
-            const htmlFile = Bun.file(join(import.meta.dir, 'index.html'))
-            if (await htmlFile.exists()) {
-              return new Response(htmlFile, {
-                headers: { 'Content-Type': 'text/html' },
-              })
-            }
+            return app.fetch(req)
+          },
+        }
+      : {
+          port,
+          maxRequestBodySize: process.env.MAX_REQUEST_BODY_SIZE
+            ? parseInt(process.env.MAX_REQUEST_BODY_SIZE)
+            : 1024 * 1024 * 1024 * 10, // Default 10GB
+          development: true,
+          fetch: app.fetch,
+          routes: {
+            // Serve index.html for root
+            '/': index,
 
-            const htmlFileNpm = Bun.file(join(import.meta.dir, 'shumai-app.html'))
-            if (await htmlFileNpm.exists()) {
-              return new Response(htmlFileNpm, {
-                headers: { 'Content-Type': 'text/html' },
-              })
-            }
-          }
+            // Proxy API requests to Hono
+            '/api/*': app.fetch,
+            '/files/*': app.fetch,
 
-          return app.fetch(req)
+            // Catch-all for SPA routing (fallback to index.html)
+            '/*': index,
+          },
         },
-      }
-    : {
-        port,
-        maxRequestBodySize: process.env.MAX_REQUEST_BODY_SIZE
-          ? parseInt(process.env.MAX_REQUEST_BODY_SIZE)
-          : 1024 * 1024 * 1024 * 10, // Default 10GB
-        development: true,
-        fetch: app.fetch,
-        routes: {
-          // Serve index.html for root
-          '/': index,
+  )
 
-          // Proxy API requests to Hono
-          '/api/*': app.fetch,
-          '/files/*': app.fetch,
+  console.log(`🚀 Server running at ${server.url}`)
 
-          // Catch-all for SPA routing (fallback to index.html)
-          '/*': index,
-        },
-      },
-)
+  const shutdown = () => {
+    console.log('\nShutting down gracefully...')
+    assetService.stopCleanupJob()
+    server.stop(true)
+    process.exit(0)
+  }
 
-console.log(`🚀 Server running at ${server.url}`)
-
-const shutdown = () => {
-  console.log('\nShutting down gracefully...')
-  assetService.stopCleanupJob()
-  server.stop(true)
-  process.exit(0)
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
 }
 
-process.on('SIGINT', shutdown)
-process.on('SIGTERM', shutdown)
+handleDaemonCommands('shumai', run).catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/core/src/utils/daemon.test.ts
+++ b/packages/core/src/utils/daemon.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it, vi, beforeEach, afterEach, type MockInstance } from 'vitest'
-import { existsSync, writeFileSync, readFileSync, rmSync, mkdirSync, createWriteStream } from 'node:fs'
+import {
+  existsSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+  createWriteStream,
+} from 'node:fs'
 import { join } from 'node:path'
 import { handleDaemonCommands } from './daemon'
 import { spawn } from 'node:child_process'
-import { Writable } from 'node:stream'
 
 // Mock os.homedir to return a temporary directory for test isolation
 vi.mock('node:os', async (importOriginal) => {
@@ -30,7 +36,7 @@ vi.mock('node:child_process', () => {
 // Mock node:fs to mock createWriteStream for ESM safety
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>()
-  const { Writable } = require('node:stream')
+  const { Writable } = await import('node:stream')
   return {
     ...actual,
     createWriteStream: vi.fn(() => {
@@ -60,7 +66,7 @@ describe('handleDaemonCommands', () => {
       throw new Error('process.exit')
     })
     mockKill = vi.spyOn(process, 'kill').mockImplementation(() => true)
-    
+
     vi.mocked(spawn).mockClear()
     vi.mocked(createWriteStream).mockClear()
   })

--- a/packages/core/src/utils/daemon.test.ts
+++ b/packages/core/src/utils/daemon.test.ts
@@ -1,12 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach, type MockInstance } from 'vitest'
-import {
-  existsSync,
-  writeFileSync,
-  readFileSync,
-  rmSync,
-  mkdirSync,
-  createWriteStream,
-} from 'node:fs'
+import { existsSync, writeFileSync, readFileSync, rmSync, mkdirSync, openSync } from 'node:fs'
 import { join } from 'node:path'
 import { handleDaemonCommands } from './daemon'
 import { spawn } from 'node:child_process'
@@ -33,19 +26,12 @@ vi.mock('node:child_process', () => {
   }
 })
 
-// Mock node:fs to mock createWriteStream for ESM safety
+// Mock node:fs to mock openSync for ESM safety
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>()
-  const { Writable } = await import('node:stream')
   return {
     ...actual,
-    createWriteStream: vi.fn(() => {
-      return new Writable({
-        write(_chunk: unknown, _encoding: string, callback: (error?: Error | null) => void) {
-          callback()
-        },
-      })
-    }),
+    openSync: vi.fn(() => 42),
   }
 })
 
@@ -68,7 +54,7 @@ describe('handleDaemonCommands', () => {
     mockKill = vi.spyOn(process, 'kill').mockImplementation(() => true)
 
     vi.mocked(spawn).mockClear()
-    vi.mocked(createWriteStream).mockClear()
+    vi.mocked(openSync).mockClear()
   })
 
   afterEach(() => {
@@ -105,7 +91,7 @@ describe('handleDaemonCommands', () => {
     expect(runFn).not.toHaveBeenCalled()
     expect(mockKill).toHaveBeenCalledWith(12345, 'SIGTERM')
     expect(mockExit).toHaveBeenCalledWith(0)
-    expect(createWriteStream).not.toHaveBeenCalled()
+    expect(openSync).not.toHaveBeenCalled()
   })
 
   it('daemonizes the process if -d is passed', async () => {

--- a/packages/core/src/utils/daemon.test.ts
+++ b/packages/core/src/utils/daemon.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi, beforeEach, afterEach, type MockInstance } from 'vitest'
+import { existsSync, writeFileSync, readFileSync, rmSync, mkdirSync, createWriteStream } from 'node:fs'
+import { join } from 'node:path'
+import { handleDaemonCommands } from './daemon'
+import { spawn } from 'node:child_process'
+import { Writable } from 'node:stream'
+
+// Mock os.homedir to return a temporary directory for test isolation
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  const mockTempDir = `${actual.tmpdir()}/shumai-test-daemon-${Math.random().toString(36).substring(2)}`
+  return {
+    ...actual,
+    homedir: () => mockTempDir,
+  }
+})
+
+// Mock node:child_process for spawn tests
+vi.mock('node:child_process', () => {
+  return {
+    spawn: vi.fn(() => {
+      return {
+        pid: 99999,
+        unref: vi.fn(),
+      }
+    }),
+  }
+})
+
+// Mock node:fs to mock createWriteStream for ESM safety
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  const { Writable } = require('node:stream')
+  return {
+    ...actual,
+    createWriteStream: vi.fn(() => {
+      return new Writable({
+        write(_chunk: unknown, _encoding: string, callback: (error?: Error | null) => void) {
+          callback()
+        },
+      })
+    }),
+  }
+})
+
+import { homedir } from 'node:os'
+
+describe('handleDaemonCommands', () => {
+  const appName = 'test-app'
+  const mockTempDir = homedir()
+  const pidFile = join(mockTempDir, '.shumai', 'pids', `${appName}.pid`)
+
+  let mockExit: MockInstance<typeof process.exit>
+  let mockKill: MockInstance<typeof process.kill>
+  const originalArgv = process.argv
+
+  beforeEach(() => {
+    mkdirSync(mockTempDir, { recursive: true })
+    mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit')
+    })
+    mockKill = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    
+    vi.mocked(spawn).mockClear()
+    vi.mocked(createWriteStream).mockClear()
+  })
+
+  afterEach(() => {
+    process.argv = originalArgv
+    vi.restoreAllMocks()
+    try {
+      rmSync(mockTempDir, { recursive: true, force: true })
+    } catch {
+      // Ignore
+    }
+  })
+
+  it('runs the runFn on normal startup', async () => {
+    process.argv = ['node', 'script.js']
+    const runFn = vi.fn().mockResolvedValue(undefined)
+
+    await handleDaemonCommands(appName, runFn)
+
+    expect(runFn).toHaveBeenCalled()
+    expect(existsSync(pidFile)).toBe(true)
+    expect(readFileSync(pidFile, 'utf8').trim()).toBe(process.pid.toString())
+  })
+
+  it('stops the process if stop command is passed', async () => {
+    process.argv = ['node', 'script.js', 'stop']
+    const runFn = vi.fn().mockResolvedValue(undefined)
+
+    // Write a dummy PID file
+    mkdirSync(join(mockTempDir, '.shumai', 'pids'), { recursive: true })
+    writeFileSync(pidFile, '12345')
+
+    await expect(handleDaemonCommands(appName, runFn)).rejects.toThrow('process.exit')
+
+    expect(runFn).not.toHaveBeenCalled()
+    expect(mockKill).toHaveBeenCalledWith(12345, 'SIGTERM')
+    expect(mockExit).toHaveBeenCalledWith(0)
+    expect(createWriteStream).not.toHaveBeenCalled()
+  })
+
+  it('daemonizes the process if -d is passed', async () => {
+    process.argv = ['node', 'script.js', '-d']
+    const runFn = vi.fn().mockResolvedValue(undefined)
+
+    await expect(handleDaemonCommands(appName, runFn)).rejects.toThrow('process.exit')
+
+    expect(runFn).not.toHaveBeenCalled()
+    expect(spawn).toHaveBeenCalled()
+    expect(existsSync(pidFile)).toBe(true)
+    expect(readFileSync(pidFile, 'utf8').trim()).toBe('99999')
+    expect(mockExit).toHaveBeenCalledWith(0)
+  })
+
+  it('restarts the process if restart command is passed', async () => {
+    process.argv = ['node', 'script.js', 'restart']
+    const runFn = vi.fn().mockResolvedValue(undefined)
+
+    // Write a dummy PID file
+    mkdirSync(join(mockTempDir, '.shumai', 'pids'), { recursive: true })
+    writeFileSync(pidFile, '12345')
+
+    await expect(handleDaemonCommands(appName, runFn)).rejects.toThrow('process.exit')
+
+    expect(runFn).not.toHaveBeenCalled()
+    expect(mockKill).toHaveBeenCalledWith(12345, 'SIGTERM')
+    expect(spawn).toHaveBeenCalled()
+    expect(mockExit).toHaveBeenCalledWith(0)
+  })
+})

--- a/packages/core/src/utils/daemon.ts
+++ b/packages/core/src/utils/daemon.ts
@@ -8,7 +8,7 @@ import {
   watch,
   statSync,
   createReadStream,
-  createWriteStream,
+  openSync,
 } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
@@ -97,7 +97,9 @@ function startDaemon(appName: string, pidFile: string, logFile: string): void {
     if (!isNaN(pid)) {
       try {
         process.kill(pid, 0)
-        console.error(`${appName} is already running (PID: ${pid}). Use '${appName} stop' or '${appName} restart'.`)
+        console.error(
+          `${appName} is already running (PID: ${pid}). Use '${appName} stop' or '${appName} restart'.`,
+        )
         process.exit(1)
       } catch {
         try {
@@ -110,13 +112,13 @@ function startDaemon(appName: string, pidFile: string, logFile: string): void {
   }
 
   console.log(`Starting ${appName} in background...`)
-  const logStream = createWriteStream(logFile, { flags: 'a' })
+  const logFd = openSync(logFile, 'a')
 
   const childArgs = process.argv.slice(1).filter((arg) => arg !== '-d' && arg !== 'restart')
 
   const child = spawn(process.argv[0], childArgs, {
     detached: true,
-    stdio: ['ignore', logStream, logStream],
+    stdio: ['ignore', logFd, logFd],
     env: {
       ...process.env,
       SHUMAI_DAEMONIZED: 'true',
@@ -173,7 +175,10 @@ function viewLogs(appName: string, logFile: string): void {
   process.on('SIGTERM', cleanup)
 }
 
-export async function handleDaemonCommands(appName: string, runFn: () => Promise<void>): Promise<void> {
+export async function handleDaemonCommands(
+  appName: string,
+  runFn: () => Promise<void>,
+): Promise<void> {
   const pidFile = join(PID_DIR, `${appName}.pid`)
   const logFile = join(LOG_DIR, `${appName}.log`)
 
@@ -216,7 +221,9 @@ export async function handleDaemonCommands(appName: string, runFn: () => Promise
     if (!isNaN(pid)) {
       try {
         process.kill(pid, 0)
-        console.error(`${appName} is already running (PID: ${pid}). Use '${appName} stop' or '${appName} restart'.`)
+        console.error(
+          `${appName} is already running (PID: ${pid}). Use '${appName} stop' or '${appName} restart'.`,
+        )
         process.exit(1)
       } catch {
         // Process is dead, clean up PID file

--- a/packages/core/src/utils/daemon.ts
+++ b/packages/core/src/utils/daemon.ts
@@ -5,7 +5,6 @@ import {
   readFileSync,
   unlinkSync,
   mkdirSync,
-  watch,
   statSync,
   createReadStream,
   openSync,
@@ -150,9 +149,9 @@ function viewLogs(appName: string, logFile: string): void {
   process.stdout.write(lastLines + '\n')
 
   let cursor = statSync(logFile).size
-  const watcher = watch(logFile, (event) => {
-    if (event === 'change') {
-      try {
+  const interval = setInterval(() => {
+    try {
+      if (existsSync(logFile)) {
         const stats = statSync(logFile)
         if (stats.size > cursor) {
           const stream = createReadStream(logFile, { start: cursor, end: stats.size - 1 })
@@ -161,14 +160,14 @@ function viewLogs(appName: string, logFile: string): void {
         } else if (stats.size < cursor) {
           cursor = stats.size
         }
-      } catch {
-        // Ignore read errors
       }
+    } catch {
+      // Ignore read errors
     }
-  })
+  }, 250)
 
   const cleanup = () => {
-    watcher.close()
+    clearInterval(interval)
     process.exit(0)
   }
   process.on('SIGINT', cleanup)

--- a/packages/core/src/utils/daemon.ts
+++ b/packages/core/src/utils/daemon.ts
@@ -94,7 +94,7 @@ function startDaemon(appName: string, pidFile: string, logFile: string): void {
   // Check if already running
   if (existsSync(pidFile)) {
     const pid = parseInt(readFileSync(pidFile, 'utf8').trim(), 10)
-    if (!isNaN(pid)) {
+    if (!isNaN(pid) && pid !== process.pid) {
       try {
         process.kill(pid, 0)
         console.error(
@@ -218,7 +218,7 @@ export async function handleDaemonCommands(
   // Normal Startup logic: check if already running
   if (existsSync(pidFile)) {
     const pid = parseInt(readFileSync(pidFile, 'utf8').trim(), 10)
-    if (!isNaN(pid)) {
+    if (!isNaN(pid) && pid !== process.pid) {
       try {
         process.kill(pid, 0)
         console.error(

--- a/packages/core/src/utils/daemon.ts
+++ b/packages/core/src/utils/daemon.ts
@@ -256,7 +256,6 @@ export async function handleDaemonCommands(
   process.on('exit', cleanPidFile)
 
   const handleSignal = (signal: string) => {
-    cleanPidFile()
     if (process.listenerCount(signal) === 1) {
       process.exit(0)
     }

--- a/packages/core/src/utils/daemon.ts
+++ b/packages/core/src/utils/daemon.ts
@@ -1,0 +1,263 @@
+import { spawn } from 'node:child_process'
+import {
+  existsSync,
+  writeFileSync,
+  readFileSync,
+  unlinkSync,
+  mkdirSync,
+  watch,
+  statSync,
+  createReadStream,
+  createWriteStream,
+} from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+
+const SHUMAI_DIR = join(homedir(), '.shumai')
+const PID_DIR = join(SHUMAI_DIR, 'pids')
+const LOG_DIR = join(SHUMAI_DIR, 'logs')
+
+async function stopProcess(appName: string, pidFile: string): Promise<boolean> {
+  if (!existsSync(pidFile)) {
+    console.log(`No running instance of ${appName} found.`)
+    return false
+  }
+
+  const pid = parseInt(readFileSync(pidFile, 'utf8').trim(), 10)
+  if (isNaN(pid)) {
+    console.log(`Invalid PID found in ${pidFile}. Cleaning up file.`)
+    try {
+      unlinkSync(pidFile)
+    } catch {
+      // Ignore
+    }
+    return false
+  }
+
+  let isRunning = false
+  try {
+    process.kill(pid, 0)
+    isRunning = true
+  } catch {
+    // Not running
+  }
+
+  if (!isRunning) {
+    console.log(`Process ${pid} is not running. Cleaning up PID file.`)
+    try {
+      unlinkSync(pidFile)
+    } catch {
+      // Ignore
+    }
+    return false
+  }
+
+  console.log(`Stopping ${appName} (PID: ${pid})...`)
+  try {
+    process.kill(pid, 'SIGTERM')
+  } catch (err) {
+    console.error(`Failed to send SIGTERM to process ${pid}:`, err)
+    return false
+  }
+
+  // Wait for it to stop
+  for (let i = 0; i < 30; i++) {
+    try {
+      process.kill(pid, 0)
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    } catch {
+      isRunning = false
+      break
+    }
+  }
+
+  if (isRunning) {
+    console.log(`Process ${pid} did not stop gracefully. Sending SIGKILL...`)
+    try {
+      process.kill(pid, 'SIGKILL')
+    } catch (err) {
+      console.error(`Failed to send SIGKILL to process ${pid}:`, err)
+    }
+  }
+
+  try {
+    unlinkSync(pidFile)
+  } catch {
+    // Ignore
+  }
+
+  console.log(`Successfully stopped ${appName}.`)
+  return true
+}
+
+function startDaemon(appName: string, pidFile: string, logFile: string): void {
+  // Check if already running
+  if (existsSync(pidFile)) {
+    const pid = parseInt(readFileSync(pidFile, 'utf8').trim(), 10)
+    if (!isNaN(pid)) {
+      try {
+        process.kill(pid, 0)
+        console.error(`${appName} is already running (PID: ${pid}). Use '${appName} stop' or '${appName} restart'.`)
+        process.exit(1)
+      } catch {
+        try {
+          unlinkSync(pidFile)
+        } catch {
+          // Ignore
+        }
+      }
+    }
+  }
+
+  console.log(`Starting ${appName} in background...`)
+  const logStream = createWriteStream(logFile, { flags: 'a' })
+
+  const childArgs = process.argv.slice(1).filter((arg) => arg !== '-d' && arg !== 'restart')
+
+  const child = spawn(process.argv[0], childArgs, {
+    detached: true,
+    stdio: ['ignore', logStream, logStream],
+    env: {
+      ...process.env,
+      SHUMAI_DAEMONIZED: 'true',
+    },
+  })
+
+  if (child.pid === undefined) {
+    console.error(`Failed to spawn background process for ${appName}.`)
+    process.exit(1)
+  }
+
+  child.unref()
+  writeFileSync(pidFile, child.pid.toString(), 'utf8')
+  console.log(`🚀 Started ${appName} in background (PID: ${child.pid}).`)
+  console.log(`📄 Logs are being written to ${logFile}`)
+  process.exit(0)
+}
+
+function viewLogs(appName: string, logFile: string): void {
+  if (!existsSync(logFile)) {
+    console.log(`No log file found for ${appName}.`)
+    process.exit(0)
+  }
+
+  // Print existing content (last 100 lines)
+  const content = readFileSync(logFile, 'utf8')
+  const lines = content.split('\n')
+  const lastLines = lines.slice(-100).join('\n')
+  process.stdout.write(lastLines + '\n')
+
+  let cursor = statSync(logFile).size
+  const watcher = watch(logFile, (event) => {
+    if (event === 'change') {
+      try {
+        const stats = statSync(logFile)
+        if (stats.size > cursor) {
+          const stream = createReadStream(logFile, { start: cursor, end: stats.size - 1 })
+          stream.pipe(process.stdout, { end: false })
+          cursor = stats.size
+        } else if (stats.size < cursor) {
+          cursor = stats.size
+        }
+      } catch {
+        // Ignore read errors
+      }
+    }
+  })
+
+  const cleanup = () => {
+    watcher.close()
+    process.exit(0)
+  }
+  process.on('SIGINT', cleanup)
+  process.on('SIGTERM', cleanup)
+}
+
+export async function handleDaemonCommands(appName: string, runFn: () => Promise<void>): Promise<void> {
+  const pidFile = join(PID_DIR, `${appName}.pid`)
+  const logFile = join(LOG_DIR, `${appName}.log`)
+
+  // Ensure directories exist
+  mkdirSync(PID_DIR, { recursive: true })
+  mkdirSync(LOG_DIR, { recursive: true })
+
+  const args = process.argv.slice(2)
+  const isStop = args.includes('stop')
+  const isRestart = args.includes('restart')
+  const isLogs = args.includes('logs')
+  const isDaemon = args.includes('-d') && process.env.SHUMAI_DAEMONIZED !== 'true'
+
+  if (isStop) {
+    await stopProcess(appName, pidFile)
+    process.exit(0)
+  }
+
+  if (isRestart) {
+    await stopProcess(appName, pidFile)
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    startDaemon(appName, pidFile, logFile)
+    process.exit(0)
+  }
+
+  if (isLogs) {
+    viewLogs(appName, logFile)
+    // Keep process open for logs tailing
+    return new Promise(() => {})
+  }
+
+  if (isDaemon) {
+    startDaemon(appName, pidFile, logFile)
+    process.exit(0)
+  }
+
+  // Normal Startup logic: check if already running
+  if (existsSync(pidFile)) {
+    const pid = parseInt(readFileSync(pidFile, 'utf8').trim(), 10)
+    if (!isNaN(pid)) {
+      try {
+        process.kill(pid, 0)
+        console.error(`${appName} is already running (PID: ${pid}). Use '${appName} stop' or '${appName} restart'.`)
+        process.exit(1)
+      } catch {
+        // Process is dead, clean up PID file
+        try {
+          unlinkSync(pidFile)
+        } catch {
+          // Ignore
+        }
+      }
+    }
+  }
+
+  // Write the PID file
+  writeFileSync(pidFile, process.pid.toString(), 'utf8')
+
+  const cleanPidFile = () => {
+    try {
+      if (existsSync(pidFile)) {
+        const pidStr = readFileSync(pidFile, 'utf8').trim()
+        if (parseInt(pidStr, 10) === process.pid) {
+          unlinkSync(pidFile)
+        }
+      }
+    } catch {
+      // Ignore
+    }
+  }
+
+  // Register cleanups
+  process.on('exit', cleanPidFile)
+
+  const handleSignal = (signal: string) => {
+    cleanPidFile()
+    if (process.listenerCount(signal) === 1) {
+      process.exit(0)
+    }
+  }
+
+  process.on('SIGINT', () => handleSignal('SIGINT'))
+  process.on('SIGTERM', () => handleSignal('SIGTERM'))
+
+  // Run the main app
+  await runFn()
+}

--- a/packages/core/src/utils/daemon.ts
+++ b/packages/core/src/utils/daemon.ts
@@ -16,6 +16,18 @@ const SHUMAI_DIR = join(homedir(), '.shumai')
 const PID_DIR = join(SHUMAI_DIR, 'pids')
 const LOG_DIR = join(SHUMAI_DIR, 'logs')
 
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'EPERM') {
+      return true
+    }
+    return false
+  }
+}
+
 async function stopProcess(appName: string, pidFile: string): Promise<boolean> {
   if (!existsSync(pidFile)) {
     console.log(`No running instance of ${appName} found.`)
@@ -33,14 +45,7 @@ async function stopProcess(appName: string, pidFile: string): Promise<boolean> {
     return false
   }
 
-  let isRunning = false
-  try {
-    process.kill(pid, 0)
-    isRunning = true
-  } catch {
-    // Not running
-  }
-
+  let isRunning = isProcessRunning(pid)
   if (!isRunning) {
     console.log(`Process ${pid} is not running. Cleaning up PID file.`)
     try {
@@ -61,13 +66,11 @@ async function stopProcess(appName: string, pidFile: string): Promise<boolean> {
 
   // Wait for it to stop
   for (let i = 0; i < 30; i++) {
-    try {
-      process.kill(pid, 0)
-      await new Promise((resolve) => setTimeout(resolve, 100))
-    } catch {
+    if (!isProcessRunning(pid)) {
       isRunning = false
       break
     }
+    await new Promise((resolve) => setTimeout(resolve, 100))
   }
 
   if (isRunning) {
@@ -94,13 +97,12 @@ function startDaemon(appName: string, pidFile: string, logFile: string): void {
   if (existsSync(pidFile)) {
     const pid = parseInt(readFileSync(pidFile, 'utf8').trim(), 10)
     if (!isNaN(pid) && pid !== process.pid) {
-      try {
-        process.kill(pid, 0)
+      if (isProcessRunning(pid)) {
         console.error(
           `${appName} is already running (PID: ${pid}). Use '${appName} stop' or '${appName} restart'.`,
         )
         process.exit(1)
-      } catch {
+      } else {
         try {
           unlinkSync(pidFile)
         } catch {
@@ -218,13 +220,12 @@ export async function handleDaemonCommands(
   if (existsSync(pidFile)) {
     const pid = parseInt(readFileSync(pidFile, 'utf8').trim(), 10)
     if (!isNaN(pid) && pid !== process.pid) {
-      try {
-        process.kill(pid, 0)
+      if (isProcessRunning(pid)) {
         console.error(
           `${appName} is already running (PID: ${pid}). Use '${appName} stop' or '${appName} restart'.`,
         )
         process.exit(1)
-      } catch {
+      } else {
         // Process is dead, clean up PID file
         try {
           unlinkSync(pidFile)

--- a/packages/core/src/utils/daemon.ts
+++ b/packages/core/src/utils/daemon.ts
@@ -111,7 +111,7 @@ function startDaemon(appName: string, pidFile: string, logFile: string): void {
   }
 
   console.log(`Starting ${appName} in background...`)
-  const logFd = openSync(logFile, 'a')
+  const logFd = openSync(logFile, 'w')
 
   const childArgs = process.argv.slice(1).filter((arg) => arg !== '-d' && arg !== 'restart')
 

--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -165,6 +165,7 @@ async function buildPlatformPackages(
   entrypoint: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   plugins: any[] = [],
+  external?: string[],
 ) {
   for (const target of targets) {
     const dirName = `${appName}-${target.platform}-${target.arch}`
@@ -180,6 +181,7 @@ async function buildPlatformPackages(
       binaryName,
       bunTarget: target.bunTarget,
       plugins,
+      external,
     })
 
     // Generate package.json for platform-specific package
@@ -209,6 +211,7 @@ async function buildMainPackage({
   entrypoint,
   plugins = [],
   extraDependencies = {},
+  external = commonExternal,
 }: {
   appName: string
   description: string
@@ -217,6 +220,7 @@ async function buildMainPackage({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   plugins?: any[]
   extraDependencies?: Record<string, string>
+  external?: string[]
 }) {
   console.log(`\n📄 Packaging wrapper app ${appName}...`)
   const mainOutDir = path.join(distDir, appName)
@@ -235,7 +239,7 @@ async function buildMainPackage({
     minify: true,
     naming: `${appName}-app.[ext]`,
     plugins,
-    external: commonExternal,
+    external,
     define: {
       'process.env.NODE_ENV': JSON.stringify('production'),
     },
@@ -489,13 +493,15 @@ const shumaiPlugins = [
   }),
   tailwindPlugin,
 ]
-await buildPlatformPackages('shumai', dummyRunnerPath)
+const shumaiExternal = commonExternal.filter((dep) => dep !== 'zod')
+await buildPlatformPackages('shumai', dummyRunnerPath, shumaiPlugins, shumaiExternal)
 await buildMainPackage({
   appName: 'shumai',
   description: 'A fullstack AI-powered media workspace and workflow engine',
   hasPrisma: true,
   entrypoint: './apps/web/src/index.ts',
   plugins: shumaiPlugins,
+  external: shumaiExternal,
 })
 
 // 3. Build shumai-agent (Agent app & platform binaries)

--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -373,7 +373,8 @@ console.log(\`ℹ️ [${appName}] Running from CWD: \${process.cwd()}\`)
 console.log(\`ℹ️ [${appName}] DATABASE_URL is: \${process.env.DATABASE_URL ? '(defined)' : '(undefined)'}\`)
 
 const prismaSchemaPath = join(__dirname, '..', 'prisma', 'schema.prisma')
-if (existsSync(prismaSchemaPath)) {
+const isUtilityCommand = process.argv.includes('stop') || process.argv.includes('logs')
+if (existsSync(prismaSchemaPath) && !isUtilityCommand) {
   console.log('🔄 Running database migrations...')
   activeProcess = spawn(
     binaryPath,


### PR DESCRIPTION
## Summary

This PR adds support for running the main Shumai applications in the background using a `-d` CLI flag. It also adds three new CLI subcommands: `stop`, `restart`, and `logs` to manage the lifecycle and view logs of these background processes.

## Changes

- Created a shared utility helper [packages/core/src/utils/daemon.ts](file:///Users/yiling/Projects/shumai/packages/core/src/utils/daemon.ts) that manages PID file tracking, detached process spawning, graceful stopping, restarting, and log tailing.
- Wrapped the entrypoints of all three applications ([apps/web/src/index.ts](file:///Users/yiling/Projects/shumai/apps/web/src/index.ts), [apps/agent/src/index.ts](file:///Users/yiling/Projects/shumai/apps/agent/src/index.ts), [apps/transcode/src/index.ts](file:///Users/yiling/Projects/shumai/apps/transcode/src/index.ts)) in the new `handleDaemonCommands` helper.
- Updated [scripts/build-npm.ts](file:///Users/yiling/Projects/shumai/scripts/build-npm.ts) to skip database migrations in the production binary wrapper when `stop` or `logs` utility subcommands are called.
- Added comprehensive unit tests in [packages/core/src/utils/daemon.test.ts](file:///Users/yiling/Projects/shumai/packages/core/src/utils/daemon.test.ts).

## Verification

- Ran `bun run lint` and verified it passes cleanly.
- Ran `bun run format` to ensure style consistency.
- Ran `bun run typecheck` to verify complete type safety.
- Ran `bun run test` workspace-wide to verify all 504 unit/integration tests pass, including the new daemon test suite:
  ```
  ✓ packages/core/src/utils/daemon.test.ts (4 tests) 6575ms
     ✓ stops the process if stop command is passed  3031ms
     ✓ restarts the process if restart command is passed  3535ms
  ```

## Notes

- Pids and logs are stored inside the user's home directory (`~/.shumai/pids` and `~/.shumai/logs`) to prevent permission issues.
