### PR TITLE
feat(transcode): change video poster resolution to 480p

### DIFF
--- a/packages/core/src/transcode/transcode.ts
+++ b/packages/core/src/transcode/transcode.ts
@@ -256,7 +256,7 @@ export class TranscodeService {
     duration: number,
   ): Promise<void> {
     const spriteFps = 100 / duration
-    const filterComplex = `[0:v]fps=${spriteFps},scale=w=480:h=-2,tile=10x10[sprite_out];[0:v]scale=-2:720:force_original_aspect_ratio=decrease,select='eq(n\\,0)'[thumb_out]`
+    const filterComplex = `[0:v]fps=${spriteFps},scale=w=480:h=-2,tile=10x10[sprite_out];[0:v]scale=-2:480:force_original_aspect_ratio=decrease,select='eq(n\\,0)'[thumb_out]`
 
     const args = [
       '-i',


### PR DESCRIPTION
## Summary

    This pull request updates the video poster generation settings in the transcode service to scale output WebP poster images to 480p instead of 720p.

    ## Changes

    - Updated the video poster output scale filter from `scale=-2:720` to `scale=-2:480` in `generateSprite` inside `packages/core/src/transcode/transcode.ts`.

    ## Verification

    - Ran project-wide validation tasks, which all passed successfully:
      - `bun run lint`
      - `bun run format`
      - `bun run typecheck`
      - `bun run test` (all 539 tests passed)

    ## Notes

    None.