### PR TITLE
feat(folders): auto expand folder tree in left sidebar on navigation

### DIFF
--- a/packages/webui/components/file-system-manager.tsx
+++ b/packages/webui/components/file-system-manager.tsx
@@ -448,6 +448,7 @@ export default function FileSystemManager({
                   projectName={projectName}
                   rootFolderId={rootFolderId}
                   dragState={dragState}
+                  ancestorFolders={folderInfo?.ancestorFolders ?? []}
                 />
               </div>
               <ResizeHandle

--- a/packages/webui/components/folder-tree.tsx
+++ b/packages/webui/components/folder-tree.tsx
@@ -26,6 +26,7 @@ import {
   DropdownMenuSeparator,
 } from '@/ui/components/ui/dropdown-menu'
 import { Input } from '@/ui/components/ui/input'
+import { ScrollArea } from '@/ui/components/ui/scroll-area'
 import { usePermissions } from '@/ui/hooks/use-permissions'
 import { cn } from '@/ui/lib/utils'
 import { useDraggable, useDroppable } from '@dnd-kit/react'
@@ -466,72 +467,75 @@ export function FolderTree({
           </div>
         </header>
 
-        <div
+        <ScrollArea
           className={cn(
-            'flex-1 overflow-y-auto min-h-0 space-y-0.5 pr-1 transition-all duration-300 ease-in-out',
+            'flex-1 min-h-0 transition-all duration-300 ease-in-out',
             isAssetsExpanded
               ? 'opacity-100 visible pointer-events-auto'
               : 'opacity-0 invisible pointer-events-none h-0',
           )}
         >
-          <FolderTreeItem
-            key={rootFolderId}
-            teamId={teamId}
-            projectId={projectId}
-            folder={{
-              id: rootFolderId,
-              name: projectName,
-              type: 'folder',
-              sizeByte: 0,
-              fileCount: 0,
-              status: 'processed',
-              mediaType: null,
-              createdAt: '',
-              updatedAt: '',
-            }}
-            level={0}
-            isRoot={true}
-            dragState={dragState}
-            onSelect={onSelect}
-            selectedFolderId={selectedFolderId}
-            canEdit={canEdit}
-            onRenameTrigger={(id, currentName) => {
-              setRenameId(id)
-              setRenameType('folder')
-              setRenameName(currentName)
-              setIsRenameOpen(true)
-            }}
-            onDeleteTrigger={(id) => {
-              setDeleteId(id)
-              setDeleteType('folder')
-              setIsDeleteOpen(true)
-            }}
-            onDownloadTrigger={(id) => {
-              handleDownloadFolder(id)
-            }}
-            ancestorFolders={ancestorFolders}
-          />
+          <div className="space-y-0.5 pr-1">
+            <FolderTreeItem
+              key={rootFolderId}
+              teamId={teamId}
+              projectId={projectId}
+              folder={{
+                id: rootFolderId,
+                name: projectName,
+                type: 'folder',
+                sizeByte: 0,
+                fileCount: 0,
+                status: 'processed',
+                mediaType: null,
+                createdAt: '',
+                updatedAt: '',
+              }}
+              level={0}
+              isRoot={true}
+              dragState={dragState}
+              onSelect={onSelect}
+              selectedFolderId={selectedFolderId}
+              canEdit={canEdit}
+              onRenameTrigger={(id, currentName) => {
+                setRenameId(id)
+                setRenameType('folder')
+                setRenameName(currentName)
+                setIsRenameOpen(true)
+              }}
+              onDeleteTrigger={(id) => {
+                setDeleteId(id)
+                setDeleteType('folder')
+                setIsDeleteOpen(true)
+              }}
+              onDownloadTrigger={(id) => {
+                handleDownloadFolder(id)
+              }}
+              ancestorFolders={ancestorFolders}
+            />
 
-          {canEdit && (
-            <div
-              className={cn(
-                'group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-                isRecentlyDeleted && 'bg-sidebar-accent text-sidebar-accent-foreground font-medium',
-              )}
-              onClick={() =>
-                navigate({
-                  to: '/projects/$projectId/recently-deleted',
-                  params: { projectId },
-                })
-              }
-            >
-              <div className="flex h-4 w-4 items-center justify-center">
-                <Trash2 className="h-4 w-4 text-sidebar-primary" />
+            {canEdit && (
+              <div
+                className={cn(
+                  'group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+                  isRecentlyDeleted &&
+                    'bg-sidebar-accent text-sidebar-accent-foreground font-medium',
+                )}
+                onClick={() =>
+                  navigate({
+                    to: '/projects/$projectId/recently-deleted',
+                    params: { projectId },
+                  })
+                }
+              >
+                <div className="flex h-4 w-4 items-center justify-center">
+                  <Trash2 className="h-4 w-4 text-sidebar-primary" />
+                </div>
+                <span className="flex-1 truncate text-sidebar-foreground">Recently Deleted</span>
               </div>
-              <span className="flex-1 truncate text-sidebar-foreground">Recently Deleted</span>
-            </div>
-          )}
-        </div>
+            )}
+          </div>
+        </ScrollArea>
       </div>
 
       {!hideCollections && (
@@ -563,106 +567,108 @@ export function FolderTree({
             )}
           </header>
 
-          <div
+          <ScrollArea
             className={cn(
-              'flex-1 overflow-y-auto min-h-0 space-y-0.5 pr-1 transition-all duration-300 ease-in-out',
+              'flex-1 min-h-0 transition-all duration-300 ease-in-out',
               isCollectionsExpanded
                 ? 'opacity-100 visible pointer-events-auto'
                 : 'opacity-0 invisible pointer-events-none h-0',
             )}
           >
-            <div
-              className="group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-              onClick={() =>
-                navigate({
-                  to: '/projects/$projectId/collections',
-                  params: { projectId },
-                })
-              }
-            >
-              <div className="flex h-4 w-4 items-center justify-center">
-                <LayoutGrid className="h-4 w-4 text-sidebar-primary" />
-              </div>
-              <span className="flex-1 truncate text-sidebar-foreground">
-                All Collections ({collectionsData?.pages[0]?.pageInfo?.total || 0})
-              </span>
-            </div>
-
-            {collections.map((collection) => {
-              const isColActive = params?.collectionId === collection.id
-              return (
-                <div
-                  key={collection.id}
-                  className={cn(
-                    'group flex cursor-pointer items-center justify-between rounded-md px-2 py-1 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-                    isColActive && 'bg-sidebar-accent text-sidebar-accent-foreground font-medium',
-                  )}
-                  onClick={() =>
-                    navigate({
-                      to: '/projects/$projectId/collections/$collectionId',
-                      params: { projectId, collectionId: collection.id },
-                    })
-                  }
-                >
-                  <div className="flex items-center gap-2 min-w-0 flex-1">
-                    <div className="flex h-4 w-4 items-center justify-center shrink-0">
-                      <Bookmark className="h-4 w-4 text-sidebar-primary" />
-                    </div>
-                    <span className="truncate text-sidebar-foreground flex-1">
-                      {collection.name}
-                    </span>
-                  </div>
-
-                  {canEdit && (
-                    <div
-                      className="opacity-0 group-hover:opacity-100 transition-opacity"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <DropdownMenu modal={false}>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon-sm"
-                            className="h-6 w-6 shrink-0 hover:bg-muted hover:text-muted-foreground p-0"
-                          >
-                            <MoreHorizontal className="h-3.5 w-3.5" />
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" className="w-32">
-                          <DropdownMenuItem
-                            onClick={() => {
-                              setRenameId(collection.id)
-                              setRenameType('collection')
-                              setRenameName(collection.name)
-                              setIsRenameOpen(true)
-                            }}
-                          >
-                            Rename
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            className="text-destructive focus:text-destructive focus:bg-destructive/10"
-                            onClick={() => {
-                              setDeleteId(collection.id)
-                              setDeleteType('collection')
-                              setIsDeleteOpen(true)
-                            }}
-                          >
-                            Delete
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </div>
-                  )}
+            <div className="space-y-0.5 pr-1">
+              <div
+                className="group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                onClick={() =>
+                  navigate({
+                    to: '/projects/$projectId/collections',
+                    params: { projectId },
+                  })
+                }
+              >
+                <div className="flex h-4 w-4 items-center justify-center">
+                  <LayoutGrid className="h-4 w-4 text-sidebar-primary" />
                 </div>
-              )
-            })}
-            <div ref={collectionsInViewRef} className="h-1" />
-            {isFetchingNextCollections && (
-              <div className="flex justify-center p-2">
-                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                <span className="flex-1 truncate text-sidebar-foreground">
+                  All Collections ({collectionsData?.pages[0]?.pageInfo?.total || 0})
+                </span>
               </div>
-            )}
-          </div>
+
+              {collections.map((collection) => {
+                const isColActive = params?.collectionId === collection.id
+                return (
+                  <div
+                    key={collection.id}
+                    className={cn(
+                      'group flex cursor-pointer items-center justify-between rounded-md px-2 py-1 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+                      isColActive && 'bg-sidebar-accent text-sidebar-accent-foreground font-medium',
+                    )}
+                    onClick={() =>
+                      navigate({
+                        to: '/projects/$projectId/collections/$collectionId',
+                        params: { projectId, collectionId: collection.id },
+                      })
+                    }
+                  >
+                    <div className="flex items-center gap-2 min-w-0 flex-1">
+                      <div className="flex h-4 w-4 items-center justify-center shrink-0">
+                        <Bookmark className="h-4 w-4 text-sidebar-primary" />
+                      </div>
+                      <span className="truncate text-sidebar-foreground flex-1">
+                        {collection.name}
+                      </span>
+                    </div>
+
+                    {canEdit && (
+                      <div
+                        className="opacity-0 group-hover:opacity-100 transition-opacity"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <DropdownMenu modal={false}>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon-sm"
+                              className="h-6 w-6 shrink-0 hover:bg-muted hover:text-muted-foreground p-0"
+                            >
+                              <MoreHorizontal className="h-3.5 w-3.5" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end" className="w-32">
+                            <DropdownMenuItem
+                              onClick={() => {
+                                setRenameId(collection.id)
+                                setRenameType('collection')
+                                setRenameName(collection.name)
+                                setIsRenameOpen(true)
+                              }}
+                            >
+                              Rename
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              className="text-destructive focus:text-destructive focus:bg-destructive/10"
+                              onClick={() => {
+                                setDeleteId(collection.id)
+                                setDeleteType('collection')
+                                setIsDeleteOpen(true)
+                              }}
+                            >
+                              Delete
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+              <div ref={collectionsInViewRef} className="h-1" />
+              {isFetchingNextCollections && (
+                <div className="flex justify-center p-2">
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                </div>
+              )}
+            </div>
+          </ScrollArea>
         </div>
       )}
 
@@ -697,58 +703,60 @@ export function FolderTree({
             )}
           </header>
 
-          <div
+          <ScrollArea
             className={cn(
-              'flex-1 overflow-y-auto min-h-0 space-y-0.5 pr-1 transition-all duration-300 ease-in-out',
+              'flex-1 min-h-0 transition-all duration-300 ease-in-out',
               isSharesExpanded
                 ? 'opacity-100 visible pointer-events-auto'
                 : 'opacity-0 invisible pointer-events-none h-0',
             )}
           >
-            <div
-              className="group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-              onClick={() =>
-                navigate({
-                  to: '/projects/$projectId/shares',
-                  params: { projectId },
-                })
-              }
-            >
-              <div className="flex h-4 w-4 items-center justify-center">
-                <LayoutGrid className="h-4 w-4 text-sidebar-primary" />
+            <div className="space-y-0.5 pr-1">
+              <div
+                className="group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                onClick={() =>
+                  navigate({
+                    to: '/projects/$projectId/shares',
+                    params: { projectId },
+                  })
+                }
+              >
+                <div className="flex h-4 w-4 items-center justify-center">
+                  <LayoutGrid className="h-4 w-4 text-sidebar-primary" />
+                </div>
+                <span className="flex-1 truncate text-sidebar-foreground">
+                  All Share Links ({shareLinksData?.pages[0]?.pageInfo?.total || 0})
+                </span>
               </div>
-              <span className="flex-1 truncate text-sidebar-foreground">
-                All Share Links ({shareLinksData?.pages[0]?.pageInfo?.total || 0})
-              </span>
-            </div>
 
-            {shareLinks.map((link) => (
-              <ShareLinkItem
-                key={link.id}
-                link={link}
-                projectId={projectId}
-                dragState={dragState}
-                canEdit={canEdit}
-                onRenameTrigger={(id, currentName) => {
-                  setRenameId(id)
-                  setRenameType('share')
-                  setRenameName(currentName)
-                  setIsRenameOpen(true)
-                }}
-                onDeleteTrigger={(id) => {
-                  setDeleteId(id)
-                  setDeleteType('share')
-                  setIsDeleteOpen(true)
-                }}
-              />
-            ))}
-            <div ref={sharesInViewRef} className="h-1" />
-            {isFetchingNextShareLinks && (
-              <div className="flex justify-center p-2">
-                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-              </div>
-            )}
-          </div>
+              {shareLinks.map((link) => (
+                <ShareLinkItem
+                  key={link.id}
+                  link={link}
+                  projectId={projectId}
+                  dragState={dragState}
+                  canEdit={canEdit}
+                  onRenameTrigger={(id, currentName) => {
+                    setRenameId(id)
+                    setRenameType('share')
+                    setRenameName(currentName)
+                    setIsRenameOpen(true)
+                  }}
+                  onDeleteTrigger={(id) => {
+                    setDeleteId(id)
+                    setDeleteType('share')
+                    setIsDeleteOpen(true)
+                  }}
+                />
+              ))}
+              <div ref={sharesInViewRef} className="h-1" />
+              {isFetchingNextShareLinks && (
+                <div className="flex justify-center p-2">
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                </div>
+              )}
+            </div>
+          </ScrollArea>
         </div>
       )}
 

--- a/packages/webui/components/folder-tree.tsx
+++ b/packages/webui/components/folder-tree.tsx
@@ -475,7 +475,7 @@ export function FolderTree({
               : 'opacity-0 invisible pointer-events-none h-0',
           )}
         >
-          <div className="space-y-0.5 pr-1">
+          <div className="space-y-0.5 pr-3">
             <FolderTreeItem
               key={rootFolderId}
               teamId={teamId}
@@ -575,7 +575,7 @@ export function FolderTree({
                 : 'opacity-0 invisible pointer-events-none h-0',
             )}
           >
-            <div className="space-y-0.5 pr-1">
+            <div className="space-y-0.5 pr-3">
               <div
                 className="group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
                 onClick={() =>
@@ -711,7 +711,7 @@ export function FolderTree({
                 : 'opacity-0 invisible pointer-events-none h-0',
             )}
           >
-            <div className="space-y-0.5 pr-1">
+            <div className="space-y-0.5 pr-3">
               <div
                 className="group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
                 onClick={() =>

--- a/packages/webui/components/folder-tree.tsx
+++ b/packages/webui/components/folder-tree.tsx
@@ -29,7 +29,13 @@ import { Input } from '@/ui/components/ui/input'
 import { usePermissions } from '@/ui/hooks/use-permissions'
 import { cn } from '@/ui/lib/utils'
 import { useDraggable, useDroppable } from '@dnd-kit/react'
-import type { AssetInfo, AssetInfoPaginatedList, CollectionInfo, ShareLinkInfo } from '@shumai/dtos'
+import type {
+  AssetInfo,
+  AssetInfoPaginatedList,
+  CollectionInfo,
+  ShareLinkInfo,
+  AncestorFolder,
+} from '@shumai/dtos'
 import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useMatch, useNavigate, useParams } from '@tanstack/react-router'
 import {
@@ -65,6 +71,7 @@ interface FolderTreeProps {
   selectedFolderId?: string
   hideCollections?: boolean
   hideShares?: boolean
+  ancestorFolders?: AncestorFolder[]
 }
 
 export function FolderTree({
@@ -77,6 +84,7 @@ export function FolderTree({
   selectedFolderId,
   hideCollections,
   hideShares,
+  ancestorFolders,
 }: FolderTreeProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
@@ -501,6 +509,7 @@ export function FolderTree({
             onDownloadTrigger={(id) => {
               handleDownloadFolder(id)
             }}
+            ancestorFolders={ancestorFolders}
           />
 
           {canEdit && (
@@ -1011,6 +1020,7 @@ interface FolderTreeItemProps {
   onRenameTrigger: (id: string, name: string) => void
   onDeleteTrigger: (id: string) => void
   onDownloadTrigger: (id: string) => void
+  ancestorFolders?: AncestorFolder[]
 }
 
 function FolderTreeItem({
@@ -1026,8 +1036,19 @@ function FolderTreeItem({
   onRenameTrigger,
   onDeleteTrigger,
   onDownloadTrigger,
+  ancestorFolders,
 }: FolderTreeItemProps) {
-  const [isExpanded, setIsExpanded] = useState(isRoot || false)
+  const isAncestor = useMemo(() => {
+    return ancestorFolders?.some((f) => f.id === folder.id) ?? false
+  }, [ancestorFolders, folder.id])
+
+  const [isExpanded, setIsExpanded] = useState(isRoot || isAncestor)
+
+  useEffect(() => {
+    if (isAncestor) {
+      setIsExpanded(true)
+    }
+  }, [isAncestor])
   const navigate = useNavigate()
   const params = useParams({
     from: '/projects/$projectId/folders/$folderId',
@@ -1246,6 +1267,7 @@ function FolderTreeItem({
               onRenameTrigger={onRenameTrigger}
               onDeleteTrigger={onDeleteTrigger}
               onDownloadTrigger={onDownloadTrigger}
+              ancestorFolders={ancestorFolders}
             />
           ))}
           {hasNextPage && (


### PR DESCRIPTION
## Summary

This PR enables the folder tree in the left sidebar to automatically expand parent folders when navigating directly to a subfolder (e.g. `/projects/$projectId/folders/a-b-c`), and migrates the left sidebar lists to use Shadcn's `<ScrollArea>` component instead of standard native overflow-y-auto divs.

## Changes

- **packages/webui/components/folder-tree.tsx**:
  - Added `ancestorFolders` prop to the `FolderTree` and `FolderTreeItem` components. Introduced logic inside `FolderTreeItem` to verify if the folder is an ancestor of the current route, initializing `isExpanded` to `true` and listening to `ancestorFolders` changes via `useEffect` to trigger cascading expansion down the hierarchy.
  - Replaced standard native `overflow-y-auto` divs for **Assets**, **Collections**, and **Share Links** scrollable containers with Shadcn's `<ScrollArea>` component, wrapping list contents in appropriate layout wrapper divs to maintain consistent spacing and custom scrollbars.
- **packages/webui/components/file-system-manager.tsx**: Passed `folderInfo?.ancestorFolders` down to `<FolderTree />` component call.

## Verification

All code checks and formatting checks have passed successfully:
- `bun run typecheck` (Passed)
- `bun run lint` (Passed)
- `bun run format` (Passed)
- `bun run test` (Passed 72 test files, 527 tests)

## Notes

No external dependencies added. The `ancestorFolders` property is optional, ensuring compatibility in dialogs or pages where the breadcrumb/ancestor structure is not present.
