### PR TITLE
fix(webui): fix missing left sidebar for nested folders

### DIFF
--- a/packages/webui/routes/projects/$projectId/files/$fileId.tsx
+++ b/packages/webui/routes/projects/$projectId/files/$fileId.tsx
@@ -172,10 +172,7 @@ function FileViewPage() {
     navigate,
   ])
 
-  const parentFolderId =
-    fileData?.ancestorFolders?.[fileData.ancestorFolders.length - 1]?.id ??
-    projectInfo?.rootFolder ??
-    ''
+  const parentFolderId = fileData?.ancestorFolders?.[0]?.id ?? projectInfo?.rootFolder ?? ''
 
   useEffect(() => {
     if (!parentFolderId || !activeFileId) return


### PR DESCRIPTION
## Summary

This PR fixes a bug where the left sidebar carousel (which displays files in the current folder) is not shown on the file detail page when viewing a file in a nested folder.

## Changes

- Updated `parentFolderId` extraction in `packages/webui/routes/projects/$projectId/files/$fileId.tsx` to use the first element (`[0]`) of `ancestorFolders` instead of the last element (`[length - 1]`). Since the backend returns `ancestorFolders` ordered closest-first (leaf-to-root), index `0` represents the immediate parent.

## Verification

Ran verification checks successfully:
- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test` (all 539 tests passed)

## Notes

None.