### PR TITLE
feat(share): secure share info API and fix wrong password feedback

### DIFF
--- a/packages/api/src/public-share.ts
+++ b/packages/api/src/public-share.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import type { Context } from 'hono'
 import { zValidator } from '@hono/zod-validator'
 import { shareService } from '@shumai/core/src/share/share'
 import { assetService } from '@shumai/core/src/asset/asset'
@@ -11,6 +12,12 @@ import { auth } from '@shumai/core/src/auth/auth'
 import { prisma } from '@shumai/db'
 import { createCommentRequestSchema } from '@shumai/dtos'
 import { notificationService } from '@shumai/core/src/notification/notification'
+import {
+  ShareLinkNotFoundError,
+  ShareLinkDisabledError,
+  ShareLinkExpiredError,
+  ShareLinkPasswordInvalidError,
+} from '@shumai/core/src/share/errors'
 
 const app = new Hono()
 
@@ -28,6 +35,22 @@ function toFieldInfo(
     description: f.description,
     aiAutofill: f.aiAutofill,
   }
+}
+
+export function handlePublicShareError(c: Context, err: unknown) {
+  if (err instanceof ShareLinkPasswordInvalidError) {
+    return c.json({ error: 'Unauthorized' }, 401)
+  }
+  if (err instanceof ShareLinkExpiredError || err instanceof ShareLinkDisabledError) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return c.json({ error: msg }, 403)
+  }
+  if (err instanceof ShareLinkNotFoundError) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return c.json({ error: msg }, 404)
+  }
+  const msg = err instanceof Error ? err.message : String(err)
+  return c.json({ error: msg }, 500)
 }
 
 const sharedChildrenRequestSchema = paginationParamsSchema.extend({
@@ -54,21 +77,7 @@ const route = app
         defaultSortOrder: shareLink.defaultSortOrder,
       })
     } catch (err) {
-      const msg = (err as Error).message
-      if (msg === 'Invalid password for share link') {
-        return c.json({ error: 'Unauthorized' }, 401)
-      }
-      if (msg === 'Share link has expired' || msg === 'Share link is disabled') {
-        return c.json({ error: msg }, 403)
-      }
-      if (
-        msg === 'Share link not found' ||
-        msg === 'Share link not found for this asset' ||
-        msg === 'Asset is not shared'
-      ) {
-        return c.json({ error: msg }, 404)
-      }
-      return c.json({ error: msg }, 500)
+      return handlePublicShareError(c, err)
     }
   })
   .get('/shares/:shareId/fields', async (c) => {
@@ -88,14 +97,7 @@ const route = app
           .map((f) => toFieldInfo(f.field, f.visible)),
       )
     } catch (err) {
-      const msg = (err as Error).message
-      if (msg === 'Invalid password for share link') {
-        return c.json({ error: 'Unauthorized' }, 401)
-      }
-      if (msg === 'Share link has expired' || msg === 'Share link is disabled') {
-        return c.json({ error: msg }, 403)
-      }
-      return c.json({ error: msg }, 500)
+      return handlePublicShareError(c, err)
     }
   })
   .get(
@@ -128,14 +130,7 @@ const route = app
 
         return c.json(res)
       } catch (err) {
-        const msg = (err as Error).message
-        if (msg === 'Invalid password for share link') {
-          return c.json({ error: 'Unauthorized' }, 401)
-        }
-        if (msg === 'Share link has expired' || msg === 'Share link is disabled') {
-          return c.json({ error: msg }, 403)
-        }
-        return c.json({ error: msg }, 500)
+        return handlePublicShareError(c, err)
       }
     },
   )
@@ -149,14 +144,7 @@ const route = app
       const asset = await assetService.getAsset({ assetId: fileId })
       return c.json(asset)
     } catch (err) {
-      const msg = (err as Error).message
-      if (msg === 'Invalid password for share link') {
-        return c.json({ error: 'Unauthorized' }, 401)
-      }
-      if (msg === 'Share link has expired' || msg === 'Share link is disabled') {
-        return c.json({ error: msg }, 403)
-      }
-      return c.json({ error: msg }, 500)
+      return handlePublicShareError(c, err)
     }
   })
   .get(
@@ -174,14 +162,7 @@ const route = app
         const res = await assetService.listComments(targetFileId, req)
         return c.json(res)
       } catch (err) {
-        const msg = (err as Error).message
-        if (msg === 'Invalid password for share link') {
-          return c.json({ error: 'Unauthorized' }, 401)
-        }
-        if (msg === 'Share link has expired' || msg === 'Share link is disabled') {
-          return c.json({ error: msg }, 403)
-        }
-        return c.json({ error: msg }, 500)
+        return handlePublicShareError(c, err)
       }
     },
   )
@@ -253,14 +234,7 @@ const route = app
 
         return c.json(comment, 201)
       } catch (err) {
-        const msg = (err as Error).message
-        if (msg === 'Invalid password for share link') {
-          return c.json({ error: 'Unauthorized' }, 401)
-        }
-        if (msg === 'Share link has expired' || msg === 'Share link is disabled') {
-          return c.json({ error: msg }, 403)
-        }
-        return c.json({ error: msg }, 500)
+        return handlePublicShareError(c, err)
       }
     },
   )

--- a/packages/api/src/public-share.ts
+++ b/packages/api/src/public-share.ts
@@ -37,8 +37,10 @@ const sharedChildrenRequestSchema = paginationParamsSchema.extend({
 const route = app
   .get('/shares/:shareId/info', async (c) => {
     const shareId = c.req.param('shareId')
+    const password = c.req.header('x-share-password')
     try {
       const shareLink = await shareService.getShareLink(shareId)
+      await shareService.verifyPublicAccess(shareLink.rootFolderId, password)
       return c.json({
         id: shareLink.id,
         name: shareLink.name,
@@ -52,7 +54,21 @@ const route = app
         defaultSortOrder: shareLink.defaultSortOrder,
       })
     } catch (err) {
-      return c.json({ error: (err as Error).message }, 404)
+      const msg = (err as Error).message
+      if (msg === 'Invalid password for share link') {
+        return c.json({ error: 'Unauthorized' }, 401)
+      }
+      if (msg === 'Share link has expired' || msg === 'Share link is disabled') {
+        return c.json({ error: msg }, 403)
+      }
+      if (
+        msg === 'Share link not found' ||
+        msg === 'Share link not found for this asset' ||
+        msg === 'Asset is not shared'
+      ) {
+        return c.json({ error: msg }, 404)
+      }
+      return c.json({ error: msg }, 500)
     }
   })
   .get('/shares/:shareId/fields', async (c) => {

--- a/packages/api/src/share.test.ts
+++ b/packages/api/src/share.test.ts
@@ -6,6 +6,7 @@ import { authMiddleware } from './middleware/auth'
 import { shareService } from '@shumai/core/src/share/share'
 import { assetService } from '@shumai/core/src/asset/asset'
 import { authzService, Permission, ResourceType } from '@shumai/core/src/authz/authz'
+import { ShareLinkPasswordInvalidError, ShareLinkExpiredError } from '@shumai/core/src/share/errors'
 
 vi.mock('./middleware/auth', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -89,7 +90,7 @@ describe('Share API', () => {
         updatedAt: new Date().toISOString(),
       })
       vi.spyOn(shareService, 'verifyPublicAccess').mockRejectedValue(
-        new Error('Invalid password for share link'),
+        new ShareLinkPasswordInvalidError('Invalid password for share link'),
       )
 
       const res = await app.request('/shares/share1/info', {
@@ -115,7 +116,7 @@ describe('Share API', () => {
         updatedAt: new Date().toISOString(),
       })
       vi.spyOn(shareService, 'verifyPublicAccess').mockRejectedValue(
-        new Error('Share link has expired'),
+        new ShareLinkExpiredError('Share link has expired'),
       )
 
       const res = await app.request('/shares/share1/info', {

--- a/packages/api/src/share.test.ts
+++ b/packages/api/src/share.test.ts
@@ -57,15 +57,74 @@ describe('Share API', () => {
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       })
+      vi.spyOn(shareService, 'verifyPublicAccess').mockResolvedValue({
+        id: 'share1',
+        name: 'Public Share',
+        rootFolderId: 'folder1',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
 
       const res = await app.request('/shares/share1/info', {
         method: 'GET',
+        headers: { 'x-share-password': 'pass' },
       })
 
       expect(res.status).toBe(200)
       const body = await res.json()
       expect(body.name).toBe('Public Share')
       expect(body.hasPassword).toBe(true)
+      expect(shareService.verifyPublicAccess).toHaveBeenCalledWith('folder1', 'pass')
+    })
+
+    test('Unauthorized', async () => {
+      vi.spyOn(shareService, 'getShareLink').mockResolvedValue({
+        id: 'share1',
+        name: 'Public Share',
+        isDisabled: false,
+        isExpired: false,
+        hasPassword: true,
+        rootFolderId: 'folder1',
+        projectId: 'project1',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
+      vi.spyOn(shareService, 'verifyPublicAccess').mockRejectedValue(
+        new Error('Invalid password for share link'),
+      )
+
+      const res = await app.request('/shares/share1/info', {
+        method: 'GET',
+        headers: { 'x-share-password': 'wrong' },
+      })
+
+      expect(res.status).toBe(401)
+      const body = await res.json()
+      expect(body.error).toBe('Unauthorized')
+    })
+
+    test('Expired/Disabled', async () => {
+      vi.spyOn(shareService, 'getShareLink').mockResolvedValue({
+        id: 'share1',
+        name: 'Public Share',
+        isDisabled: false,
+        isExpired: false,
+        hasPassword: true,
+        rootFolderId: 'folder1',
+        projectId: 'project1',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
+      vi.spyOn(shareService, 'verifyPublicAccess').mockRejectedValue(
+        new Error('Share link has expired'),
+      )
+
+      const res = await app.request('/shares/share1/info', {
+        method: 'GET',
+      })
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error).toBe('Share link has expired')
     })
   })
 

--- a/packages/core/src/share/errors.ts
+++ b/packages/core/src/share/errors.ts
@@ -1,0 +1,31 @@
+export class ShareLinkNotFoundError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ShareLinkNotFoundError'
+    Object.setPrototypeOf(this, ShareLinkNotFoundError.prototype)
+  }
+}
+
+export class ShareLinkDisabledError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ShareLinkDisabledError'
+    Object.setPrototypeOf(this, ShareLinkDisabledError.prototype)
+  }
+}
+
+export class ShareLinkExpiredError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ShareLinkExpiredError'
+    Object.setPrototypeOf(this, ShareLinkExpiredError.prototype)
+  }
+}
+
+export class ShareLinkPasswordInvalidError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ShareLinkPasswordInvalidError'
+    Object.setPrototypeOf(this, ShareLinkPasswordInvalidError.prototype)
+  }
+}

--- a/packages/core/src/share/share.ts
+++ b/packages/core/src/share/share.ts
@@ -9,6 +9,12 @@ import {
 } from '@shumai/dtos'
 import { PaginatedData, paginateQuery } from '@shumai/core/src/pagination'
 import { getAvatarUrl } from '@shumai/core/src/user/avatar'
+import {
+  ShareLinkNotFoundError,
+  ShareLinkDisabledError,
+  ShareLinkExpiredError,
+  ShareLinkPasswordInvalidError,
+} from './errors'
 
 export class ShareService {
   async createShareLink(
@@ -143,7 +149,7 @@ export class ShareService {
       where: { id: shareLinkId },
       include: { creator: true },
     })
-    if (!shareLink) throw new Error('Share link not found')
+    if (!shareLink) throw new ShareLinkNotFoundError('Share link not found')
     return await this.toShareLinkInfo(shareLink)
   }
 
@@ -264,7 +270,7 @@ export class ShareService {
     `
 
     if (rows.length === 0) {
-      throw new Error('Asset is not shared')
+      throw new ShareLinkNotFoundError('Asset is not shared')
     }
 
     const shareRootId = rows[0].shareRootId
@@ -273,19 +279,19 @@ export class ShareService {
     })
 
     if (!shareLink) {
-      throw new Error('Share link not found for this asset')
+      throw new ShareLinkNotFoundError('Share link not found for this asset')
     }
 
     if (shareLink.isDisabled) {
-      throw new Error('Share link is disabled')
+      throw new ShareLinkDisabledError('Share link is disabled')
     }
 
     if (shareLink.expireAt && shareLink.expireAt < new Date()) {
-      throw new Error('Share link has expired')
+      throw new ShareLinkExpiredError('Share link has expired')
     }
 
     if (shareLink.password && shareLink.password !== providedPassword) {
-      throw new Error('Invalid password for share link')
+      throw new ShareLinkPasswordInvalidError('Invalid password for share link')
     }
 
     return shareLink

--- a/packages/core/src/share/share.ts
+++ b/packages/core/src/share/share.ts
@@ -301,6 +301,7 @@ export class ShareService {
       expireAt: l.expireAt?.toISOString(),
       isDisabled: l.isDisabled,
       hasPassword: !!l.password,
+      password: l.password,
       defaultSortOrder: l.defaultSortOrder,
       viewMode: l.viewMode,
       fieldVisibility: l.fieldVisibility as Record<string, boolean> | undefined,

--- a/packages/dtos/src/share.ts
+++ b/packages/dtos/src/share.ts
@@ -7,6 +7,7 @@ export interface ShareLinkInfo {
   expireAt?: string
   isDisabled: boolean
   hasPassword: boolean
+  password?: string | null
   defaultSortOrder?: string
   viewMode?: string
   fieldVisibility?: Record<string, boolean>

--- a/packages/webui/components/public-share-manager.tsx
+++ b/packages/webui/components/public-share-manager.tsx
@@ -21,48 +21,81 @@ import type { Annotation } from '@/ui/types'
 import { useNavigate } from '@tanstack/react-router'
 
 interface PublicShareManagerProps {
-  shareInfo: {
-    id: string
-    name: string
-    expireAt: string | null
-    isDisabled: boolean
-    isExpired: boolean
-    hasPassword: boolean
-    rootFolderId: string
-    projectId: string
-    viewMode?: string | null
-    defaultSortOrder?: string | null
-  }
+  shareId: string
   initialFolderId?: string
   initialFileId?: string
   startTime?: number
 }
 
+interface PublicShareInfo {
+  id: string
+  name: string
+  expireAt: string | null
+  isDisabled: boolean
+  isExpired: boolean
+  hasPassword: boolean
+  rootFolderId: string
+  projectId: string
+  viewMode?: string | null
+  defaultSortOrder?: string | null
+}
+
 export function PublicShareManager({
-  shareInfo,
+  shareId,
   initialFolderId,
   initialFileId,
   startTime,
 }: PublicShareManagerProps) {
   const navigate = useNavigate()
   const [password, setPassword] = useState(() => {
-    return localStorage.getItem(`share_pwd_${shareInfo.id}`) || ''
+    return localStorage.getItem(`share_pwd_${shareId}`) || ''
   })
   const [passwordInput, setPasswordInput] = useState('')
-  const [isPasswordValid, setIsPasswordValid] = useState(!shareInfo.hasPassword || !!password)
 
-  const currentFolderId = initialFolderId || shareInfo.rootFolderId
+  const {
+    data: shareInfo,
+    error: shareInfoError,
+    isLoading: isShareInfoLoading,
+  } = useQuery<PublicShareInfo>({
+    queryKey: ['share-info', shareId, password],
+    queryFn: async () => {
+      const res = await client.api.shares[':shareId'].info.$get(
+        {
+          param: { shareId },
+        },
+        {
+          headers: {
+            'x-share-password': password,
+          },
+        },
+      )
+      if (res.status === 401) {
+        throw new Error('Unauthorized')
+      }
+      if (res.status === 403) {
+        const body = (await res.json()) as { error?: string }
+        throw new Error(body.error || 'Forbidden')
+      }
+      if (!res.ok) {
+        throw new Error('Failed to fetch share info')
+      }
+      return (await res.json()) as unknown as PublicShareInfo
+    },
+    retry: false,
+  })
+
+  const currentFolderId = initialFolderId || shareInfo?.rootFolderId
   const viewingFileId = initialFileId || null
 
   const [ancestorFolders, setAncestorFolders] = useState<AncestorFolder[]>([])
 
   // Fetch ancestors for breadcrumb
   const { data: folderInfo } = useQuery({
-    queryKey: ['public-share-folder', shareInfo.id, currentFolderId, password],
+    queryKey: ['public-share-folder', shareId, currentFolderId, password],
     queryFn: async () => {
       const res = await client.api.shares[':shareId'].files[':fileId'].$get(
         {
-          param: { shareId: shareInfo.id, fileId: currentFolderId },
+          param: { shareId, fileId: currentFolderId! },
         },
         {
           headers: {
@@ -73,11 +106,11 @@ export function PublicShareManager({
       if (res.status === 401) throw new Error('Unauthorized')
       return (await res.json()) as unknown as AssetInfo
     },
-    enabled: isPasswordValid && !shareInfo.isExpired && !shareInfo.isDisabled,
+    enabled: !!shareInfo && !!currentFolderId,
   })
 
   useEffect(() => {
-    if (folderInfo?.ancestorFolders) {
+    if (folderInfo?.ancestorFolders && shareInfo) {
       // Filter ancestors to only those within the share root
       const rootIndex = folderInfo.ancestorFolders.findIndex((f) => f.id === shareInfo.rootFolderId)
       if (rootIndex !== -1) {
@@ -86,7 +119,7 @@ export function PublicShareManager({
         setAncestorFolders([])
       }
     }
-  }, [folderInfo, shareInfo.rootFolderId, currentFolderId])
+  }, [folderInfo, shareInfo, currentFolderId])
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [rightSidebarWidth, setRightSidebarWidth] = useState(360)
@@ -103,11 +136,11 @@ export function PublicShareManager({
     isFetchingNextPage: isFetchingNextFoldersPage,
     error: foldersError,
   } = useInfiniteQuery<AssetInfoPaginatedList>({
-    queryKey: ['public-share-children', shareInfo.id, currentFolderId, 'folder', password],
+    queryKey: ['public-share-children', shareId, currentFolderId, 'folder', password],
     queryFn: async ({ pageParam }) => {
       const res = await client.api.shares[':shareId'].folders[':folderId'].children.$get(
         {
-          param: { shareId: shareInfo.id, folderId: currentFolderId },
+          param: { shareId, folderId: currentFolderId! },
           query: {
             assetType: 'folder',
             after: pageParam as string,
@@ -123,7 +156,7 @@ export function PublicShareManager({
       if (res.status === 403) throw new Error('Expired')
       return (await res.json()) as unknown as AssetInfoPaginatedList
     },
-    enabled: isPasswordValid && !shareInfo.isExpired && !shareInfo.isDisabled,
+    enabled: !!shareInfo && !!currentFolderId,
     initialPageParam: '',
     getNextPageParam: (lastPage) => lastPage.pageInfo?.cursor || undefined,
     retry: false,
@@ -135,11 +168,11 @@ export function PublicShareManager({
     hasNextPage: hasNextPageFiles,
     isFetchingNextPage: isFetchingNextFilesPage,
   } = useInfiniteQuery<AssetInfoPaginatedList>({
-    queryKey: ['public-share-children', shareInfo.id, currentFolderId, 'file', password],
+    queryKey: ['public-share-children', shareId, currentFolderId, 'file', password],
     queryFn: async ({ pageParam }) => {
       const res = await client.api.shares[':shareId'].folders[':folderId'].children.$get(
         {
-          param: { shareId: shareInfo.id, folderId: currentFolderId },
+          param: { shareId, folderId: currentFolderId! },
           query: {
             assetType: 'file',
             after: pageParam as string,
@@ -155,18 +188,18 @@ export function PublicShareManager({
       if (res.status === 403) throw new Error('Expired')
       return (await res.json()) as unknown as AssetInfoPaginatedList
     },
-    enabled: isPasswordValid && !shareInfo.isExpired && !shareInfo.isDisabled,
+    enabled: !!shareInfo && !!currentFolderId,
     initialPageParam: '',
     getNextPageParam: (lastPage) => lastPage.pageInfo?.cursor || undefined,
     retry: false,
   })
 
   const { data: publicFields } = useQuery({
-    queryKey: ['public-share-fields', shareInfo.id, password],
+    queryKey: ['public-share-fields', shareId, password],
     queryFn: async () => {
       const res = await client.api.shares[':shareId'].fields.$get(
         {
-          param: { shareId: shareInfo.id },
+          param: { shareId },
         },
         {
           headers: {
@@ -177,15 +210,15 @@ export function PublicShareManager({
       if (res.status === 401) throw new Error('Unauthorized')
       return (await res.json()) as unknown as FieldInfo[]
     },
-    enabled: isPasswordValid && !shareInfo.isExpired && !shareInfo.isDisabled,
+    enabled: !!shareInfo,
   })
 
   const { data: viewingFileData, isLoading: isViewingFileLoading } = useQuery({
-    queryKey: ['public-share-file', shareInfo.id, viewingFileId, password],
+    queryKey: ['public-share-file', shareId, viewingFileId, password],
     queryFn: async () => {
       const res = await client.api.shares[':shareId'].files[':fileId'].$get(
         {
-          param: { shareId: shareInfo.id, fileId: viewingFileId! },
+          param: { shareId, fileId: viewingFileId! },
         },
         {
           headers: {
@@ -196,16 +229,15 @@ export function PublicShareManager({
       if (res.status === 401) throw new Error('Unauthorized')
       return (await res.json()) as unknown as AssetInfo
     },
-    enabled: !!viewingFileId && isPasswordValid && !shareInfo.isExpired && !shareInfo.isDisabled,
+    enabled: !!viewingFileId && !!shareInfo,
   })
 
   useEffect(() => {
     if (foldersError?.message === 'Unauthorized') {
-      setIsPasswordValid(false)
       setPassword('')
-      localStorage.removeItem(`share_pwd_${shareInfo.id}`)
+      localStorage.removeItem(`share_pwd_${shareId}`)
     }
-  }, [foldersError, shareInfo.id])
+  }, [foldersError, shareId])
 
   const folders = useMemo(
     () => foldersData?.pages.flatMap((page) => page.data ?? []) ?? [],
@@ -226,21 +258,20 @@ export function PublicShareManager({
   const handlePasswordSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     setPassword(passwordInput)
-    setIsPasswordValid(true)
-    localStorage.setItem(`share_pwd_${shareInfo.id}`, passwordInput)
+    localStorage.setItem(`share_pwd_${shareId}`, passwordInput)
   }
 
   const handleItemDoubleClick = (item: AssetInfo) => {
     if (item.type === 'folder' || item.targetType === 'folder') {
       navigate({
         to: '/share/$shareId/folders/$folderId',
-        params: { shareId: shareInfo.id, folderId: item.id! },
+        params: { shareId, folderId: item.id! },
       })
     } else {
       navigate({
         to: '/share/$shareId/files/$fileId',
         params: {
-          shareId: shareInfo.id,
+          shareId,
           fileId: item.versionStack ? item.versionStack.id : item.id!,
         },
       })
@@ -249,17 +280,18 @@ export function PublicShareManager({
   }
 
   const handleBreadcrumbClick = (folderId: string) => {
+    if (!shareInfo) return
     const targetId = folderId === 'root' ? shareInfo.rootFolderId : folderId
 
     if (targetId === shareInfo.rootFolderId) {
       navigate({
         to: '/share/$shareId',
-        params: { shareId: shareInfo.id },
+        params: { shareId },
       })
     } else {
       navigate({
         to: '/share/$shareId/folders/$folderId',
-        params: { shareId: shareInfo.id, folderId: targetId },
+        params: { shareId, folderId: targetId },
       })
     }
     setSelectedIds(new Set())
@@ -294,7 +326,7 @@ export function PublicShareManager({
   const { setProjectState, clearProjectState } = useTopNavStore()
 
   useEffect(() => {
-    if (isPasswordValid && !shareInfo.isExpired && !shareInfo.isDisabled) {
+    if (shareInfo && currentFolderId) {
       const currentFolderName =
         currentFolderId === shareInfo.rootFolderId
           ? shareInfo.name
@@ -315,7 +347,7 @@ export function PublicShareManager({
         },
         isRootFolder: currentFolderId === shareInfo.rootFolderId && !viewingFileId,
         isPublic: true,
-        shareId: shareInfo.id,
+        shareId,
         fileId: viewingFileId || undefined,
         onFolderClick: handleBreadcrumbClick,
         isRightSidebarCollapsed,
@@ -325,7 +357,6 @@ export function PublicShareManager({
 
     return () => clearProjectState()
   }, [
-    isPasswordValid,
     shareInfo,
     currentFolderId,
     folders,
@@ -339,49 +370,73 @@ export function PublicShareManager({
 
   let content
 
-  if (shareInfo.isExpired || shareInfo.isDisabled) {
+  if (isShareInfoLoading && !shareInfoError) {
     content = (
-      <div className="flex flex-1 items-center justify-center p-4">
-        <Card className="w-full max-w-md">
-          <CardHeader className="text-center">
-            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
-              <AlertCircle className="h-6 w-6 text-destructive" />
-            </div>
-            <CardTitle>Share {shareInfo.isDisabled ? 'Disabled' : 'Expired'}</CardTitle>
-          </CardHeader>
-          <CardContent className="text-center text-muted-foreground">
-            {shareInfo.isDisabled
-              ? 'This share link has been disabled by the owner.'
-              : 'This share link has expired and is no longer accessible.'}
-          </CardContent>
-        </Card>
+      <div className="flex flex-1 items-center justify-center bg-background">
+        <Loader2 className="h-8 w-8 animate-spin text-foreground" />
       </div>
     )
-  } else if (!isPasswordValid) {
+  } else if (shareInfoError) {
+    if (shareInfoError.message === 'Unauthorized') {
+      const isPasswordWrong = password !== ''
+      content = (
+        <div className="flex flex-1 items-center justify-center p-4">
+          <Card className="w-full max-w-md">
+            <CardHeader className="text-center">
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+                <Lock className="h-6 w-6 text-primary" />
+              </div>
+              <CardTitle>Password Protected</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <form onSubmit={handlePasswordSubmit} className="space-y-4">
+                <div className="space-y-2">
+                  <Input
+                    type="password"
+                    placeholder="Enter password"
+                    value={passwordInput}
+                    onChange={(e) => setPasswordInput(e.target.value)}
+                    autoFocus
+                  />
+                  {isPasswordWrong && (
+                    <p className="text-sm font-medium text-destructive">
+                      Incorrect password. Please try again.
+                    </p>
+                  )}
+                </div>
+                <Button type="submit" className="w-full">
+                  Access Share
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+      )
+    } else {
+      const isExpired = shareInfoError.message.includes('expired')
+      const isDisabled = shareInfoError.message.includes('disabled')
+      content = (
+        <div className="flex flex-1 items-center justify-center p-4">
+          <Card className="w-full max-w-md">
+            <CardHeader className="text-center">
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+                <AlertCircle className="h-6 w-6 text-destructive" />
+              </div>
+              <CardTitle>
+                {isExpired ? 'Share Expired' : isDisabled ? 'Share Disabled' : 'Error'}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="text-center text-muted-foreground">
+              {shareInfoError.message}
+            </CardContent>
+          </Card>
+        </div>
+      )
+    }
+  } else if (!shareInfo) {
     content = (
-      <div className="flex flex-1 items-center justify-center p-4">
-        <Card className="w-full max-w-md">
-          <CardHeader className="text-center">
-            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
-              <Lock className="h-6 w-6 text-primary" />
-            </div>
-            <CardTitle>Password Protected</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={handlePasswordSubmit} className="space-y-4">
-              <Input
-                type="password"
-                placeholder="Enter password"
-                value={passwordInput}
-                onChange={(e) => setPasswordInput(e.target.value)}
-                autoFocus
-              />
-              <Button type="submit" className="w-full">
-                Access Share
-              </Button>
-            </form>
-          </CardContent>
-        </Card>
+      <div className="flex flex-1 items-center justify-center bg-background">
+        <Loader2 className="h-8 w-8 animate-spin text-foreground" />
       </div>
     )
   } else {
@@ -406,37 +461,39 @@ export function PublicShareManager({
             )}
           </div>
         ) : (
-          <FileBrowser
-            teamId=""
-            projectId={shareInfo.projectId}
-            assetId={currentFolderId}
-            folders={folders}
-            files={files}
-            selectedItem={null}
-            selectedIds={selectedIds}
-            onItemSelect={(item, e) => {
-              if (e.metaKey || e.ctrlKey) {
-                const next = new Set(selectedIds)
-                if (next.has(item.id!)) next.delete(item.id!)
-                else next.add(item.id!)
-                setSelectedIds(next)
-              } else {
-                setSelectedIds(new Set([item.id!]))
-              }
-            }}
-            onItemDoubleClick={handleItemDoubleClick}
-            onSaveField={() => {}}
-            displayStyle={(shareInfo.viewMode as 'card' | 'list') ?? 'card'}
-            onClearSelection={() => setSelectedIds(new Set())}
-            fetchNextFoldersPage={fetchNextFoldersPage}
-            hasNextFoldersPage={hasNextPageFolders}
-            isFetchingNextFoldersPage={isFetchingNextFoldersPage}
-            fetchNextFilesPage={fetchNextFilesPage}
-            hasNextFilesPage={hasNextPageFiles}
-            isFetchingNextFilesPage={isFetchingNextFilesPage}
-            isShareView={true}
-            isPublic={true}
-          />
+          currentFolderId && (
+            <FileBrowser
+              teamId=""
+              projectId={shareInfo.projectId}
+              assetId={currentFolderId}
+              folders={folders}
+              files={files}
+              selectedItem={null}
+              selectedIds={selectedIds}
+              onItemSelect={(item, e) => {
+                if (e.metaKey || e.ctrlKey) {
+                  const next = new Set(selectedIds)
+                  if (next.has(item.id!)) next.delete(item.id!)
+                  else next.add(item.id!)
+                  setSelectedIds(next)
+                } else {
+                  setSelectedIds(new Set([item.id!]))
+                }
+              }}
+              onItemDoubleClick={handleItemDoubleClick}
+              onSaveField={() => {}}
+              displayStyle={(shareInfo.viewMode as 'card' | 'list') ?? 'card'}
+              onClearSelection={() => setSelectedIds(new Set())}
+              fetchNextFoldersPage={fetchNextFoldersPage}
+              hasNextFoldersPage={hasNextPageFolders}
+              isFetchingNextFoldersPage={isFetchingNextFoldersPage}
+              fetchNextFilesPage={fetchNextFilesPage}
+              hasNextFilesPage={hasNextPageFiles}
+              isFetchingNextFilesPage={isFetchingNextFilesPage}
+              isShareView={true}
+              isPublic={true}
+            />
+          )
         )}
 
         {!isRightSidebarCollapsed && (
@@ -457,7 +514,7 @@ export function PublicShareManager({
                 publicFields={publicFields}
                 onCommentSelect={handleCommentSelect}
                 isPublic={true}
-                shareId={shareInfo.id}
+                shareId={shareId}
                 currentTime={currentTime}
                 onTyping={() => {
                   if (videoRef.current) {

--- a/packages/webui/components/share-settings-sidebar.tsx
+++ b/packages/webui/components/share-settings-sidebar.tsx
@@ -45,10 +45,14 @@ export function ShareSettingsSidebar({
   onSortOrderChange,
 }: ShareSettingsSidebarProps) {
   const queryClient = useQueryClient()
-  const [password, setPassword] = useState('')
+  const [password, setPassword] = useState(shareLink.password || '')
   const [expireAt, setExpireAt] = useState<Date | undefined>(
     shareLink.expireAt ? new Date(shareLink.expireAt) : undefined,
   )
+
+  React.useEffect(() => {
+    setPassword(shareLink.password || '')
+  }, [shareLink.password])
   const [isPasswordEnabled, setIsPasswordEnabled] = useState(shareLink.hasPassword)
   const [isExpireEnabled, setIsExpireEnabled] = useState(!!shareLink.expireAt)
 
@@ -146,10 +150,10 @@ export function ShareSettingsSidebar({
                   {isPasswordEnabled && (
                     <div className="flex gap-2 animate-in fade-in slide-in-from-top-1 duration-200">
                       <Input
-                        type="password"
+                        type="text"
                         value={password}
                         onChange={(e) => setPassword(e.target.value)}
-                        placeholder={shareLink.hasPassword ? '••••••••' : 'Set password'}
+                        placeholder="Enter password"
                         className="text-xs"
                       />
                       <Button size="sm" onClick={() => updateShare({ password })}>

--- a/packages/webui/routes/share/$shareId.tsx
+++ b/packages/webui/routes/share/$shareId.tsx
@@ -1,43 +1,9 @@
-import { client } from '@/ui/api/client'
-import { ProjectFolderSkeleton } from '@/ui/components/loading-skeletons'
-import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 
 function ShareLayout() {
-  const { shareId } = Route.useParams()
-
-  const {
-    data: shareInfo,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: ['share-info', shareId],
-    queryFn: async () => {
-      const res = await client.api.shares[':shareId'].info.$get({
-        param: { shareId },
-      })
-      if (!res.ok) throw new Error('Failed to fetch share info')
-      return await res.json()
-    },
-  })
-
-  if (isLoading) return <ProjectFolderSkeleton />
-
-  if (error || !shareInfo)
-    return (
-      <div className="flex h-screen items-center justify-center text-destructive">
-        Share not found or inaccessible.
-      </div>
-    )
-
   return <Outlet />
 }
 
 export const Route = createFileRoute('/share/$shareId')({
   component: ShareLayout,
-  beforeLoad: ({ params: { shareId } }) => {
-    return {
-      password: localStorage.getItem(`share_pwd_${shareId}`) || '',
-    }
-  },
 })

--- a/packages/webui/routes/share/$shareId/files/$fileId.tsx
+++ b/packages/webui/routes/share/$shareId/files/$fileId.tsx
@@ -1,36 +1,11 @@
-import { client } from '@/ui/api/client'
 import { PublicShareManager } from '@/ui/components/public-share-manager'
-import { useQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 
 function PublicShareFilePage() {
   const { shareId, fileId } = Route.useParams()
   const { start } = Route.useSearch()
 
-  const { data: shareInfo } = useQuery({
-    queryKey: ['share-info', shareId],
-    queryFn: async () => {
-      const res = await client.api.shares[':shareId'].info.$get({
-        param: { shareId },
-      })
-      if (!res.ok) throw new Error('Failed to fetch share info')
-      return await res.json()
-    },
-  })
-
-  if (!shareInfo) return null
-
-  return (
-    <PublicShareManager
-      shareInfo={{
-        ...shareInfo,
-        expireAt: shareInfo.expireAt ?? null,
-        isDisabled: shareInfo.isDisabled ?? false,
-      }}
-      initialFileId={fileId}
-      startTime={start}
-    />
-  )
+  return <PublicShareManager shareId={shareId} initialFileId={fileId} startTime={start} />
 }
 
 export const Route = createFileRoute('/share/$shareId/files/$fileId')({

--- a/packages/webui/routes/share/$shareId/folders/$folderId.tsx
+++ b/packages/webui/routes/share/$shareId/folders/$folderId.tsx
@@ -1,34 +1,10 @@
-import { client } from '@/ui/api/client'
 import { PublicShareManager } from '@/ui/components/public-share-manager'
-import { useQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 
 function PublicShareFolderPage() {
   const { shareId, folderId } = Route.useParams()
 
-  const { data: shareInfo } = useQuery({
-    queryKey: ['share-info', shareId],
-    queryFn: async () => {
-      const res = await client.api.shares[':shareId'].info.$get({
-        param: { shareId },
-      })
-      if (!res.ok) throw new Error('Failed to fetch share info')
-      return await res.json()
-    },
-  })
-
-  if (!shareInfo) return null
-
-  return (
-    <PublicShareManager
-      shareInfo={{
-        ...shareInfo,
-        expireAt: shareInfo.expireAt ?? null,
-        isDisabled: shareInfo.isDisabled ?? false,
-      }}
-      initialFolderId={folderId}
-    />
-  )
+  return <PublicShareManager shareId={shareId} initialFolderId={folderId} />
 }
 
 export const Route = createFileRoute('/share/$shareId/folders/$folderId')({

--- a/packages/webui/routes/share/$shareId/index.tsx
+++ b/packages/webui/routes/share/$shareId/index.tsx
@@ -1,34 +1,10 @@
-import { client } from '@/ui/api/client'
 import { PublicShareManager } from '@/ui/components/public-share-manager'
-import { useQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 
 function PublicShareIndexPage() {
   const { shareId } = Route.useParams()
 
-  const { data: shareInfo } = useQuery({
-    queryKey: ['share-info', shareId],
-    queryFn: async () => {
-      const res = await client.api.shares[':shareId'].info.$get({
-        param: { shareId },
-      })
-      if (!res.ok) throw new Error('Failed to fetch share info')
-      return await res.json()
-    },
-  })
-
-  if (!shareInfo) return null
-
-  return (
-    <PublicShareManager
-      shareInfo={{
-        ...shareInfo,
-        expireAt: shareInfo.expireAt ?? null,
-        isDisabled: shareInfo.isDisabled ?? false,
-      }}
-      initialFolderId={shareInfo.rootFolderId}
-    />
-  )
+  return <PublicShareManager shareId={shareId} />
 }
 
 export const Route = createFileRoute('/share/$shareId/')({


### PR DESCRIPTION
## Summary

This PR secures the public share info API, refactors the share settings page to display the raw password in plain text to the owner, and refactors public share error handling to use custom strongly-typed error classes.

## Changes

### 1. Strongly-Typed Share Error Handling
- **Core Error Classes (`packages/core/src/share/errors.ts`)**:
  - Defined custom error classes: `ShareLinkNotFoundError`, `ShareLinkDisabledError`, `ShareLinkExpiredError`, and `ShareLinkPasswordInvalidError`.
- **Core Service (`packages/core/src/share/share.ts`)**:
  - Updated `getShareLink` and `verifyPublicAccess` to throw the appropriate custom error classes instead of generic `Error` instances.
- **API Error Mapping (`packages/api/src/public-share.ts`)**:
  - Implemented centralized `handlePublicShareError` helper to translate custom error classes into standard HTTP status codes (401, 403, 404, or 500).
  - Deduplicated try-catch blocks across all 6 public share routes by utilizing this new helper.
- **API Tests (`packages/api/src/share.test.ts`)**:
  - Updated mock rejections to throw instances of the custom error classes to preserve type safety.

### 2. Public Share Password Protection & Error Feedback
- **API (`packages/api/src/public-share.ts`)**:
  - Retrieve `x-share-password` header in `/shares/:shareId/info`.
  - Validate access via `shareService.verifyPublicAccess`.
  - Return `401 Unauthorized` for incorrect/missing passwords, and `403 Forbidden` for expired/disabled shares.
- **UI (`packages/webui/components/public-share-manager.tsx`)**:
  - Moved the `share-info` query inside `PublicShareManager`, making it reactive to the `password` state.
  - Implemented incorrect password detection (shows *"Incorrect password. Please try again."* error message under the password input).
  - Centralized expired, disabled, and loading UI handling.
- **Routing Layout (`packages/webui/routes`)**:
  - Simplified the `ShareLayout` and route definitions to directly render `<Outlet />`, delegating access gates and queries to `PublicShareManager`.

### 3. Expose Raw Password on Share Settings Page
- **DTO (`packages/dtos/src/share.ts`)**:
  - Added optional `password?: string | null` field to the `ShareLinkInfo` interface.
- **Core Service (`packages/core/src/share/share.ts`)**:
  - Mapped database `password` to the returned `ShareLinkInfo` object in `toShareLinkInfo` helper.
  - Public `/info` endpoint continues to omit this field to prevent security leaks.
- **UI Settings Sidebar (`packages/webui/components/share-settings-sidebar.tsx`)**:
  - Initialized and synced state using the new `password` prop in `ShareLinkInfo`.
  - Updated the password `<Input>` element to use `type="text"` to present the raw password as a plain text string instead of obscuring it.

## Verification

Ran all testing and quality checks:
- `bun run test` (All 530 tests passed successfully, including new API tests for `/info`).
- `bun run lint` (Passed successfully with no errors).
- `bun run format` (Passed successfully).
- `bun run typecheck` (Passed successfully).

## Notes

None.
