### PR TITLE
fix(webui): resolve conditional hooks and setState-in-render errors

### DIFF
--- a/packages/webui/components/team-selector.tsx
+++ b/packages/webui/components/team-selector.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/ui/components/ui/dialog'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
+import { useEffect } from 'react'
 import { m } from '@/ui/paraglide/messages.js'
 
 export function TeamSelector() {
@@ -23,14 +24,20 @@ export function TeamSelector() {
     },
   })
 
+  const teams = teamsData?.data
+  const onlyTeamId = teams?.length === 1 ? teams[0].id : null
+
+  useEffect(() => {
+    if (onlyTeamId) {
+      navigate({ to: `/teams/${onlyTeamId}` })
+    }
+  }, [onlyTeamId, navigate])
+
   if (isLoading) {
     return <div>{m.loading()}</div>
   }
 
-  const teams = teamsData?.data
-
-  if (teams?.length === 1) {
-    navigate({ to: `/teams/${teams[0].id}` })
+  if (onlyTeamId) {
     return null
   }
 

--- a/packages/webui/routes/__root.tsx
+++ b/packages/webui/routes/__root.tsx
@@ -40,14 +40,9 @@ function RootComponent() {
   const { uploading } = useUploadStore()
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const navigate = useNavigate()
+  const { teamId: storedTeamId, setTeamId } = useTeamContextStore()
 
   const showSidebar = user && (pathname.startsWith('/teams/') || pathname.startsWith('/projects/'))
-
-  if (!showSidebar) {
-    return <Outlet />
-  }
-
-  const { teamId: storedTeamId, setTeamId } = useTeamContextStore()
 
   useEffect(() => {
     resolveTeamIdFromPath(pathname).then((resolvedTeamId) => {
@@ -69,6 +64,10 @@ function RootComponent() {
     },
     enabled: !!storedTeamId,
   })
+
+  if (!showSidebar) {
+    return <Outlet />
+  }
 
   const unreadCount = me?.unreadNotificationCount ?? 0
   const displayCount = unreadCount > 99 ? '99+' : unreadCount


### PR DESCRIPTION
## Summary

Fixes the React runtime errors thrown when opening a team's projects page (`/teams/:teamId`):

- `Rendered more hooks than during the previous render` / hook-order change crash in `RootComponent`.
- `Cannot update a component (Transitioner) while rendering a different component (TeamSelector)`.

## Changes

- **`routes/__root.tsx`**: `RootComponent` called `useTeamContextStore`, `useEffect`, and `useQuery` *after* an early `return <Outlet />`. When `showSidebar` flipped from false to true (navigating into `/teams` or `/projects`), extra hooks appeared, violating the Rules of Hooks. Moved all hooks above the conditional return so they always run in a stable order.
- **`components/team-selector.tsx`**: The single-team auto-redirect called `navigate()` during render, updating the router's `Transitioner` mid-render. Moved the redirect into a `useEffect` keyed on the resolved team id.

## Verification

Ran the full required check suite; all pass simultaneously:

- `bun run lint` ✓
- `bun run format` ✓
- `bun run typecheck` ✓
- `bun run test` ✓ (564 tests / 76 files passed)

## Notes

Both changes are behavior-preserving; they only correct *when* the hooks/side effects run.