### PR TITLE
fix(webui): truncate long folder, collection, and share link names in sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ AWS_ENDPOINT_URL_S3=http://localhost
 
 #### Step 6: Run Shumai
 
+> [!IMPORTANT]
+> **For Bun Users:** Since the published package binaries contain a `#!/usr/bin/env node` shebang, running the global command directly (e.g., `shumai`) will execute under Node.js. If you installed with Bun and want to run under the Bun runtime, you must prefix all commands with `bun run --bun` (e.g., `bun run --bun shumai`, `bun run --bun shumai -d`, `bun run --bun shumai stop`).
+
 Start the application from your workspace folder:
 
 ```bash

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -26,6 +26,9 @@ export SHUMAI_API_KEY="your-developer-api-token"
 
 ## Usage
 
+> [!IMPORTANT]
+> **For Bun Users:** Since the package binary contains a `#!/usr/bin/env node` shebang, running `shumai-cli` directly will run under Node.js. If you wish to run it using Bun, prefix the command with `bun run --bun` (e.g., `bun run --bun shumai-cli project ls`).
+
 Run `shumai-cli` or query specific commands:
 
 ```bash

--- a/docs/configuration/temporal.mdx
+++ b/docs/configuration/temporal.mdx
@@ -80,3 +80,6 @@ Run this on your sandboxed agent execution nodes (requires sandbox dependencies 
 npm install -g @shumai-one/shumai-agent
 shumai-agent
 ```
+
+> [!IMPORTANT]
+> **For Bun Users:** Since the worker package binaries contain a `#!/usr/bin/env node` shebang, running `shumai-transcode` or `shumai-agent` directly will run under Node.js. If you wish to run them using Bun, prefix the commands with `bun run --bun` (e.g., `bun run --bun shumai-transcode` or `bun run --bun shumai-agent`).

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -72,9 +72,14 @@ To handle media processing and security isolation, the host machine must have th
     AWS_ENDPOINT_URL_S3=http://localhost
     ```
 4.  **Start Shumai**:
+
+    > [!IMPORTANT]
+    > **For Bun Users:** Since the published package binaries contain a `#!/usr/bin/env node` shebang, running `shumai` directly will execute under Node.js. If you installed using Bun and want to run it under the Bun runtime, prefix the command with `bun run --bun` (e.g., `bun run --bun shumai`).
+
     ```bash
     shumai
     ```
+
     Open your browser to `http://localhost:3000`.
 
 ---

--- a/packages/webui/components/folder-tree.tsx
+++ b/packages/webui/components/folder-tree.tsx
@@ -469,7 +469,7 @@ export function FolderTree({
 
         <ScrollArea
           className={cn(
-            'flex-1 min-h-0 transition-all duration-300 ease-in-out',
+            'flex-1 min-h-0 transition-all duration-300 ease-in-out [&>div>div]:block!',
             isAssetsExpanded
               ? 'opacity-100 visible pointer-events-auto'
               : 'opacity-0 invisible pointer-events-none h-0',
@@ -569,7 +569,7 @@ export function FolderTree({
 
           <ScrollArea
             className={cn(
-              'flex-1 min-h-0 transition-all duration-300 ease-in-out',
+              'flex-1 min-h-0 transition-all duration-300 ease-in-out [&>div>div]:block!',
               isCollectionsExpanded
                 ? 'opacity-100 visible pointer-events-auto'
                 : 'opacity-0 invisible pointer-events-none h-0',
@@ -599,7 +599,7 @@ export function FolderTree({
                   <div
                     key={collection.id}
                     className={cn(
-                      'group flex cursor-pointer items-center justify-between rounded-md px-2 py-1 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+                      'group flex cursor-pointer items-center justify-between rounded-md px-2 py-1 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground min-w-0',
                       isColActive && 'bg-sidebar-accent text-sidebar-accent-foreground font-medium',
                     )}
                     onClick={() =>
@@ -620,7 +620,7 @@ export function FolderTree({
 
                     {canEdit && (
                       <div
-                        className="opacity-0 group-hover:opacity-100 transition-opacity"
+                        className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
                         onClick={(e) => e.stopPropagation()}
                       >
                         <DropdownMenu modal={false}>
@@ -705,7 +705,7 @@ export function FolderTree({
 
           <ScrollArea
             className={cn(
-              'flex-1 min-h-0 transition-all duration-300 ease-in-out',
+              'flex-1 min-h-0 transition-all duration-300 ease-in-out [&>div>div]:block!',
               isSharesExpanded
                 ? 'opacity-100 visible pointer-events-auto'
                 : 'opacity-0 invisible pointer-events-none h-0',
@@ -958,7 +958,7 @@ function ShareLinkItem({
     <div
       ref={setDroppableRef}
       className={cn(
-        'group flex cursor-pointer items-center justify-between rounded-md px-2 py-1 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+        'group flex cursor-pointer items-center justify-between rounded-md px-2 py-1 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground min-w-0',
         isActive && 'bg-sidebar-accent text-sidebar-accent-foreground font-medium',
         isOver && isValidDropTarget && 'bg-sidebar-accent ring-2 ring-primary ring-inset',
       )}
@@ -978,7 +978,7 @@ function ShareLinkItem({
 
       {canEdit && (
         <div
-          className="opacity-0 group-hover:opacity-100 transition-opacity"
+          className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
           onClick={(e) => e.stopPropagation()}
         >
           <DropdownMenu modal={false}>
@@ -1176,7 +1176,7 @@ function FolderTreeItem({
       <div
         ref={setNodeRef}
         className={cn(
-          'group flex cursor-pointer items-center gap-1 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+          'group flex cursor-pointer items-center gap-1 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground min-w-0',
           (isActive || isSelected) &&
             'bg-sidebar-accent text-sidebar-accent-foreground font-medium',
           isDragging && 'opacity-50',
@@ -1188,7 +1188,10 @@ function FolderTreeItem({
         onClick={handleFolderClick}
       >
         {!isRoot && (
-          <button onClick={handleToggleExpand} className="flex h-4 w-4 items-center justify-center">
+          <button
+            onClick={handleToggleExpand}
+            className="flex h-4 w-4 items-center justify-center shrink-0"
+          >
             {isExpanded ? (
               <ChevronDown className="h-3 w-3" />
             ) : (
@@ -1197,15 +1200,15 @@ function FolderTreeItem({
           </button>
         )}
         {isRoot ? (
-          <Clapperboard className="h-4 w-4 text-sidebar-primary" />
+          <Clapperboard className="h-4 w-4 text-sidebar-primary shrink-0" />
         ) : (
-          <Folder className="h-4 w-4 text-sidebar-primary" />
+          <Folder className="h-4 w-4 text-sidebar-primary shrink-0" />
         )}
         <span className="flex-1 truncate text-sidebar-foreground">{folder.name}</span>
 
         {canEdit && !isRoot && (
           <div
-            className="opacity-0 group-hover:opacity-100 transition-opacity"
+            className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
             onClick={(e) => e.stopPropagation()}
           >
             <DropdownMenu modal={false}>


### PR DESCRIPTION
## Summary

This PR fixes a layout overflow issue in the file list page sidebar, where long folder names, collection names, and share link names would stretch the sidebar wide instead of truncating correctly.

## Changes

- Added `[&>div>div]:block!` to the parent `<ScrollArea>` components in `folder-tree.tsx` to override Radix UI's internal viewport wrapper style from `display: table` to `display: block !important`.
- Added `min-w-0` to the flex container rows of folders, collections, and share links so that they are constrained to the width of the sidebar.
- Added `shrink-0` to toggle chevron buttons, icons, and action menu triggers to prevent them from squishing when text truncates.

## Verification

Ran workspace verification checks:
- `bun run format` (Passed)
- `bun run lint` (Passed)
- `bun run typecheck` (Passed)
- `bun run test` (Passed)

## Notes

None.
