### PR TITLE
fix(webui): preserve video ended state by skipping playhead snap on ended

### DIFF
--- a/packages/webui/components/viewers/use-frame-player.ts
+++ b/packages/webui/components/viewers/use-frame-player.ts
@@ -126,8 +126,11 @@ export function useFramePlayer(
       setCurrentFrame(clamped)
 
       // Snap the playhead to the center of the paused frame to align browser compositor
-      const safeCenterTime = calculateFrameCenterTime(clamped, frameRate)
-      video.currentTime = safeCenterTime
+      // Skip snapping if the video has ended to preserve the native ended state and allow native replay
+      if (!video.ended) {
+        const safeCenterTime = calculateFrameCenterTime(clamped, frameRate)
+        video.currentTime = safeCenterTime
+      }
     }
 
     video.addEventListener('play', handlePlay)


### PR DESCRIPTION
## Summary

    This PR resolves a bug where the video player's replay button or video area click would fail to restart playback once the video ended.

    ## Changes

    - Modified `handlePause` in `packages/webui/components/viewers/use-frame-player.ts` to skip playhead snapping when the video is in an ended state (`video.ended === true`).
    - This preserves the native browser `ended` state, allowing the default browser replay mechanism to rewind the video to 0 and replay it when play/pause is toggled.

    ## Verification

    - Verified that the video replay functions properly when the video finishes playing.
    - All workspace validation checks run and passed successfully (`bun run lint`, `bun run format`, `bun run typecheck`, `bun run test`).

    ## Notes

    None.