### PR TITLE
chore(cli): rename npm package to @shumai-one/shumai-cli

### DIFF
--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -572,7 +572,7 @@ async function buildCliPackage() {
 
   // Generate package.json for CLI
   const packageJson = {
-    name: '@shumai-one/cli',
+    name: '@shumai-one/shumai-cli',
     version,
     description: 'Command line interface for the shumai media workspace',
     type: 'module',

--- a/scripts/release-local.ts
+++ b/scripts/release-local.ts
@@ -181,7 +181,7 @@ const wrapperAppNames = [
   '@shumai-one/shumai',
   '@shumai-one/shumai-agent',
   '@shumai-one/shumai-transcode',
-  '@shumai-one/cli',
+  '@shumai-one/shumai-cli',
 ]
 const dependencies = Object.fromEntries(
   packages


### PR DESCRIPTION
## Summary

Rename the published NPM package for the CLI to `@shumai-one/shumai-cli`.

## Changes

- Updated the `name` field in `scripts/build-npm.ts` CLI package metadata to `@shumai-one/shumai-cli`.
- Updated the CLI package name reference in `scripts/release-local.ts` `wrapperAppNames` list to `@shumai-one/shumai-cli`.

## Verification

- Ran `bun run lint` successfully.
- Ran `bun run format` successfully.
- Ran `bun run typecheck` successfully.
- Ran `bun run test` successfully.

## Notes

None.
