### PR TITLE
feat(settings): use singular headers and remove collapse/counters for single agent types

### DIFF
--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -127,6 +127,54 @@ describe('Agent Activities', () => {
     expect(res.text).toBe('Error: API key not valid')
   })
 
+  it('should pass thinkingLevel from agent config to createAgentSession', async () => {
+    const mockHarness = {
+      prompt: vi.fn().mockResolvedValue({
+        content: [],
+        usage: { input: 0, output: 0 },
+      }),
+      getThinkingLevel: vi.fn().mockReturnValue('high'),
+    }
+    const mockSession = {
+      getEntries: vi.fn().mockResolvedValue([]),
+      getStorage: vi.fn().mockReturnValue({ sessionId: 'mock-session-id' }),
+    }
+
+    vi.mocked(piAgent.createAgentSession).mockResolvedValue({
+      session: mockSession as unknown as Session<DatabaseSessionMetadata>,
+      harness: mockHarness as unknown as AgentHarness,
+    })
+
+    const context = {
+      agent: {
+        id: 'b1',
+        provider: { name: 'google' },
+        modelRef: { modelId: 'gemini' },
+        config: { thinkingLevel: 'high' },
+      },
+      dbProviders: [],
+      teamSkills: [],
+      allowedDomains: [],
+    } as unknown as AgentExecutionContext
+
+    await agentChatActivity({
+      teamId: 't1',
+      agentId: 'b1',
+      message: 'Hi',
+      imageUrls: [],
+      projectId: 'p1',
+      folderId: 'f1',
+      sessionId: 'mock-session-id',
+      context,
+    })
+
+    expect(piAgent.createAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thinkingLevel: 'high',
+      }),
+    )
+  })
+
   it('should call autofillAiActivity and run autofill tool', async () => {
     const mockHarness = {
       prompt: vi.fn().mockResolvedValue({

--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -97,12 +97,16 @@ If you need to create files in the local filesystem (for example, a temporary fi
     systemPrompt += `\n\nYour current model supports the following input types: ${modelConfig.input.join(', ')}.`
   }
 
+  const agentConfig = agent.config as PrismaJson.AgentConfig | null | undefined
+  const thinkingLevel = agentConfig?.thinkingLevel || 'off'
+
   const { session, harness } = await createAgentSession({
     teamId: params.teamId,
     agentId: params.agentId,
     providerName,
     modelId,
     systemPrompt,
+    thinkingLevel,
     teamSkills: teamSkills.map((s) => ({
       id: s.id,
       name: s.name,

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -257,4 +257,76 @@ describe('Sandbox Network isolation integration', () => {
       resetSpy.mockRestore()
     }
   })
+
+  it('should pass thinkingLevel to AgentHarness and default to off', async () => {
+    const team = await prisma.team.create({
+      data: { name: 'Test Team' },
+    })
+
+    await prisma.user.create({
+      data: {
+        id: 'test-agent-1',
+        name: 'Agent 1',
+        email: 'agent1@test.com',
+        type: 'agent',
+      },
+    })
+    await prisma.agent.create({
+      data: {
+        id: 'test-agent-1',
+        teamId: team.id,
+        type: 'chat',
+        config: { provider: 'google', model: 'gemini' },
+      },
+    })
+
+    await prisma.user.create({
+      data: {
+        id: 'test-agent-2',
+        name: 'Agent 2',
+        email: 'agent2@test.com',
+        type: 'agent',
+      },
+    })
+    await prisma.agent.create({
+      data: {
+        id: 'test-agent-2',
+        teamId: team.id,
+        type: 'chat',
+        config: { provider: 'google', model: 'gemini' },
+      },
+    })
+
+    const initializeSpy = vi.spyOn(SandboxManager, 'initialize').mockResolvedValue()
+    try {
+      // Call createAgentSession with thinkingLevel
+      const { harness: harnessHigh } = await createAgentSession({
+        teamId: team.id,
+        agentId: 'test-agent-1',
+        providerName: 'google',
+        modelId: 'gemini',
+        systemPrompt: 'prompt',
+        teamSkills: [],
+        allowedDomains: [],
+        providers: [],
+        thinkingLevel: 'high',
+      })
+      expect(harnessHigh.getThinkingLevel()).toBe('high')
+
+      // Call createAgentSession without thinkingLevel
+      const { harness: harnessDefault } = await createAgentSession({
+        teamId: team.id,
+        agentId: 'test-agent-2',
+        providerName: 'google',
+        modelId: 'gemini',
+        systemPrompt: 'prompt',
+        teamSkills: [],
+        allowedDomains: [],
+        providers: [],
+      })
+      expect(harnessDefault.getThinkingLevel()).toBe('off')
+    } finally {
+      initializeSpy.mockRestore()
+    }
+  })
 })

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,5 +1,10 @@
 import { SandboxManager } from '@anthropic-ai/sandbox-runtime'
-import { AgentHarness, Session, type AgentTool } from '@earendil-works/pi-agent-core'
+import {
+  AgentHarness,
+  Session,
+  type AgentTool,
+  type ThinkingLevel,
+} from '@earendil-works/pi-agent-core'
 import { NodeExecutionEnv } from '@earendil-works/pi-agent-core/node'
 import { getModel } from '@earendil-works/pi-ai'
 import { Type, type TSchema } from '@sinclair/typebox'
@@ -29,6 +34,7 @@ export interface CreateAgentSessionParams {
   userId?: string
   userCommentId?: string | null
   customTools?: AgentTool[]
+  thinkingLevel?: string
   providers: Array<{
     name: string
     config: PrismaJson.ProviderConfig
@@ -53,6 +59,7 @@ export async function createAgentSession(params: CreateAgentSessionParams) {
     userId,
     userCommentId: passedUserCommentId,
     customTools = [],
+    thinkingLevel,
   } = params
 
   const storage = await DatabaseSessionStorage.create({
@@ -233,6 +240,7 @@ export async function createAgentSession(params: CreateAgentSessionParams) {
     env: new NodeExecutionEnv({ cwd: process.cwd() }),
     session,
     model,
+    thinkingLevel: (thinkingLevel || 'off') as ThinkingLevel,
     systemPrompt: async () => {
       let prompt = systemPrompt
 

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -39,7 +39,7 @@ const route = new Hono<{ Variables: { user: User } }>()
           avatar: (await getAvatarUrl(agent.user.image)) || undefined,
           providerId: agent.providerId || undefined,
           modelId: agent.modelId || undefined,
-          thinkingLevel: config.thinkingLevel || '',
+          thinkingLevel: config.thinkingLevel || 'off',
           systemPrompt: config.systemPrompt,
           soul: agent.soul || undefined,
           skills: agent.skills.map((s) => ({
@@ -81,7 +81,7 @@ const route = new Hono<{ Variables: { user: User } }>()
       avatar: (await getAvatarUrl(agent.user.image)) || undefined,
       providerId: agent.providerId || undefined,
       modelId: agent.modelId || undefined,
-      thinkingLevel: config.thinkingLevel || '',
+      thinkingLevel: config.thinkingLevel || 'off',
       systemPrompt: config.systemPrompt,
       soul: agent.soul || undefined,
       skills: agent.skills.map((s) => ({
@@ -119,7 +119,7 @@ const route = new Hono<{ Variables: { user: User } }>()
       avatar: (await getAvatarUrl(agent.user.image)) || undefined,
       providerId: agent.providerId || undefined,
       modelId: agent.modelId || undefined,
-      thinkingLevel: config.thinkingLevel || '',
+      thinkingLevel: config.thinkingLevel || 'off',
       systemPrompt: config.systemPrompt,
       soul: agent.soul || undefined,
       skills: agent.skills.map((s) => ({

--- a/packages/db/src/prisma-json-types.ts
+++ b/packages/db/src/prisma-json-types.ts
@@ -27,7 +27,7 @@ declare global {
     export interface AgentConfig {
       provider: string
       model: string
-      thinkingLevel?: string
+      thinkingLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
       systemPrompt?: string
       appendSystemPrompt?: string[]
     }

--- a/packages/dtos/src/agent.ts
+++ b/packages/dtos/src/agent.ts
@@ -3,6 +3,9 @@ import { z } from 'zod'
 export const agentTypeSchema = z.enum(['chat', 'autofill', 'embedding'])
 export type AgentType = z.infer<typeof agentTypeSchema>
 
+export const thinkingLevelSchema = z.enum(['off', 'minimal', 'low', 'medium', 'high', 'xhigh'])
+export type ThinkingLevel = z.infer<typeof thinkingLevelSchema>
+
 export const agentSkillSchema = z.object({
   id: z.string().optional(),
   skillId: z.string(),
@@ -23,7 +26,7 @@ export const agentInfoSchema = z.object({
   avatar: z.string().optional(),
   providerId: z.string().optional(),
   modelId: z.string().optional(),
-  thinkingLevel: z.string().optional().default(''),
+  thinkingLevel: thinkingLevelSchema.optional().default('off'),
   systemPrompt: z.string().optional(),
   soul: z.string().optional(),
   skills: z.array(agentSkillSchema).optional(),
@@ -37,7 +40,7 @@ const baseAgentRequest = z.object({
   avatar: z.string().optional(),
   providerId: z.string().optional(),
   modelId: z.string().optional(),
-  thinkingLevel: z.string().optional().default(''),
+  thinkingLevel: thinkingLevelSchema.optional().default('off'),
   systemPrompt: z.string().optional(),
   soul: z.string().optional(),
   skills: z.array(z.string()).optional(),

--- a/packages/webui/components/settings/AgentFormDialog.tsx
+++ b/packages/webui/components/settings/AgentFormDialog.tsx
@@ -116,7 +116,7 @@ export function AgentFormDialog({
   const form = useForm({
     defaultValues: {
       name: initialValues?.name || '',
-      type: type || initialValues?.type || 'chat',
+      type: initialValues?.type || type || 'chat',
       avatar: initialValues?.avatar || AVAILABLE_AVATARS[0],
       providerId: initialValues?.providerId || '',
       modelId: initialValues?.modelId || '',

--- a/packages/webui/components/settings/AgentFormDialog.tsx
+++ b/packages/webui/components/settings/AgentFormDialog.tsx
@@ -400,17 +400,19 @@ export function AgentFormDialog({
                         children={(field) => (
                           <Field>
                             <FieldLabel>Thinking Level</FieldLabel>
-                            <Select value={field.state.value} onValueChange={(val) => field.handleChange(val as ThinkingLevel)}>
+                            <Select
+                              value={field.state.value}
+                              onValueChange={(val) => field.handleChange(val as ThinkingLevel)}
+                            >
                               <SelectTrigger>
                                 <SelectValue />
                               </SelectTrigger>
                               <SelectContent>
-                                <SelectItem value="off">Off</SelectItem>
-                                <SelectItem value="minimal">Minimal</SelectItem>
-                                <SelectItem value="low">Low (Fast)</SelectItem>
-                                <SelectItem value="medium">Medium (Balanced)</SelectItem>
-                                <SelectItem value="high">High (Reasoning)</SelectItem>
-                                <SelectItem value="xhigh">Extra High</SelectItem>
+                                {thinkingLevelSchema.options.map((level) => (
+                                  <SelectItem key={level} value={level}>
+                                    {level.charAt(0).toUpperCase() + level.slice(1)}
+                                  </SelectItem>
+                                ))}
                               </SelectContent>
                             </Select>
                           </Field>

--- a/packages/webui/components/settings/AgentFormDialog.tsx
+++ b/packages/webui/components/settings/AgentFormDialog.tsx
@@ -24,7 +24,7 @@ import { useForm, useStore } from '@tanstack/react-form'
 import { Loader2, Puzzle } from 'lucide-react'
 import { useEffect, useMemo } from 'react'
 import { toast } from 'sonner'
-import { AgentInfo, AgentType } from '@shumai/dtos'
+import { AgentInfo, AgentType, ThinkingLevel, thinkingLevelSchema } from '@shumai/dtos'
 import { Textarea } from '@/ui/components/ui/textarea'
 import { ScrollArea } from '@/ui/components/ui/scroll-area'
 import { z } from 'zod'
@@ -47,7 +47,7 @@ const agentFormSchema = z.object({
   providerId: z.string().optional(),
   modelId: z.string().optional(),
   soul: z.string().optional(),
-  thinkingLevel: z.string().optional(),
+  thinkingLevel: thinkingLevelSchema.optional(),
   systemPrompt: z.string().optional(),
   skills: z.array(z.string()).optional(),
 })
@@ -121,7 +121,7 @@ export function AgentFormDialog({
       providerId: initialValues?.providerId || '',
       modelId: initialValues?.modelId || '',
       soul: initialValues?.soul || '',
-      thinkingLevel: initialValues?.thinkingLevel || 'medium',
+      thinkingLevel: initialValues?.thinkingLevel || 'off',
       systemPrompt: initialValues?.systemPrompt || '',
       skills: initialValues?.skills?.map((s) => s.skillId) || ([] as string[]),
     } as AgentFormValues,
@@ -400,14 +400,17 @@ export function AgentFormDialog({
                         children={(field) => (
                           <Field>
                             <FieldLabel>Thinking Level</FieldLabel>
-                            <Select value={field.state.value} onValueChange={field.handleChange}>
+                            <Select value={field.state.value} onValueChange={(val) => field.handleChange(val as ThinkingLevel)}>
                               <SelectTrigger>
                                 <SelectValue />
                               </SelectTrigger>
                               <SelectContent>
+                                <SelectItem value="off">Off</SelectItem>
+                                <SelectItem value="minimal">Minimal</SelectItem>
                                 <SelectItem value="low">Low (Fast)</SelectItem>
                                 <SelectItem value="medium">Medium (Balanced)</SelectItem>
                                 <SelectItem value="high">High (Reasoning)</SelectItem>
+                                <SelectItem value="xhigh">Extra High</SelectItem>
                               </SelectContent>
                             </Select>
                           </Field>

--- a/packages/webui/components/settings/AgentsSettings.tsx
+++ b/packages/webui/components/settings/AgentsSettings.tsx
@@ -16,7 +16,7 @@ import {
 } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'
-import { AgentInfo, AgentType } from '@shumai/dtos'
+import { AgentInfo, AgentType, ThinkingLevel } from '@shumai/dtos'
 import { AgentFormDialog } from './AgentFormDialog'
 import {
   DropdownMenu,
@@ -104,7 +104,7 @@ export function AgentsSettings({ teamId }: AgentsSettingsProps) {
       avatar?: string
       providerId?: string
       modelId?: string
-      thinkingLevel?: string
+      thinkingLevel?: ThinkingLevel
       systemPrompt?: string
       soul?: string
       skills?: string[]

--- a/packages/webui/components/settings/AgentsSettings.tsx
+++ b/packages/webui/components/settings/AgentsSettings.tsx
@@ -206,6 +206,7 @@ export function AgentsSettings({ teamId }: AgentsSettingsProps) {
           {AGENT_TYPES.map((section) => {
             const typeAgents = agents.filter((a) => a.type === section.type)
             const Icon = section.icon
+            const isSingleAgentType = section.type === 'autofill' || section.type === 'embedding'
 
             return (
               <div
@@ -213,20 +214,24 @@ export function AgentsSettings({ teamId }: AgentsSettingsProps) {
                 className="bg-card rounded-xl border border-border overflow-hidden"
               >
                 <div
-                  className="px-6 py-4 flex items-center justify-between cursor-pointer hover:bg-muted/50 transition-colors"
-                  onClick={() => toggleSection(section.type)}
+                  className={cn(
+                    'px-6 py-4 flex items-center justify-between',
+                    !isSingleAgentType && 'cursor-pointer hover:bg-muted/50 transition-colors',
+                  )}
+                  onClick={!isSingleAgentType ? () => toggleSection(section.type) : undefined}
                 >
                   <div className="flex items-center gap-2">
-                    <h3 className="font-semibold text-foreground">{section.label} Agents</h3>
-                    <Badge variant="secondary" className="h-5 px-1.5 min-w-[1.25rem] text-[10px]">
-                      {typeAgents.length}
-                    </Badge>
+                    <h3 className="font-semibold text-foreground">
+                      {section.label} {isSingleAgentType ? 'Agent' : 'Agents'}
+                    </h3>
+                    {!isSingleAgentType && (
+                      <Badge variant="secondary" className="h-5 px-1.5 min-w-[1.25rem] text-[10px]">
+                        {typeAgents.length}
+                      </Badge>
+                    )}
                   </div>
                   <div className="flex items-center gap-2">
-                    {!(
-                      (section.type === 'autofill' || section.type === 'embedding') &&
-                      typeAgents.length > 0
-                    ) && (
+                    {!(isSingleAgentType && typeAgents.length > 0) && (
                       <Button
                         variant="ghost"
                         size="icon"
@@ -240,16 +245,18 @@ export function AgentsSettings({ teamId }: AgentsSettingsProps) {
                         <Plus className="w-4 h-4" />
                       </Button>
                     )}
-                    <ChevronDown
-                      className={cn(
-                        'w-5 h-5 text-muted-foreground transition-transform duration-200',
-                        expandedSections[section.type] ? 'rotate-180' : '',
-                      )}
-                    />
+                    {!isSingleAgentType && (
+                      <ChevronDown
+                        className={cn(
+                          'w-5 h-5 text-muted-foreground transition-transform duration-200',
+                          expandedSections[section.type] ? 'rotate-180' : '',
+                        )}
+                      />
+                    )}
                   </div>
                 </div>
 
-                {expandedSections[section.type] && (
+                {(isSingleAgentType || expandedSections[section.type]) && (
                   <div className="px-6 pb-6 pt-2 space-y-3">
                     <div className="grid grid-cols-1 gap-4">
                       {typeAgents.map((agent) => (
@@ -338,7 +345,7 @@ export function AgentsSettings({ teamId }: AgentsSettingsProps) {
                             <Icon className="w-5 h-5 text-muted-foreground" />
                           </div>
                           <p className="text-sm text-muted-foreground">
-                            No {section.label} agents found
+                            No {section.label} {isSingleAgentType ? 'agent' : 'agents'} found
                           </p>
                           <Button
                             variant="link"


### PR DESCRIPTION
## Summary

This PR addresses three Agent Settings UI and backend issues:
1. Since users can create only one Autofill or Embedding agent, we now display these headers in singular form ("Autofill Agent", "Embedding Agent"), remove the redundant counters from their headers, and remove the collapse/expand option.
2. Fixes a bug where editing an existing Embedding agent would incorrectly show the same config fields as a Chat/Autofill agent instead of only showing name/avatar.
3. Fixes a bug where the `thinkingLevel` preference configured in UI/DB was not passed to `AgentHarness` when creating agent sessions, defaulting it to `"off"` for type-safety and alignment.

## Changes

- Updated packages/webui/components/settings/AgentsSettings.tsx to handle Autofill and Embedding agents as single agent types (`isSingleAgentType`) and typed parameters in update mutations using the imported `ThinkingLevel` type.
- Changed headers for `isSingleAgentType` sections to use singular `Agent` instead of plural `Agents` (e.g. `Autofill Agent` instead of `Autofill Agents`).
- Removed `Badge` count/counter from the header for single agent types.
- Removed collapse/expand functionality (and `ChevronDown` arrow, pointer cursor, and hover styles) from single agent type headers, ensuring their panels remain expanded.
- Adjusted empty state text to singular (`No Autofill agent found` and `No Embedding agent found`).
- Updated packages/webui/components/settings/AgentFormDialog.tsx to prioritize `initialValues?.type` over the `type` prop when initializing form default values, ensuring the correct configuration inputs are rendered when editing an Embedding agent.
- Defined and exported `thinkingLevelSchema` and `ThinkingLevel` type inside packages/dtos/src/agent.ts to establish single point of definition and reuse it across frontend and backend.
- Updated `PrismaJson.AgentConfig` in packages/db/src/prisma-json-types.ts to enforce type-safety for `thinkingLevel`.
- Propagated the `thinkingLevel` from `agent.config` in packages/agent/src/activities/agent.ts down to `createAgentSession` parameters and `AgentHarness` initialization in packages/agent/src/index.ts.
- Added unit tests in packages/agent/src/index.test.ts and packages/agent/src/activities/agent.test.ts to reproduce the missing propagation and verify correct defaults.

## Verification

- Ran `bun run lint` successfully.
- Ran `bun run format` successfully.
- Ran `bun run typecheck` successfully.
- Ran `bun run test` (all 72 test suites, 527 tests passed).

## Notes

None.