### PR TITLE
fix(version-stack): resolve correct latest version ID of version stack

### DIFF
--- a/packages/core/src/asset/asset.test.ts
+++ b/packages/core/src/asset/asset.test.ts
@@ -2376,4 +2376,59 @@ describe('AssetService — natural sort by name', () => {
       ).rejects.toThrow('Asset not found or has no storage key')
     })
   })
+
+  describe('resolveLatestVersionId', () => {
+    it('resolves the latest version ID of a version stack correctly (the one with the smallest sort index)', async () => {
+      const team = await prisma.team.create({ data: { name: 'Test Team' } })
+      const project = await prisma.project.create({
+        data: { name: 'Test Project', teamId: team.id },
+      })
+      const user = await prisma.user.create({
+        data: { name: 'Test User', email: `test-${Date.now()}@example.com` },
+      })
+
+      const stack = await prisma.asset.create({
+        data: {
+          name: 'stack',
+          type: AssetType.version_stack,
+          project: { connect: { id: project.id } },
+          creator: { connect: { id: user.id } },
+          status: AssetStatus.uploaded,
+        },
+      })
+
+      // Oldest version (A): larger sort index
+      const fileA = await prisma.asset.create({
+        data: {
+          name: 'fileA.mp4',
+          type: AssetType.file,
+          project: { connect: { id: project.id } },
+          parent: { connect: { id: stack.id } },
+          creator: { connect: { id: user.id } },
+          status: AssetStatus.uploaded,
+          sortIndex: 'y',
+        },
+      })
+
+      // Latest version (B): smaller sort index
+      const fileB = await prisma.asset.create({
+        data: {
+          name: 'fileB.mp4',
+          type: AssetType.file,
+          project: { connect: { id: project.id } },
+          parent: { connect: { id: stack.id } },
+          creator: { connect: { id: user.id } },
+          status: AssetStatus.uploaded,
+          sortIndex: 'x',
+        },
+      })
+
+      // Act: resolve latest version of the stack
+      const resolvedId = await assetService.resolveLatestVersionId(stack.id)
+
+      // Assert: should resolve to the latest version (fileB)
+      expect(resolvedId).toBe(fileB.id)
+      expect(resolvedId).not.toBe(fileA.id)
+    })
+  })
 })

--- a/packages/core/src/asset/asset.ts
+++ b/packages/core/src/asset/asset.ts
@@ -909,7 +909,7 @@ export class AssetService {
     if (currentType === AssetType.version_stack) {
       const latestChild = await this.prismaClient.asset.findFirst({
         where: { parentId: currentId, isDeleted: false },
-        orderBy: { sortIndex: 'desc' },
+        orderBy: { sortIndex: 'asc' },
         select: { id: true },
       })
       if (latestChild) {


### PR DESCRIPTION
## Summary

Fixes a bug where opening a version stack displayed comments for the oldest version (video A) instead of the latest version (video B).

## Changes

- Fixed resolveLatestVersionId in packages/core/src/asset/asset.ts to order children by sortIndex: 'asc' instead of sortIndex: 'desc'. Since smaller sort index represents a newer version, this correctly resolves the latest version's ID.
- Added a unit test resolveLatestVersionId in packages/core/src/asset/asset.test.ts to reproduce and verify the resolution logic.

## Verification

Ran all linting, formatting, type checking, unit tests, and E2E tests:
- bun run lint (Passed)
- bun run format (Passed)
- bun run typecheck (Passed)
- bun run test (Passed 592/592 tests)
- bun run test:e2e (Passed 21/21 Playwright tests)

## Notes

- Checked for similar sorting/resolution issues in other places in the codebase and verified that all other usages of sortIndex correctly assume ascending order for newer versions or are range-based inserts.