### PR TITLE
refactor(storage): use original filenames for stored files

### DIFF
--- a/packages/agent/src/tools/create-file.ts
+++ b/packages/agent/src/tools/create-file.ts
@@ -6,6 +6,7 @@ import * as path from 'path'
 import { s3Service } from '@shumai/core/src/s3/s3'
 import { detectSupportedMimeType } from '@shumai/core/src/utils/mime'
 import { ulid } from 'ulid'
+import { sanitizeFilename } from '@shumai/core/src/utils/filename'
 
 function getMimeType(filePath: string): string {
   try {
@@ -64,7 +65,7 @@ export function createCreateFileTool(userId: string): AgentTool<typeof createFil
         const mimeType = getMimeType(absolutePath)
 
         // Generate compliant S3 key matching normal file upload format
-        const s3Key = `files/${ulid()}/raw`
+        const s3Key = `files/${ulid()}/${sanitizeFilename(path.basename(absolutePath))}`
         await s3Service.uploadFileToKey(absolutePath, s3Key, mimeType)
 
         const result = await executeAgentToolWorkflow({

--- a/packages/agent/src/tools/create-version.ts
+++ b/packages/agent/src/tools/create-version.ts
@@ -6,6 +6,7 @@ import * as path from 'path'
 import { s3Service } from '@shumai/core/src/s3/s3'
 import { detectSupportedMimeType } from '@shumai/core/src/utils/mime'
 import { ulid } from 'ulid'
+import { sanitizeFilename } from '@shumai/core/src/utils/filename'
 
 function getMimeType(filePath: string): string {
   try {
@@ -65,7 +66,7 @@ export function createCreateVersionTool(userId: string): AgentTool<typeof create
         const mimeType = getMimeType(absolutePath)
 
         // Generate compliant S3 key matching normal file upload format
-        const s3Key = `files/${ulid()}/raw`
+        const s3Key = `files/${ulid()}/${sanitizeFilename(path.basename(absolutePath))}`
         await s3Service.uploadFileToKey(absolutePath, s3Key, mimeType)
 
         const result = await executeAgentToolWorkflow({

--- a/packages/api/src/file.ts
+++ b/packages/api/src/file.ts
@@ -299,5 +299,32 @@ const route = new Hono<{ Variables: { user: User } }>()
     const files = await assetService.getDownloadLinks(req.ids)
     return c.json({ files })
   })
+  .post(
+    '/files/download-url',
+    zValidator('json', z.object({ key: z.string().min(1), assetId: z.string().min(1) })),
+    async (c) => {
+      const user = c.get('user')
+      const req = c.req.valid('json')
+      const { key, assetId } = req
+
+      // Validate key format
+      if (!key.startsWith('files/')) {
+        return c.json({ error: 'Invalid key' }, 400)
+      }
+
+      // Verify user has read access to the asset
+      await authzService.hasPermission({
+        user,
+        permission: Permission.Read,
+        type: ResourceType.Asset,
+        id: assetId,
+      })
+
+      // Verify key belongs to the asset and generate download URL
+      const url = await assetService.getDownloadUrl(assetId, key)
+
+      return c.json({ url })
+    },
+  )
 
 export default route

--- a/packages/api/src/public-share.ts
+++ b/packages/api/src/public-share.ts
@@ -147,6 +147,28 @@ const route = app
       return handlePublicShareError(c, err)
     }
   })
+  .post(
+    '/shares/:shareId/files/:fileId/download-url',
+    zValidator('json', z.object({ key: z.string().min(1) })),
+    async (c) => {
+      const fileId = c.req.param('fileId')
+      const password = c.req.header('x-share-password')
+      const { key } = c.req.valid('json')
+
+      try {
+        await shareService.verifyPublicAccess(fileId, password)
+
+        if (!key.startsWith('files/')) {
+          return c.json({ error: 'Invalid key' }, 400)
+        }
+
+        const url = await assetService.getDownloadUrl(fileId, key)
+        return c.json({ url })
+      } catch (err) {
+        return handlePublicShareError(c, err)
+      }
+    },
+  )
   .get(
     '/shares/:shareId/files/:fileId/comments',
     zValidator('query', paginationParamsSchema),

--- a/packages/api/src/s3.test.ts
+++ b/packages/api/src/s3.test.ts
@@ -39,7 +39,7 @@ describe('S3 API', () => {
     }
   })
 
-  it('GET /files/* with filename query parameter sets Content-Disposition header', async () => {
+  it('GET /files/* sets Content-Disposition: attachment only when download=1 query param is present', async () => {
     // We need to capture the onFound callback from serveStatic options
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let onFoundCallback: ((path: string, c: any) => void) | undefined
@@ -54,25 +54,33 @@ describe('S3 API', () => {
     const { default: route } = await import('./s3')
     const app = new Hono().route('/files', route)
 
-    // First, verify onFound is called through the mock
-    await app.request('/files/b1/test.webp?filename=my-file.txt')
+    await app.request('/files/b1/test.webp?download=1')
 
     expect(onFoundCallback).toBeDefined()
 
-    // Test the callback directly
-    const mockContext = {
-      req: {
-        query: (key: string) => (key === 'filename' ? 'my-file.txt' : undefined),
-      },
+    // Test with download=1
+    const mockContextWithDownload = {
+      req: { query: (key: string) => (key === 'download' ? '1' : undefined) },
       header: vi.fn(),
     }
 
     if (onFoundCallback) {
-      onFoundCallback('/files/b1/test.webp', mockContext)
-      expect(mockContext.header).toHaveBeenCalledWith(
+      onFoundCallback('/files/b1/test.webp', mockContextWithDownload)
+      expect(mockContextWithDownload.header).toHaveBeenCalledWith(
         'Content-Disposition',
-        'attachment; filename="my-file.txt"',
+        'attachment',
       )
+    }
+
+    // Test without download param
+    const mockContextWithout = {
+      req: { query: () => undefined },
+      header: vi.fn(),
+    }
+
+    if (onFoundCallback) {
+      onFoundCallback('/files/b1/test.webp', mockContextWithout)
+      expect(mockContextWithout.header).not.toHaveBeenCalled()
     }
   })
 

--- a/packages/api/src/s3.ts
+++ b/packages/api/src/s3.ts
@@ -9,10 +9,8 @@ const route = new Hono()
       root: './data',
       rewriteRequestPath: (path) => path.replace(/^\/files\//, ''),
       onFound: (_path, c) => {
-        const filename = c.req.query('filename')
-        if (filename) {
-          const safeFilename = filename.replace(/["\r\n]/g, '_')
-          c.header('Content-Disposition', `attachment; filename="${safeFilename}"`)
+        if (c.req.query('download') === '1') {
+          c.header('Content-Disposition', 'attachment')
         }
       },
     }),

--- a/packages/core/src/asset/asset.test.ts
+++ b/packages/core/src/asset/asset.test.ts
@@ -2222,4 +2222,103 @@ describe('AssetService — natural sort by name', () => {
       expect(childActiveDb?.status).toBe('uploaded')
     })
   })
+
+  describe('getDownloadUrl', () => {
+    it('should return a presigned download URL for a key in the same directory', async () => {
+      const asset = await prisma.asset.create({
+        data: {
+          name: 'test.mp4',
+          type: AssetType.file,
+          status: AssetStatus.uploaded,
+          storageKey: {
+            create: { key: 'files/01TESTULID000000000000000/test.mp4' },
+          },
+        },
+      })
+
+      const url = await assetService.getDownloadUrl(
+        asset.id,
+        'files/01TESTULID000000000000000/test-720p.mp4',
+      )
+
+      expect(url).toBe('http://mock-s3-url')
+    })
+
+    it('should return a presigned download URL for the original key', async () => {
+      const asset = await prisma.asset.create({
+        data: {
+          name: 'test.mp4',
+          type: AssetType.file,
+          status: AssetStatus.uploaded,
+          storageKey: {
+            create: { key: 'files/01TESTULID000000000000000/test.mp4' },
+          },
+        },
+      })
+
+      const url = await assetService.getDownloadUrl(
+        asset.id,
+        'files/01TESTULID000000000000000/test.mp4',
+      )
+
+      expect(url).toBe('http://mock-s3-url')
+    })
+
+    it('should throw if the key does not share the same parent directory', async () => {
+      const asset = await prisma.asset.create({
+        data: {
+          name: 'test.mp4',
+          type: AssetType.file,
+          status: AssetStatus.uploaded,
+          storageKey: {
+            create: { key: 'files/01TESTULID000000000000000/test.mp4' },
+          },
+        },
+      })
+
+      await expect(
+        assetService.getDownloadUrl(asset.id, 'files/01OTHERULIDXXXXXXXXXX/hack.mp4'),
+      ).rejects.toThrow('Key does not belong to this asset')
+    })
+
+    it('should throw if the key contains path traversal segments', async () => {
+      const asset = await prisma.asset.create({
+        data: {
+          name: 'test.mp4',
+          type: AssetType.file,
+          status: AssetStatus.uploaded,
+          storageKey: {
+            create: { key: 'files/01TESTULID000000000000000/test.mp4' },
+          },
+        },
+      })
+
+      await expect(
+        assetService.getDownloadUrl(
+          asset.id,
+          'files/01TESTULID000000000000000/../01OTHERULIDXXXXXXXXXX/secret.mp4',
+        ),
+      ).rejects.toThrow('Key does not belong to this asset')
+    })
+
+    it('should throw if the asset does not exist', async () => {
+      await expect(
+        assetService.getDownloadUrl('nonexistent-id', 'files/01TESTULID000000000000000/test.mp4'),
+      ).rejects.toThrow('Asset not found or has no storage key')
+    })
+
+    it('should throw if the asset has no storage key', async () => {
+      const asset = await prisma.asset.create({
+        data: {
+          name: 'folder',
+          type: AssetType.folder,
+          status: AssetStatus.uploaded,
+        },
+      })
+
+      await expect(
+        assetService.getDownloadUrl(asset.id, 'files/01TESTULID000000000000000/test.mp4'),
+      ).rejects.toThrow('Asset not found or has no storage key')
+    })
+  })
 })

--- a/packages/core/src/asset/asset.ts
+++ b/packages/core/src/asset/asset.ts
@@ -842,7 +842,6 @@ export class AssetService {
           process.env.S3_BUCKET || 'shumai',
           info.media.original.key,
           'GET',
-          a.name,
         )
       }
     }
@@ -1583,7 +1582,7 @@ export class AssetService {
         }
       }
 
-      const media = latestVersion.media as PrismaJson.MediaInfo | null
+      let media = latestVersion.media as PrismaJson.MediaInfo | null
       if (media && media.videoPreview?.key) {
         media.videoPreview.url = await s3Service.presign(
           process.env.S3_BUCKET || 'shumai',
@@ -1593,21 +1592,19 @@ export class AssetService {
       }
 
       const key = latestVersion.storageKey?.key
-      if (media && key) {
-        const fileName =
-          a.type === AssetType.version_stack && (a.name === '' || !a.name)
-            ? latestVersion.name
-            : a.name
+      if (key) {
+        if (!media) {
+          media = {
+            original: null,
+            videoTranscodes: [],
+            imageTranscodes: [],
+          } as unknown as PrismaJson.MediaInfo
+        }
         media.original = {
           key,
-          downloadUrl: await s3Service.presign(
-            process.env.S3_BUCKET || 'shumai',
-            key,
-            'GET',
-            fileName,
-          ),
+          downloadUrl: await s3Service.presign(process.env.S3_BUCKET || 'shumai', key, 'GET'),
           filesizeInBytes: latestVersion.sizeByte,
-          codec: '', // TODO: extract from metadata if needed
+          codec: '',
         }
       }
 
@@ -1845,12 +1842,7 @@ export class AssetService {
         const key = file.storageKeyId ? storageKeyMap.get(file.storageKeyId) : null
         if (!key) return null
 
-        const url = await s3Service.presign(
-          process.env.S3_BUCKET || 'shumai',
-          key,
-          'GET',
-          file.name,
-        )
+        const url = await s3Service.presign(process.env.S3_BUCKET || 'shumai', key, 'GET', true)
 
         return {
           id: file.id,
@@ -1861,6 +1853,31 @@ export class AssetService {
     )
 
     return downloadLinks.filter((link): link is { id: string; name: string; url: string } => !!link)
+  }
+
+  /**
+   * Generate a presigned download URL for a given key, verifying it belongs to the asset's
+   * storage directory. This ensures users can only download files (original, transcodes, etc.)
+   * that belong to an asset they have access to.
+   */
+  async getDownloadUrl(assetId: string, key: string): Promise<string> {
+    const asset = await this.prismaClient.asset.findUnique({
+      where: { id: assetId },
+      select: { storageKey: { select: { key: true } } },
+    })
+
+    if (!asset?.storageKey?.key) {
+      throw new Error('Asset not found or has no storage key')
+    }
+
+    // Verify the requested key shares the same parent directory as the asset's storage key
+    const storageKey = asset.storageKey.key
+    const assetDir = storageKey.substring(0, storageKey.lastIndexOf('/') + 1)
+    if (key.includes('..') || !key.startsWith(assetDir)) {
+      throw new Error('Key does not belong to this asset')
+    }
+
+    return s3Service.presign(process.env.S3_BUCKET || 'shumai', key, 'GET', true)
   }
 
   private async toPreviewInfo(asset: Asset | AssetWithIncludes): Promise<PreviewInfo | null> {

--- a/packages/core/src/s3/s3.test.ts
+++ b/packages/core/src/s3/s3.test.ts
@@ -117,16 +117,43 @@ describe('S3Service implementations', () => {
       delete process.env.PRESIGNED_URL_EXPIRES_IN
     })
 
-    it('should pass filename to presign', async () => {
+    it('should not set contentDisposition for normal GET presign', async () => {
       const s3 = new S3StorageService('localhost:9000', 'key', 'secret', 'test-bucket', false)
-      await s3.presign('bucket', 'key', 'GET', 'test.txt')
+      await s3.presign('bucket', 'key', 'GET')
+
+      expect(s3PresignSpy).toHaveBeenCalledWith(
+        'key',
+        expect.not.objectContaining({
+          contentDisposition: expect.anything(),
+        }),
+      )
+    })
+
+    it('should set contentDisposition attachment when download is true', async () => {
+      const s3 = new S3StorageService('localhost:9000', 'key', 'secret', 'test-bucket', false)
+      await s3.presign('bucket', 'key', 'GET', true)
 
       expect(s3PresignSpy).toHaveBeenCalledWith(
         'key',
         expect.objectContaining({
-          contentDisposition: 'attachment; filename="test.txt"',
+          contentDisposition: 'attachment',
         }),
       )
+    })
+
+    it('should not cache download presign URLs', async () => {
+      const s3 = new S3StorageService('localhost:9000', 'key', 'secret', 'test-bucket', false)
+
+      s3PresignSpy.mockClear()
+      s3PresignSpy.mockReturnValueOnce('http://download-url-1')
+      s3PresignSpy.mockReturnValueOnce('http://download-url-2')
+
+      const url1 = await s3.presign('bucket', 'key', 'GET', true)
+      const url2 = await s3.presign('bucket', 'key', 'GET', true)
+
+      expect(url1).toBe('http://download-url-1')
+      expect(url2).toBe('http://download-url-2')
+      expect(s3PresignSpy).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -182,9 +209,9 @@ describe('S3Service implementations', () => {
       expect(url).toBe('http://localhost:3000/files/my-bucket/dir/file.txt')
     })
 
-    it('should generate a local presign URL with filename', async () => {
-      const url = await localS3.presign('my-bucket', 'dir/file.txt', 'GET', 'original.txt')
-      expect(url).toBe('http://localhost:3000/files/my-bucket/dir/file.txt?filename=original.txt')
+    it('should generate a local presign URL with download param', async () => {
+      const url = await localS3.presign('my-bucket', 'dir/file.txt', 'GET', true)
+      expect(url).toBe('http://localhost:3000/files/my-bucket/dir/file.txt?download=1')
     })
 
     it('should throw an error for unsupported presign methods', async () => {

--- a/packages/core/src/s3/s3.ts
+++ b/packages/core/src/s3/s3.ts
@@ -54,7 +54,7 @@ export interface S3Service {
   listObjects(bucket: string, prefix: string): Promise<string[]>
   uploadFile(filePath: string, contentType: string): Promise<string>
   uploadFileToKey(filePath: string, key: string, contentType: string): Promise<void>
-  presign(bucket: string, key: string, method: string, filename?: string): Promise<string>
+  presign(bucket: string, key: string, method: string, download?: boolean): Promise<string>
 }
 
 export class S3StorageService implements S3Service {
@@ -203,16 +203,16 @@ export class S3StorageService implements S3Service {
     })
   }
 
-  async presign(bucket: string, key: string, method: string, filename?: string): Promise<string> {
+  async presign(bucket: string, key: string, method: string, download?: boolean): Promise<string> {
     const expireHours = parseInt(process.env.PRESIGNED_URL_EXPIRES_IN || '5', 10)
     const expiresInSeconds = expireHours * 3600
     // Cache time is 2/3 of expire time, rounded to minute
     const cacheMinutes = Math.round((expireHours * 60 * 2) / 3)
     const cacheTtlMs = cacheMinutes * 60 * 1000
 
-    const cacheKey = `${bucket}:${key}:${filename || ''}`
+    const cacheKey = `${bucket}:${key}`
 
-    if (method === 'GET') {
+    if (method === 'GET' && !download) {
       const cached = this.presignCache.get(cacheKey)
       if (cached) return cached
     }
@@ -225,13 +225,13 @@ export class S3StorageService implements S3Service {
       method: method as any,
     }
 
-    if (filename) {
-      options.contentDisposition = `attachment; filename="${filename}"`
+    if (download) {
+      options.contentDisposition = 'attachment'
     }
 
     const url = this.client.presign(key, options)
 
-    if (method === 'GET') {
+    if (method === 'GET' && !download) {
       this.presignCache.set(cacheKey, url, cacheTtlMs)
     }
 
@@ -435,7 +435,7 @@ export class LocalStorageService implements S3Service {
     await fs.promises.copyFile(filePath, destPath)
   }
 
-  async presign(bucket: string, key: string, method: string, filename?: string): Promise<string> {
+  async presign(bucket: string, key: string, method: string, download?: boolean): Promise<string> {
     if (method !== 'GET' && method !== 'PUT') {
       throw new Error(`Invalid method: ${method}`)
     }
@@ -443,8 +443,8 @@ export class LocalStorageService implements S3Service {
       return `${this.endpoint}${signLocalUrl(bucket, key)}`
     }
     let url = `${this.endpoint}/files/${bucket}/${key}`
-    if (filename) {
-      url += `?filename=${encodeURIComponent(filename)}`
+    if (download) {
+      url += '?download=1'
     }
     return url
   }

--- a/packages/core/src/upload/upload.ts
+++ b/packages/core/src/upload/upload.ts
@@ -21,6 +21,7 @@ import {
 import { ImageTranscoder, VideoTranscoder } from '@shumai/transcode'
 import { generateKeyBetween } from 'jittered-fractional-indexing'
 import { ulid } from 'ulid'
+import { sanitizeFilename } from '@shumai/core/src/utils/filename'
 
 export class UploadService {
   constructor(private readonly prismaClient: typeof prisma = prisma) {}
@@ -130,7 +131,7 @@ export class UploadService {
       const assetType = file.type === 'folder' ? AssetType.folder : AssetType.file
       let key: string | null = null
       if (assetType === AssetType.file) {
-        key = `files/${ulid()}/raw`
+        key = `files/${ulid()}/${sanitizeFilename(file.name)}`
       }
 
       const newAsset = await tx.asset.create({

--- a/packages/core/src/utils/filename.test.ts
+++ b/packages/core/src/utils/filename.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeFilename, stemFromKey } from './filename'
+
+describe('sanitizeFilename', () => {
+  it('returns the filename unchanged when it is already safe', () => {
+    expect(sanitizeFilename('foo.mp4')).toBe('foo.mp4')
+    expect(sanitizeFilename('my-video_final.mov')).toBe('my-video_final.mov')
+  })
+
+  it('replaces slashes and backslashes with underscores', () => {
+    expect(sanitizeFilename('path/to/file.mp4')).toBe('path_to_file.mp4')
+    expect(sanitizeFilename('path\\to\\file.mp4')).toBe('path_to_file.mp4')
+  })
+
+  it('replaces NUL bytes and control characters', () => {
+    expect(sanitizeFilename('foo\x00bar.mp4')).toBe('foo_bar.mp4')
+    expect(sanitizeFilename('foo\x01bar.mp4')).toBe('foo_bar.mp4')
+  })
+
+  it('trims leading and trailing dots and whitespace', () => {
+    expect(sanitizeFilename('.hidden')).toBe('hidden')
+    expect(sanitizeFilename('...dotted...')).toBe('dotted')
+    expect(sanitizeFilename('  spaced  ')).toBe('spaced')
+    expect(sanitizeFilename('  .mixed. ')).toBe('mixed')
+  })
+
+  it('collapses multiple consecutive underscores', () => {
+    expect(sanitizeFilename('a//b')).toBe('a_b')
+    expect(sanitizeFilename('a///b')).toBe('a_b')
+  })
+
+  it('returns "file" for empty or whitespace-only input', () => {
+    expect(sanitizeFilename('')).toBe('file')
+    expect(sanitizeFilename('   ')).toBe('file')
+    expect(sanitizeFilename('...')).toBe('file')
+  })
+
+  it('preserves unicode characters', () => {
+    expect(sanitizeFilename('视频文件.mp4')).toBe('视频文件.mp4')
+    expect(sanitizeFilename('café.png')).toBe('café.png')
+  })
+
+  it('preserves spaces within the filename', () => {
+    expect(sanitizeFilename('my video file.mp4')).toBe('my video file.mp4')
+  })
+})
+
+describe('stemFromKey', () => {
+  it('extracts the stem from a key with extension', () => {
+    expect(stemFromKey('files/01ABC/foo.mp4')).toBe('foo')
+    expect(stemFromKey('files/01ABC/my-video.mov')).toBe('my-video')
+  })
+
+  it('extracts the stem from a key without extension', () => {
+    expect(stemFromKey('files/01ABC/raw')).toBe('raw')
+  })
+
+  it('handles keys with multiple dots in filename', () => {
+    expect(stemFromKey('files/01ABC/my.video.file.mp4')).toBe('my.video.file')
+  })
+
+  it('handles keys with no directory', () => {
+    expect(stemFromKey('foo.mp4')).toBe('foo')
+    expect(stemFromKey('raw')).toBe('raw')
+  })
+})

--- a/packages/core/src/utils/filename.ts
+++ b/packages/core/src/utils/filename.ts
@@ -1,0 +1,36 @@
+import path from 'path'
+
+/**
+ * Sanitize a filename for safe use as an S3 key segment.
+ * - Replaces characters unsafe for S3/filesystems with '_'
+ * - Trims leading/trailing whitespace and dots
+ * - Falls back to 'file' if the result is empty
+ */
+export function sanitizeFilename(filename: string): string {
+  // Replace NUL bytes, slashes, backslashes, and control characters
+  // eslint-disable-next-line no-control-regex
+  let safe = filename.replace(/[\x00-\x1f\x7f/\\]/g, '_')
+
+  // Trim leading/trailing whitespace and dots
+  safe = safe.replace(/^[\s.]+|[\s.]+$/g, '')
+
+  // Collapse multiple underscores
+  safe = safe.replace(/_+/g, '_')
+
+  if (!safe) {
+    return 'file'
+  }
+
+  return safe
+}
+
+/**
+ * Extract the filename stem (without extension) from a storage key.
+ * e.g. 'files/01ABC.../foo.mp4' → 'foo'
+ *      'files/01ABC.../raw' → 'raw'
+ */
+export function stemFromKey(key: string): string {
+  const basename = path.basename(key)
+  const ext = path.extname(basename)
+  return ext ? basename.slice(0, -ext.length) : basename
+}

--- a/packages/dtos/src/asset.ts
+++ b/packages/dtos/src/asset.ts
@@ -279,6 +279,7 @@ export interface ImageTranscode {
 export interface VideoTranscode {
   id: string
   url: string
+  key: string
   width: number
   height: number
   size: number

--- a/packages/transcode/src/activities/transcode.ts
+++ b/packages/transcode/src/activities/transcode.ts
@@ -2,6 +2,7 @@ import { prisma, WorkflowTaskType, WorkflowTaskStatus } from '@shumai/db'
 import { s3Service } from '@shumai/core/src/s3/s3'
 import { transcodeService } from '@shumai/core'
 import { metadataService } from '@shumai/core/src/metadata/metadata'
+import { stemFromKey } from '@shumai/core/src/utils/filename'
 import { ApplicationFailure } from '@temporalio/activity'
 import * as path from 'path'
 import * as fs from 'fs'
@@ -162,7 +163,9 @@ export async function transcodeVideoActivity(
   params: VideoActivityParams,
 ): Promise<PrismaJson.VideoTranscode> {
   const bucket = process.env.S3_BUCKET || 'shumai'
-  const key = path.join(path.dirname(params.assetKey), `video-${params.videoSpec.height}p.mp4`)
+  const stem = stemFromKey(params.assetKey)
+  const res = params.videoSpec.resolution || `${params.videoSpec.height}p`
+  const key = path.posix.join(path.posix.dirname(params.assetKey), `${stem}-${res}.mp4`)
 
   try {
     await s3Service.headObject(bucket, key)
@@ -172,7 +175,7 @@ export async function transcodeVideoActivity(
   }
 
   const tmpDir = path.dirname(params.filePath)
-  const outputFile = path.join(tmpDir, `video-${params.videoSpec.height}p.mp4`)
+  const outputFile = path.join(tmpDir, `${stem}-${res}.mp4`)
 
   try {
     let targetFps: number | string = params.originalFps || 30
@@ -237,7 +240,11 @@ export async function transcodeImageActivity(
   params: ImageActivityParams,
 ): Promise<PrismaJson.ImageTranscode> {
   const bucket = process.env.S3_BUCKET || 'shumai'
-  const key = path.join(path.dirname(params.assetKey), `image-${params.imageSpec.width}p.webp`)
+  const stem = stemFromKey(params.assetKey)
+  const key = path.posix.join(
+    path.posix.dirname(params.assetKey),
+    `${stem}-${params.imageSpec.width}p.webp`,
+  )
 
   try {
     await s3Service.headObject(bucket, key)
@@ -247,7 +254,7 @@ export async function transcodeImageActivity(
   }
 
   const tmpDir = path.dirname(params.filePath)
-  const outputFile = path.join(tmpDir, `image-${params.imageSpec.width}p.webp`)
+  const outputFile = path.join(tmpDir, `${stem}-${params.imageSpec.width}p.webp`)
 
   try {
     await transcodeService.transcodeImage(

--- a/packages/webui/components/breadcrumb-nav.tsx
+++ b/packages/webui/components/breadcrumb-nav.tsx
@@ -1,8 +1,10 @@
 import { Badge } from '@/ui/components/ui/badge'
+import { client } from '@/ui/api/client'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuPortal,
   DropdownMenuSeparator,
   DropdownMenuSub,
@@ -44,6 +46,15 @@ interface BreadcrumbNavProps {
   shareId?: string
   onFolderClick?: (folderId: string) => void
   fileId?: string
+  downloadInfo?: {
+    originalKey?: string
+    videoTranscodes?: Array<{
+      key: string
+      width: number
+      height: number
+      isRaw?: boolean
+    }>
+  }
   versions?: Array<{
     id: string
     version: number
@@ -69,6 +80,8 @@ export function BreadcrumbNav({
   isPublic = false,
   onFolderClick,
   fileId,
+  shareId,
+  downloadInfo,
   versions,
 }: BreadcrumbNavProps) {
   const navigate = useNavigate()
@@ -82,6 +95,33 @@ export function BreadcrumbNav({
       search: (prev: Record<string, unknown>) => ({ ...prev, version: versionId }),
     })
   }
+
+  const handleDownload = async (key: string) => {
+    if (!fileId) return
+    try {
+      const res = shareId
+        ? await client.api.shares[':shareId'].files[':fileId']['download-url'].$post({
+            param: { shareId, fileId },
+            json: { key },
+          })
+        : await client.api.files['download-url'].$post({
+            json: { key, assetId: fileId },
+          })
+      if (!res.ok) return
+      const { url } = await res.json()
+      const link = document.createElement('a')
+      link.href = url
+      link.download = ''
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+    } catch {
+      // silently fail
+    }
+  }
+
+  const hasVideoTranscodes =
+    downloadInfo?.videoTranscodes && downloadInfo.videoTranscodes.filter((t) => !t.isRaw).length > 0
 
   const breadcrumbs: { name: string; path?: string; id?: string; isMuted?: boolean }[] = isPublic
     ? [
@@ -155,9 +195,63 @@ export function BreadcrumbNav({
                   <ChevronDown className="h-4 w-4" />
                 </DropdownMenuTrigger>
                 <DropdownMenuContent className="w-56">
-                  <DropdownMenuItem onClick={() => console.log('Download')}>
-                    Download
-                  </DropdownMenuItem>
+                  {hasVideoTranscodes ? (
+                    <DropdownMenuSub>
+                      <DropdownMenuSubTrigger className="flex items-center gap-2">
+                        <span>{m.download()}</span>
+                      </DropdownMenuSubTrigger>
+                      <DropdownMenuPortal>
+                        <DropdownMenuSubContent className="w-48">
+                          <DropdownMenuLabel>{m.download()}</DropdownMenuLabel>
+                          {downloadInfo?.videoTranscodes
+                            ?.filter((t) => !t.isRaw)
+                            .map((t) => {
+                              const longSide = Math.max(t.width, t.height)
+                              let resolution = `${t.height}p`
+                              if (longSide >= 3840) resolution = '2160p'
+                              else if (longSide >= 1920) resolution = '1080p'
+                              else if (longSide >= 1280) resolution = '720p'
+                              else if (longSide >= 960) resolution = '540p'
+                              else if (longSide >= 640) resolution = '360p'
+                              else if (longSide >= 320) resolution = '180p'
+                              return (
+                                <DropdownMenuItem
+                                  key={resolution}
+                                  onClick={() => handleDownload(t.key)}
+                                  className="flex items-center justify-between"
+                                >
+                                  <span>{resolution}</span>
+                                  <span className="text-xs text-muted-foreground">MP4</span>
+                                </DropdownMenuItem>
+                              )
+                            })}
+                          {downloadInfo?.originalKey && (
+                            <>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem
+                                onClick={() => handleDownload(downloadInfo.originalKey!)}
+                                className="flex items-center justify-between"
+                              >
+                                <span>Original</span>
+                                <span className="text-xs text-muted-foreground">
+                                  {currentAsset.name?.split('.').pop()?.toUpperCase() || 'RAW'}
+                                </span>
+                              </DropdownMenuItem>
+                            </>
+                          )}
+                        </DropdownMenuSubContent>
+                      </DropdownMenuPortal>
+                    </DropdownMenuSub>
+                  ) : (
+                    <DropdownMenuItem
+                      onClick={() =>
+                        downloadInfo?.originalKey && handleDownload(downloadInfo.originalKey)
+                      }
+                      disabled={!downloadInfo?.originalKey}
+                    >
+                      {m.download()}
+                    </DropdownMenuItem>
+                  )}
                   {canEdit && (
                     <DropdownMenuItem onClick={() => console.log('Rename')}>
                       Rename

--- a/packages/webui/components/file-viewer.tsx
+++ b/packages/webui/components/file-viewer.tsx
@@ -1,4 +1,5 @@
 import { useScreenSize } from '@/ui/hooks/useScreenSize'
+import { client } from '@/ui/api/client'
 import { getBestTranscode } from '@/ui/lib/media'
 import type { AssetInfo } from '@shumai/dtos'
 import { Check, Copy, Download, Minus, Plus } from 'lucide-react'
@@ -19,6 +20,7 @@ type FileViewerProps = {
   onTimeUpdate?: (time: number) => void
   annotations?: Annotation[]
   startTime?: number
+  shareId?: string
   children?: ReactNode
 }
 
@@ -30,6 +32,7 @@ export function FileViewer({
   onTimeUpdate,
   annotations,
   startTime,
+  shareId,
   children,
 }: FileViewerProps) {
   const { width: screenWidth } = useScreenSize()
@@ -133,15 +136,29 @@ export function FileViewer({
     }
   }
 
-  const handleDownload = () => {
-    const url = file.media?.original?.downloadUrl
-    if (!url) return
-    const link = document.createElement('a')
-    link.href = url
-    link.download = file.name || 'image'
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
+  const handleDownload = async () => {
+    const key = file.media?.original?.key
+    if (!key || !file.id) return
+    try {
+      const res = shareId
+        ? await client.api.shares[':shareId'].files[':fileId']['download-url'].$post({
+            param: { shareId, fileId: file.id },
+            json: { key },
+          })
+        : await client.api.files['download-url'].$post({
+            json: { key, assetId: file.id },
+          })
+      if (!res.ok) return
+      const { url } = await res.json()
+      const link = document.createElement('a')
+      link.href = url
+      link.download = ''
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+    } catch {
+      // silently fail
+    }
   }
 
   const handleCopy = async () => {
@@ -210,7 +227,7 @@ export function FileViewer({
         <div className="relative px-4 py-3 bg-card border-t border-gray-200 dark:border-gray-700 z-10 flex items-center justify-end gap-2 transition-colors duration-200">
           <button
             onClick={handleDownload}
-            disabled={!file.media?.original?.downloadUrl}
+            disabled={!file.media?.original?.key}
             className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded bg-gray-200/50 dark:bg-white/10 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 transition-colors border border-transparent disabled:opacity-50 animate-in fade-in zoom-in-95 duration-200"
             title="Download original file"
           >
@@ -291,7 +308,7 @@ export function FileViewer({
             </button>
             <button
               onClick={handleDownload}
-              disabled={!file.media?.original?.downloadUrl}
+              disabled={!file.media?.original?.key}
               className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded bg-gray-200/50 dark:bg-white/10 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 transition-colors border border-transparent disabled:opacity-50 animate-in fade-in zoom-in-95 duration-200"
               title="Download original image"
             >
@@ -311,6 +328,7 @@ export function FileViewer({
           onTimeUpdate={onTimeUpdate}
           annotations={displayAnnotations}
           startTime={startTime}
+          shareId={shareId}
         >
           {children}
         </VideoPlayer>

--- a/packages/webui/components/public-share-manager.tsx
+++ b/packages/webui/components/public-share-manager.tsx
@@ -350,6 +350,17 @@ export function PublicShareManager({
         isPublic: true,
         shareId,
         fileId: viewingFileId || undefined,
+        downloadInfo: viewingFileData
+          ? {
+              originalKey: viewingFileData.media?.original?.key,
+              videoTranscodes: viewingFileData.media?.videoTranscodes?.map((t) => ({
+                key: t.key,
+                width: t.width,
+                height: t.height,
+                isRaw: t.isRaw,
+              })),
+            }
+          : undefined,
         onFolderClick: handleBreadcrumbClick,
         isRightSidebarCollapsed,
         onRightSidebarToggle: () => setIsRightSidebarCollapsed((prev) => !prev),
@@ -458,6 +469,7 @@ export function PublicShareManager({
                 onTimeUpdate={setCurrentTime}
                 annotations={annotations}
                 startTime={startTime}
+                shareId={shareId}
               />
             )}
           </div>

--- a/packages/webui/components/top-nav.tsx
+++ b/packages/webui/components/top-nav.tsx
@@ -19,6 +19,7 @@ export function TopNav() {
     currentAsset,
     isRootFolder,
     fileId,
+    downloadInfo,
     versions,
     isPublic,
     shareId,
@@ -87,6 +88,7 @@ export function TopNav() {
       isPublic={isPublic}
       shareId={shareId}
       fileId={fileId}
+      downloadInfo={downloadInfo}
       versions={versions}
       onFolderClick={onFolderClick}
     />

--- a/packages/webui/components/viewers/video-player.tsx
+++ b/packages/webui/components/viewers/video-player.tsx
@@ -1,4 +1,5 @@
 import type { AssetInfo, VideoTranscode } from '@shumai/dtos'
+import { client } from '@/ui/api/client'
 import { cn } from '@/ui/lib/utils'
 import {
   Check,
@@ -58,6 +59,7 @@ interface VideoPlayerProps {
   onTimeUpdate?: (time: number) => void
   annotations?: Annotation[]
   startTime?: number
+  shareId?: string
   children?: React.ReactNode
 }
 
@@ -76,7 +78,7 @@ interface ControlBarProps {
   handleVolumeChange: (newVolume: number) => void
   changePlaybackRate: (rate: number) => void
   changeResolution: (res: DisplayTranscode) => void
-  handleDownload: (url: string, resolution: string) => void
+  handleDownload: (key: string) => void
   toggleFullScreen: () => void
   onZoomChange: (zoom: number) => void
   onZoomReset: () => void
@@ -344,11 +346,13 @@ const ControlBar: React.FC<ControlBarProps> = ({
               {resolutions.map((res) => (
                 <DropdownMenuItem
                   key={res.resolution}
-                  onClick={() => handleDownload(res.url ?? '', res.resolution)}
+                  onClick={() => handleDownload(res.key ?? '')}
                   className="flex w-full items-center justify-between px-3 py-2 text-left text-sm text-foreground"
                 >
                   <span>{res.resolution}</span>
-                  <span className="text-xs text-muted-foreground">MP4</span>
+                  <span className="text-xs text-muted-foreground">
+                    {res.isRaw ? data.name?.split('.').pop()?.toUpperCase() || 'RAW' : 'MP4'}
+                  </span>
                 </DropdownMenuItem>
               ))}
             </DropdownMenuContent>
@@ -376,6 +380,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   onTimeUpdate,
   annotations,
   startTime,
+  shareId,
   children,
 }) => {
   const localPlayerRef = useRef<Player | null>(null)
@@ -456,12 +461,16 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   }
 
   // Initial resolution setup
-  const originalRes = {
+  const originalRes: DisplayTranscode = {
+    id: 'original',
     url: data.media.original.downloadUrl,
+    key: data.media.original.key ?? '',
     width: data.media.metadata.originalWidth ?? 0,
     height: data.media.metadata.originalHeight ?? 0,
+    size: 0,
+    isRaw: true,
     resolution: 'Original',
-  } as DisplayTranscode
+  }
 
   const resolutions: DisplayTranscode[] = (data.media.videoTranscodes ?? []).map((t) => {
     const longSide = Math.max(t.width, t.height)
@@ -837,13 +846,27 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     }
   }
 
-  const handleDownload = (url: string, resolution: string) => {
-    const link = document.createElement('a')
-    link.href = url
-    link.download = `${data.name}-${resolution}.mp4`
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
+  const handleDownload = async (key: string) => {
+    try {
+      const res = shareId
+        ? await client.api.shares[':shareId'].files[':fileId']['download-url'].$post({
+            param: { shareId, fileId: data.id! },
+            json: { key },
+          })
+        : await client.api.files['download-url'].$post({
+            json: { key, assetId: data.id! },
+          })
+      if (!res.ok) return
+      const { url } = await res.json()
+      const link = document.createElement('a')
+      link.href = url
+      link.download = ''
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+    } catch {
+      // silently fail
+    }
   }
 
   // Listen for fullscreen change events (ESC key)

--- a/packages/webui/routes/projects/$projectId/files/$fileId.tsx
+++ b/packages/webui/routes/projects/$projectId/files/$fileId.tsx
@@ -148,6 +148,15 @@ function FileViewPage() {
         },
         isRootFolder: false,
         fileId,
+        downloadInfo: {
+          originalKey: fileData.media?.original?.key,
+          videoTranscodes: fileData.media?.videoTranscodes?.map((t) => ({
+            key: t.key,
+            width: t.width,
+            height: t.height,
+            isRaw: t.isRaw,
+          })),
+        },
         versions: versionsDataList,
         onFolderClick: (id: string) => {
           navigate({

--- a/packages/webui/stores/top-nav.ts
+++ b/packages/webui/stores/top-nav.ts
@@ -13,6 +13,15 @@ export interface TopNavProjectState {
   }
   isRootFolder: boolean
   fileId?: string
+  downloadInfo?: {
+    originalKey?: string
+    videoTranscodes?: Array<{
+      key: string
+      width: number
+      height: number
+      isRaw?: boolean
+    }>
+  }
   versions?: Array<{
     id: string
     version: number


### PR DESCRIPTION
## Summary

Refactor file storage to use original filenames instead of the generic `raw` name, fix download UX across the video detail page, and properly handle `Content-Disposition` for file downloads.

## Changes

### Storage Key Format
- Uploaded files now stored as `files/{ulid}/{sanitized-original-name}` instead of `files/{ulid}/raw`
- Transcoded videos stored as `{stem}-{resolution}.mp4` (e.g. `foo-720p.mp4`)
- Transcoded images stored as `{stem}-{width}p.webp` (e.g. `foo-1920p.webp`)
- Added `sanitizeFilename()` and `stemFromKey()` utility helpers

### Download API
- Added `POST /api/files/download-url` endpoint for key-based single file downloads
  - Accepts `{ key, assetId }`, verifies read permission via `ResourceType.Asset`
  - Validates requested key belongs to the asset's storage directory (prevents key spoofing)
  - Returns presigned URL with `Content-Disposition: attachment`
- Fixed existing `download-links` bulk API to also set `Content-Disposition: attachment`

### Content-Disposition Handling
- Added `download?: boolean` param to `presign()` interface
- `Content-Disposition: attachment` only set when `download=true` (prevents breaking inline `<img>`/`<video>` rendering)
- S3: passed via presign options; Local: via `?download=1` query param
- Download URLs are not cached (infrequent, short-lived)
- Removed the old `?filename=` query param hack

### UI Fixes
- **Breadcrumb navbar download**: Fixed broken stub (was `console.log`). Video files show resolution submenu + Original; other types show direct download button
- **Video player controlbar download**: Now calls the download-url API instead of using display URLs. Shows correct file type label (actual extension for Original, MP4 for transcodes)
- **File viewer download**: Updated to use the download-url API
- **Unsupported file types**: Fixed download being disabled when `media` JSON is null — now always populates `media.original` when a storage key exists

### DTO Changes
- Added `key` field to `VideoTranscode` interface in `@shumai/dtos`

## Verification

- `bun run lint` ✅
- `bun run format` ✅
- `bun run typecheck` ✅
- `bun run test` ✅ (75 test files, 560 tests pass)

## Notes

- Existing files stored as `files/{ulid}/raw` continue to work (no data migration). Old files will download with filename `raw` — a future migration can rename them if desired.
- The `isRaw` flag on transcodes is unaffected — it's metadata, not derived from the filename.
- `path.dirname()` derivation pattern still works since the ULID directory is one level up from any filename.