### PR TITLE
ci(release): add Aliyun ACR push to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,12 +27,22 @@ jobs:
           username: shumaione
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # Log in to Aliyun ACR
+      - name: Log in to Aliyun ACR
+        uses: docker/login-action@v3
+        with:
+          registry: crpi-000nkafzu6xvpwsc.cn-hongkong.personal.cr.aliyuncs.com
+          username: njjyl723
+          password: ${{ secrets.ALI_ACR_TOKEN }}
+
       # Extract metadata (tags, labels) for Docker
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: shumaione/shumai
+          images: |
+            shumaione/shumai
+            crpi-000nkafzu6xvpwsc.cn-hongkong.personal.cr.aliyuncs.com/shumai-one/shumai
           tags: |
             type=semver,pattern={{version}}
             type=ref,event=branch


### PR DESCRIPTION
## Summary

This PR updates the GitHub release workflow to also tag and push Docker images to Aliyun ACR.

## Changes

- Configured a new Docker login step for Aliyun ACR using username `njjyl723` and password `${{ secrets.ALI_ACR_TOKEN }}`.
- Updated `docker/metadata-action` to generate metadata/tags for both Docker Hub (`shumaione/shumai`) and Aliyun ACR (`crpi-000nkafzu6xvpwsc.cn-hongkong.personal.cr.aliyuncs.com/shumai-one/shumai`).

## Verification

Ran all monorepo checks and tests locally:
- `bun run lint` (passed)
- `bun run format` (passed)
- `bun run typecheck` (passed)
- `bun run test` (passed)

## Notes

Requires setting the repository secret `ALI_ACR_TOKEN` on GitHub with the user's Aliyun ACR token.
