### PR TITLE
refactor(s3): remove automatic port appending to AWS_ENDPOINT_URL_S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Docker Compose is the fastest way to get Shumai running. You do not need to clon
    curl -o docker-compose.yaml https://raw.githubusercontent.com/shumaiOne/shumai/main/docker-compose/local/docker-compose.yaml
    ```
 3. **Configure Environment Variables (Remote Deployments only):**
-   If deploying Shumai to a remote server (e.g., AWS EC2, VPS), edit docker-compose.yaml and add AWS_ENDPOINT_URL_S3 under the environment section, setting it to your server's public IP address or domain name (e.g., http://12.34.56.78).
+   If deploying Shumai to a remote server (e.g., AWS EC2, VPS), edit docker-compose.yaml and set `AWS_ENDPOINT_URL_S3` under the environment section to your server's public IP address or domain name along with the mapped port (e.g., `http://12.34.56.78:3000`).
 4. Start the services in detached mode:
    ```bash
    docker compose up -d
@@ -126,11 +126,12 @@ DATABASE_URL=postgresql://shumai:shumai_password@localhost:5432/shumai_db?schema
 BETTER_AUTH_SECRET=ySxs7DxzHDZBbeeHNPEwBuspYwipBqz5Gk5XdBjNhWw=
 STORAGE_BACKEND=local
 SHUMAI_SERVER_PORT=3000
-AWS_ENDPOINT_URL_S3=http://localhost
+AWS_ENDPOINT_URL_S3=http://localhost:3000
 ```
 
 > [!NOTE]
-> If deploying on a remote server, update `AWS_ENDPOINT_URL_S3` from `http://localhost` to your server's public IP address or domain name.
+> `SHUMAI_SERVER_PORT` sets the port the server starts on, while `AWS_ENDPOINT_URL_S3` is used by the browser to build file upload URLs.
+> If deploying on a remote server (e.g. `http://123.456.7.8`) with a mapped port (e.g. `12345:3000` in docker-compose), set `AWS_ENDPOINT_URL_S3` to `http://123.456.7.8:12345`.
 
 #### Step 6: Run Shumai
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ Docker Compose is the fastest way to get Shumai running. You do not need to clon
    ```bash
    curl -o docker-compose.yaml https://raw.githubusercontent.com/shumaiOne/shumai/main/docker-compose/local/docker-compose.yaml
    ```
-3. **Configure Environment Variables (Remote Deployments only):**
-   If deploying Shumai to a remote server (e.g., AWS EC2, VPS), edit docker-compose.yaml and set `AWS_ENDPOINT_URL_S3` under the environment section to your server's public IP address or domain name along with the mapped port (e.g., `http://12.34.56.78:3000`).
+3. **Configure Environment Variables (Remote / Custom Port Deployments only):**
+   If exposing Shumai on a custom host/port combination (for example, if you change host port mapping to `12345:3000` in `docker-compose.yaml` and deploy on server `http://12.34.56.78`):
+   - Set `SHUMAI_SERVER_PORT: 3000` (the internal port the app starts on inside the container).
+   - Set `AWS_ENDPOINT_URL_S3: http://12.34.56.78:12345` (the external address including port used by client browsers to upload files).
 4. Start the services in detached mode:
    ```bash
    docker compose up -d

--- a/docker-compose/local/docker-compose.yaml
+++ b/docker-compose/local/docker-compose.yaml
@@ -27,6 +27,9 @@ services:
       # Database Configuration
       DATABASE_URL: postgres://shumai:shumai_password@shumai_postgres:5432/shumai_db?search_path=public&sslmode=disable
 
+      # Server Configuration
+      SHUMAI_SERVER_PORT: 3000
+
       # S3 Configuration
       STORAGE_BACKEND: local
       AWS_ENDPOINT_URL_S3: http://localhost:3000

--- a/docker-compose/local/docker-compose.yaml
+++ b/docker-compose/local/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
 
       # S3 Configuration
       STORAGE_BACKEND: local
-      AWS_ENDPOINT_URL_S3: http://localhost
+      AWS_ENDPOINT_URL_S3: http://localhost:3000
 
       # Better Auth
       BETTER_AUTH_SECRET: qSxs9DxzHDZBbeeTNPEwBuspYwipBqz5Gk5XdBjNhWw=

--- a/docs/configuration/env-variables.mdx
+++ b/docs/configuration/env-variables.mdx
@@ -48,6 +48,18 @@ Shumai supports storing files locally or on S3-compatible endpoints.
 | `S3_USE_SSL`               | Set to `true` to use HTTPS for S3 endpoints.                                                                                                            | `false` (default)                                                         |
 | `PRESIGNED_URL_EXPIRES_IN` | Number of hours for which generated presigned download/upload links are valid.                                                                          | `5` (default)                                                             |
 
+### Local Storage Port Configuration
+
+When `STORAGE_BACKEND` is set to `local` (default):
+
+- `SHUMAI_SERVER_PORT` configures the port on which the Shumai web server starts and listens.
+- `AWS_ENDPOINT_URL_S3` configures the public/external endpoint used by client browsers to upload and download files. It must include the scheme and port.
+
+For example, if you deploy Shumai on a remote server at `http://123.456.7.8` and configure port mapping `12345:3000` (exposing port 3000 internally as port 12345 externally) in Docker Compose:
+
+- Set `SHUMAI_SERVER_PORT` to `3000`.
+- Set `AWS_ENDPOINT_URL_S3` to `http://123.456.7.8:12345`.
+
 ---
 
 ## Workflow Config

--- a/docs/configuration/env-variables.mdx
+++ b/docs/configuration/env-variables.mdx
@@ -37,16 +37,16 @@ Shumai is configured via environment variables. You can define these variables i
 
 Shumai supports storing files locally or on S3-compatible endpoints.
 
-| Variable                   | Description                                                                                       | Example / Default            |
-| :------------------------- | :------------------------------------------------------------------------------------------------ | :--------------------------- |
-| `STORAGE_BACKEND`          | Storage type. Use `local` for local file system storage, or `s3` for S3-compatible cloud storage. | `local` (default) or `s3`    |
-| `AWS_ENDPOINT_URL_S3`      | Custom endpoint for S3 storage. Must change to public domain/IP if deploying remotely.            | `http://localhost` (default) |
-| `S3_BUCKET`                | S3 bucket name.                                                                                   | `shumai` (default)           |
-| `S3_ACCESS_KEY_ID`         | Access key credentials for S3.                                                                    | `minioadmin` (default)       |
-| `S3_SECRET_ACCESS_KEY`     | Secret key credentials for S3.                                                                    | `minioadmin` (default)       |
-| `S3_REGION`                | S3 storage region.                                                                                | `auto` (default)             |
-| `S3_USE_SSL`               | Set to `true` to use HTTPS for S3 endpoints.                                                      | `false` (default)            |
-| `PRESIGNED_URL_EXPIRES_IN` | Number of hours for which generated presigned download/upload links are valid.                    | `5` (default)                |
+| Variable                   | Description                                                                                                                                             | Example / Default                                                         |
+| :------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------ |
+| `STORAGE_BACKEND`          | Storage type. Use `local` for local file system storage, or `s3` for S3-compatible cloud storage.                                                       | `local` (default) or `s3`                                                 |
+| `AWS_ENDPOINT_URL_S3`      | Endpoint for S3 storage or local storage. Used by the browser to build file upload URLs. Must include port if deploying remotely or using custom ports. | `http://localhost:3000` (respects `SHUMAI_SERVER_PORT` fallback if unset) |
+| `S3_BUCKET`                | S3 bucket name.                                                                                                                                         | `shumai` (default)                                                        |
+| `S3_ACCESS_KEY_ID`         | Access key credentials for S3.                                                                                                                          | `minioadmin` (default)                                                    |
+| `S3_SECRET_ACCESS_KEY`     | Secret key credentials for S3.                                                                                                                          | `minioadmin` (default)                                                    |
+| `S3_REGION`                | S3 storage region.                                                                                                                                      | `auto` (default)                                                          |
+| `S3_USE_SSL`               | Set to `true` to use HTTPS for S3 endpoints.                                                                                                            | `false` (default)                                                         |
+| `PRESIGNED_URL_EXPIRES_IN` | Number of hours for which generated presigned download/upload links are valid.                                                                          | `5` (default)                                                             |
 
 ---
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -69,7 +69,7 @@ To handle media processing and security isolation, the host machine must have th
     DATABASE_URL=postgresql://shumai:shumai_password@localhost:5432/shumai_db?schema=public
     BETTER_AUTH_SECRET=your-random-32-character-secret-key
     STORAGE_BACKEND=local
-    AWS_ENDPOINT_URL_S3=http://localhost
+    AWS_ENDPOINT_URL_S3=http://localhost:3000
     ```
 4.  **Start Shumai**:
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -61,16 +61,23 @@ To handle media processing and security isolation, the host machine must have th
     ```
 3.  **Configure Environment Variables**:
     Create a new directory, navigate into it, and create a `.env` file:
+
     ```bash
     mkdir shumai && cd shumai
     ```
+
     Create a `.env` file with the following variables:
+
     ```env
     DATABASE_URL=postgresql://shumai:shumai_password@localhost:5432/shumai_db?schema=public
     BETTER_AUTH_SECRET=your-random-32-character-secret-key
     STORAGE_BACKEND=local
     AWS_ENDPOINT_URL_S3=http://localhost:3000
     ```
+
+    > [!TIP]
+    > `AWS_ENDPOINT_URL_S3` must include the scheme and port (e.g. `http://localhost:3000`) where Shumai is publicly accessible. This URL is used directly by client browsers for file uploads.
+
 4.  **Start Shumai**:
 
     > [!IMPORTANT]

--- a/packages/core/src/s3/s3.test.ts
+++ b/packages/core/src/s3/s3.test.ts
@@ -191,4 +191,39 @@ describe('S3Service implementations', () => {
       await expect(localS3.presign('b', 'k', 'POST')).rejects.toThrow()
     })
   })
+
+  describe('s3Service initialization', () => {
+    let originalEnv: NodeJS.ProcessEnv
+
+    beforeEach(() => {
+      originalEnv = { ...process.env }
+    })
+
+    afterEach(() => {
+      process.env = originalEnv
+    })
+
+    it('should initialize LocalStorageService with default localhost and SHUMAI_SERVER_PORT when AWS_ENDPOINT_URL_S3 is not set', async () => {
+      process.env.STORAGE_BACKEND = 'local'
+      delete process.env.AWS_ENDPOINT_URL_S3
+      process.env.SHUMAI_SERVER_PORT = '4567'
+
+      vi.resetModules()
+      const { s3Service } = await import('./s3')
+      const url = await s3Service.presign('bucket', 'key', 'GET')
+      expect(url).toContain('http://localhost:4567')
+    })
+
+    it('should initialize LocalStorageService with exact AWS_ENDPOINT_URL_S3 when it is set', async () => {
+      process.env.STORAGE_BACKEND = 'local'
+      process.env.AWS_ENDPOINT_URL_S3 = 'http://123.456.7.8:12345'
+      process.env.SHUMAI_SERVER_PORT = '4567'
+
+      vi.resetModules()
+      const { s3Service } = await import('./s3')
+      const url = await s3Service.presign('bucket', 'key', 'GET')
+      expect(url).toContain('http://123.456.7.8:12345')
+      expect(url).not.toContain('4567')
+    })
+  })
 })

--- a/packages/core/src/s3/s3.ts
+++ b/packages/core/src/s3/s3.ts
@@ -452,7 +452,7 @@ export class LocalStorageService implements S3Service {
 
 const storageBackend = process.env.STORAGE_BACKEND || 'local'
 const port = process.env.SHUMAI_SERVER_PORT || '3000'
-const s3Endpoint = process.env.AWS_ENDPOINT_URL_S3 || 'http://localhost'
+const s3Endpoint = process.env.AWS_ENDPOINT_URL_S3 || `http://localhost:${port}`
 
 export const s3Service: S3Service =
   storageBackend === 's3'
@@ -464,4 +464,4 @@ export const s3Service: S3Service =
         process.env.S3_USE_SSL === 'true',
         process.env.S3_REGION || 'auto',
       )
-    : new LocalStorageService(`${s3Endpoint}:${port}`)
+    : new LocalStorageService(s3Endpoint)


### PR DESCRIPTION
## Summary

Refactored S3 local storage endpoint behavior. Previously, the S3 endpoint URL (`AWS_ENDPOINT_URL_S3`) and server port (`SHUMAI_SERVER_PORT`) were dynamically concatenated to form the local S3 endpoint URL. This prevented correct configuration for custom hostname/port combinations when mapped via proxy or Docker. Now, `AWS_ENDPOINT_URL_S3` is used directly as the local S3 address (which must include the port if applicable), falling back to `http://localhost:${SHUMAI_SERVER_PORT}` if not set.

## Changes

- Modified `packages/core/src/s3/s3.ts` to use `AWS_ENDPOINT_URL_S3` directly, falling back to `http://localhost:${SHUMAI_SERVER_PORT}` if undefined.
- Added test cases in `packages/core/src/s3/s3.test.ts` to verify the module-level initialization behavior under custom environment variables.
- Updated `docker-compose/local/docker-compose.yaml` to specify `http://localhost:3000` for `AWS_ENDPOINT_URL_S3` by default.
- Updated docs and README (`README.md`, `docs/configuration/env-variables.mdx`, `docs/getting-started/quickstart.mdx`) to document the updated configuration requirements.

## Verification

- Verified all 532 tests pass successfully via `bun run test --run`.
- Verified typescript compilation passes via `bun run typecheck`.
- Verified formatting and linting pass via `bun run format` and `bun run lint`.

## Notes

None.