### PR TITLE
feat(file-browser): show video duration on file card preview

### DIFF
--- a/packages/core/src/asset/asset.test.ts
+++ b/packages/core/src/asset/asset.test.ts
@@ -1280,6 +1280,61 @@ describe('AssetService', () => {
     expect(updatedA.sortIndex! < assetC.sortIndex!).toBe(true)
   })
 
+  describe('Preview', () => {
+    it('toPreviewInfo includes video duration from media metadata', async () => {
+      const { project, user } = await setupBasicAssets()
+
+      const video = await prisma.asset.create({
+        data: {
+          name: 'clip.mp4',
+          type: AssetType.file,
+          projectId: project.id,
+          creatorId: user.id,
+          sizeByte: 123456,
+          mediaType: 'video/mp4',
+          status: 'processed',
+          media: {
+            poster: { key: 'poster-key' },
+            metadata: { duration: 262 },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any,
+        },
+      })
+
+      const info = await assetService.getAsset({ assetId: video.id })
+
+      expect(info.preview).toBeDefined()
+      expect(info.preview?.mediaType).toBe('video/mp4')
+      expect(info.preview?.duration).toBe(262)
+    })
+
+    it('toPreviewInfo omits duration for images', async () => {
+      const { project, user } = await setupBasicAssets()
+
+      const image = await prisma.asset.create({
+        data: {
+          name: 'pic.png',
+          type: AssetType.file,
+          projectId: project.id,
+          creatorId: user.id,
+          sizeByte: 5000,
+          mediaType: 'image/png',
+          status: 'processed',
+          media: {
+            thumbnail: { key: 'thumb-key' },
+            metadata: { originalWidth: 100, originalHeight: 80 },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any,
+        },
+      })
+
+      const info = await assetService.getAsset({ assetId: image.id })
+
+      expect(info.preview).toBeDefined()
+      expect(info.preview?.duration).toBeUndefined()
+    })
+  })
+
   describe('Symlinks', () => {
     it('toAssetInfo resolves symlink target metadata', async () => {
       const { project, user } = await setupBasicAssets()

--- a/packages/core/src/asset/asset.ts
+++ b/packages/core/src/asset/asset.ts
@@ -1913,6 +1913,7 @@ export class AssetService {
       originalHeight: asset.media.metadata?.originalHeight,
       originalWidth: asset.media.metadata?.originalWidth,
       spriteUrl,
+      duration: asset.media.metadata?.duration,
     }
   }
 

--- a/packages/dtos/src/asset.ts
+++ b/packages/dtos/src/asset.ts
@@ -13,6 +13,7 @@ export const previewInfoSchema = z.object({
   originalHeight: z.number().optional(),
   originalWidth: z.number().optional(),
   spriteUrl: z.string().optional(),
+  duration: z.number().optional(),
 })
 export type PreviewInfo = z.infer<typeof previewInfoSchema>
 

--- a/packages/webui/components/file-browser/file-card.tsx
+++ b/packages/webui/components/file-browser/file-card.tsx
@@ -276,7 +276,7 @@ export function FileCard({
             )}
           </div>
         ) : (
-          <FilePreview item={displayItem} />
+          <FilePreview item={displayItem} showDuration />
         )}
       </div>
 

--- a/packages/webui/components/file-browser/file-preview.tsx
+++ b/packages/webui/components/file-browser/file-preview.tsx
@@ -1,5 +1,6 @@
 import { File, Folder } from 'lucide-react'
 import { SpriteScrubber } from '../sprite-scrubber'
+import { formatTime } from '../viewers/utils'
 
 type FilePreviewItem = {
   type?: string | null
@@ -9,39 +10,56 @@ type FilePreviewItem = {
     thumbnailUrl?: string
     originalWidth?: number
     originalHeight?: number
+    duration?: number
   } | null
 }
 
 interface FilePreviewProps {
   item: FilePreviewItem
+  showDuration?: boolean
 }
 
-export const FilePreview = ({ item }: FilePreviewProps) => {
+export const FilePreview = ({ item, showDuration = false }: FilePreviewProps) => {
+  const isVideo = item.preview?.mediaType?.startsWith('video/')
+  const duration = item.preview?.duration
+  const durationOverlay =
+    showDuration && isVideo && typeof duration === 'number' && duration > 0 ? (
+      <span className="pointer-events-none absolute bottom-1 right-1 text-xs font-medium tabular-nums text-white">
+        {formatTime(duration)}
+      </span>
+    ) : null
+
   const isVideoWithSprite =
-    item.preview?.mediaType?.startsWith('video/') &&
-    item.preview.spriteUrl &&
+    isVideo &&
+    item.preview?.spriteUrl &&
     item.preview.thumbnailUrl &&
     item.preview.originalWidth &&
     item.preview.originalHeight
 
   if (isVideoWithSprite && item.preview) {
     return (
-      <SpriteScrubber
-        spriteUrl={item.preview.spriteUrl!}
-        thumbnailUrl={item.preview.thumbnailUrl!}
-        videoWidth={item.preview.originalWidth!}
-        videoHeight={item.preview.originalHeight!}
-      />
+      <>
+        <SpriteScrubber
+          spriteUrl={item.preview.spriteUrl!}
+          thumbnailUrl={item.preview.thumbnailUrl!}
+          videoWidth={item.preview.originalWidth!}
+          videoHeight={item.preview.originalHeight!}
+        />
+        {durationOverlay}
+      </>
     )
   }
 
   if (item.preview?.thumbnailUrl) {
     return (
-      <img
-        src={item.preview.thumbnailUrl}
-        alt="Preview"
-        className="w-full h-full object-contain bg-black"
-      />
+      <>
+        <img
+          src={item.preview.thumbnailUrl}
+          alt="Preview"
+          className="w-full h-full object-contain bg-black"
+        />
+        {durationOverlay}
+      </>
     )
   }
 


### PR DESCRIPTION
## Summary

Display the video duration in the bottom-right corner of the video file card preview area in the file list page. The duration is shown in `mm:ss` format (e.g. `04:22`, rolling over to `h:mm:ss` past an hour) with always-white text and a transparent background.

## Changes

- **DTO** (`packages/dtos/src/asset.ts`): add `duration` to `previewInfoSchema`.
- **Core** (`packages/core/src/asset/asset.ts`): populate `duration` from `media.metadata.duration` in `toPreviewInfo` (no extra DB queries).
- **WebUI** (`file-preview.tsx`): render a bottom-right white/transparent overlay using the existing `formatTime` helper, only for videos with a positive duration. Gated behind a new `showDuration` prop.
- **WebUI** (`file-card.tsx`): pass `showDuration` so the overlay appears only on file cards, not on folder card child previews.
- **Tests** (`asset.test.ts`): add a `Preview` suite asserting duration is populated for videos and omitted for images.

## Verification

- `bun run format`, `bun run lint`, `bun run typecheck` — all clean.
- `bun run test` — 566 tests across 76 files pass, including the new preview-duration tests.

## Notes

- Per spec, the overlay uses white text with no background. On bright video frames contrast could be lower; a subtle shadow/gradient can be added later if desired.
- Scope is the grid file card view only; the list-row view is unchanged.