### PR TITLE
fix(api): fix update team settings and make request schema type-safe

### DIFF
--- a/packages/api/src/team.test.ts
+++ b/packages/api/src/team.test.ts
@@ -209,17 +209,17 @@ describe('team api', () => {
   })
 
   it('PATCH /teams/:teamId/settings updates settings', async () => {
-    mockUpdateSettings.mockResolvedValue({ someKey: 'new_value' })
+    mockUpdateSettings.mockResolvedValue({ transcode: { videoStrategy: 'all' } })
 
     const res = await app.request('/teams/t1/settings', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ key: 'someKey', value: 'new_value' }),
+      body: JSON.stringify({ key: 'transcode.videoStrategy', value: 'all' }),
     })
 
     expect(res.status).toBe(200)
     const data = await res.json()
-    expect(data.someKey).toBe('new_value')
+    expect(data.transcode.videoStrategy).toBe('all')
     expect(authzService.hasPermission).toHaveBeenCalledWith(
       expect.objectContaining({
         type: ResourceType.Team,
@@ -227,7 +227,7 @@ describe('team api', () => {
         permission: Permission.Admin,
       }),
     )
-    expect(mockUpdateSettings).toHaveBeenCalledWith('t1', 'someKey', 'new_value')
+    expect(mockUpdateSettings).toHaveBeenCalledWith('t1', 'transcode.videoStrategy', 'all')
   })
 
   it('GET /teams/:teamId/user-metadata returns all metadata for the user in the team', async () => {

--- a/packages/core/src/team/team.test.ts
+++ b/packages/core/src/team/team.test.ts
@@ -260,6 +260,15 @@ describe('TeamService', () => {
 
     const newSettings = await teamService.getSettings(team.id)
     expect(newSettings).toEqual({ theme: 'dark', semanticSearchEnabled: false })
+
+    await teamService.updateSettings(team.id, 'transcode.videoStrategy', 'all')
+
+    const finalSettings = await teamService.getSettings(team.id)
+    expect(finalSettings).toEqual({
+      theme: 'dark',
+      transcode: { videoStrategy: 'all' },
+      semanticSearchEnabled: false,
+    })
   })
 
   it('should create sandbox when team is created', async () => {

--- a/packages/core/src/team/team.ts
+++ b/packages/core/src/team/team.ts
@@ -306,7 +306,16 @@ export class TeamService {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const settings = (team.settings || {}) as any
-    settings[key] = value
+
+    if (key === 'transcode.videoStrategy') {
+      if (!settings.transcode) {
+        settings.transcode = {}
+      }
+      settings.transcode.videoStrategy = value
+      delete settings['transcode.videoStrategy']
+    } else {
+      settings[key] = value
+    }
 
     const updated = await prisma.team.update({
       where: { id: teamId },

--- a/packages/dtos/src/team.ts
+++ b/packages/dtos/src/team.ts
@@ -63,12 +63,6 @@ export const listMembersQuerySchema = z.object({
     .transform((v) => v === 'true'),
 })
 
-export const updateTeamSettingsRequestSchema = z.object({
-  key: z.string(),
-  value: z.any(),
-})
-export type UpdateTeamSettingsRequest = z.infer<typeof updateTeamSettingsRequestSchema>
-
 export const VideoTranscodeStrategy = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   best_match: 'best_match',
@@ -76,6 +70,14 @@ export const VideoTranscodeStrategy = {
 } as const
 export type VideoTranscodeStrategy =
   (typeof VideoTranscodeStrategy)[keyof typeof VideoTranscodeStrategy]
+
+export const updateTeamSettingsRequestSchema = z.discriminatedUnion('key', [
+  z.object({
+    key: z.literal('transcode.videoStrategy'),
+    value: z.nativeEnum(VideoTranscodeStrategy),
+  }),
+])
+export type UpdateTeamSettingsRequest = z.infer<typeof updateTeamSettingsRequestSchema>
 
 export const sandboxSettingsSchema = z.object({
   allowedDomains: z.array(z.string()),

--- a/packages/webui/routes/teams/$teamId/settings.tsx
+++ b/packages/webui/routes/teams/$teamId/settings.tsx
@@ -1,4 +1,4 @@
-import { VideoTranscodeStrategy } from '@shumai/dtos'
+import { VideoTranscodeStrategy, UpdateTeamSettingsRequest } from '@shumai/dtos'
 import { client } from '@/ui/api/client'
 import { AgentsSettings } from '@/ui/components/settings/AgentsSettings'
 import { ProvidersSettings } from '@/ui/components/settings/ProvidersSettings'
@@ -188,11 +188,10 @@ function TeamSettingsPage() {
   }
 
   const { mutate: updateSettings } = useMutation({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    mutationFn: async (data: { teamId: string; data: { key: string; value: any } }) => {
+    mutationFn: async (data: { teamId: string; data: UpdateTeamSettingsRequest }) => {
       const res = await client.api.teams[':teamId'].settings.$patch({
         param: { teamId: data.teamId },
-        json: { key: data.data.key, value: data.data.value },
+        json: data.data,
       })
       if (!res.ok) throw new Error('Failed to update settings')
       return await res.json()


### PR DESCRIPTION
## Summary

This PR fixes a bug where updating team settings (specifically `transcode.videoStrategy`) would store the key flat in the database JSON as `"transcode.videoStrategy": "all"` instead of nested under the `transcode` object. It also updates the settings update endpoint request schema to be strictly type-safe.

## Changes

- Defined a strictly type-safe schema `updateTeamSettingsRequestSchema` using `z.discriminatedUnion` in `packages/dtos/src/team.ts`.
- Updated `teamService.updateSettings` in `packages/core/src/team/team.ts` to handle nested settings keys separately (specifically mapping `transcode.videoStrategy` to `settings.transcode.videoStrategy` and clearing any flat keys).
- Refactored the frontend settings page mutation (`packages/webui/routes/teams/$teamId/settings.tsx`) to strictly type-validate settings requests against the schema instead of using `any`.
- Updated API tests (`packages/api/src/team.test.ts`) and core service tests (`packages/core/src/team/team.test.ts`) to verify the new type-safe settings schemas and database behavior.

## Verification

Ran all lint, formatting, typechecking, and vitest runs locally. All 539 tests passed successfully:
```bash
bun run lint
bun run format
bun run typecheck
bun run test
```

## Notes

No external dependencies or migrations are required.
