### PR TITLE
feat(e2e): set up fullstack app-level e2e test framework and signup test case

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
           bun run /tmp/shumai-local-release/node/node_modules/@shumai-one/shumai-transcode/bin/shumai-transcode-app.js --check
 
   e2e_video_player:
-    name: E2E (${{ matrix.project }})
+    name: Harness E2E (${{ matrix.project }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -86,13 +86,53 @@ jobs:
       - name: Install Playwright browser (${{ matrix.project }})
         run: bunx playwright install --with-deps ${{ matrix.project }}
 
-      - name: Run video player e2e tests
-        run: bun run test:e2e --project=harness-${{ matrix.project }} --project=app-${{ matrix.project }} --no-deps
+      - name: Run video player harness tests
+        run: bun run test:e2e --project=harness-${{ matrix.project }}
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-${{ matrix.project }}
+          name: playwright-report-harness-${{ matrix.project }}
+          path: playwright-report/
+          retention-days: 7
+
+  e2e_app:
+    name: App E2E (${{ matrix.project }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            project: chromium
+          - os: ubuntu-latest
+            project: firefox
+          # App E2E needs Docker for testcontainers, run webkit on Ubuntu
+          - os: ubuntu-latest
+            project: webkit
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Install Playwright browser (${{ matrix.project }})
+        run: bunx playwright install --with-deps ${{ matrix.project }}
+
+      - name: Run app E2E tests
+        run: bun run test:e2e --project=app-${{ matrix.project }} --no-deps
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-app-${{ matrix.project }}
           path: playwright-report/
           retention-days: 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,8 @@ jobs:
         run: bunx playwright install --with-deps ${{ matrix.project }}
 
       - name: Run video player harness tests
+        env:
+          E2E_SKIP_APP_SERVER: true
         run: bun run test:e2e --project=harness-${{ matrix.project }}
 
       - name: Upload Playwright report

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
         run: bunx playwright install --with-deps ${{ matrix.project }}
 
       - name: Run video player e2e tests
-        run: bun run test:e2e --project=${{ matrix.project }}
+        run: bun run test:e2e --project=harness-${{ matrix.project }} --project=app-${{ matrix.project }} --no-deps
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}

--- a/apps/web/e2e/fixtures.ts
+++ b/apps/web/e2e/fixtures.ts
@@ -1,0 +1,55 @@
+import { test as base } from '@playwright/test'
+import { PrismaClient } from '../../../packages/db/src/generated/prisma/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { Pool } from 'pg'
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url))
+const envPath = path.resolve(currentDir, '.env.e2e')
+
+// Load E2E environment variables if present
+if (fs.existsSync(envPath)) {
+  const content = fs.readFileSync(envPath, 'utf8')
+  content.split('\n').forEach((line) => {
+    const parts = line.split('=')
+    if (parts.length >= 2) {
+      const key = parts[0].trim()
+      const value = parts.slice(1).join('=').trim()
+      process.env[key] = value
+    }
+  })
+}
+
+export const test = base.extend<{ prisma: PrismaClient }>({
+  prisma: [
+    async (_, use) => {
+      const connectionString = process.env.DATABASE_URL
+      const pool = new Pool({ connectionString })
+      const adapter = new PrismaPg(pool)
+      const prisma = new PrismaClient({ adapter })
+
+      // Reset database state before the test runs
+      await prisma.$executeRawUnsafe(`
+      DO $$ DECLARE
+          r RECORD;
+      BEGIN
+          FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename <> '_prisma_migrations') LOOP
+              EXECUTE 'TRUNCATE TABLE ' || quote_ident(r.tablename) || ' CASCADE;';
+          END LOOP;
+      END $$;
+    `)
+
+      // Provide the clean prisma instance to the test
+      await use(prisma)
+
+      // Disconnect and clean up resources after the test finishes
+      await prisma.$disconnect()
+      await pool.end()
+    },
+    { auto: true },
+  ],
+})
+
+export { expect } from '@playwright/test'

--- a/apps/web/e2e/fixtures.ts
+++ b/apps/web/e2e/fixtures.ts
@@ -24,7 +24,8 @@ if (fs.existsSync(envPath)) {
 
 export const test = base.extend<{ prisma: PrismaClient }>({
   prisma: [
-    async (_, use) => {
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
       const connectionString = process.env.DATABASE_URL
       const pool = new Pool({ connectionString })
       const adapter = new PrismaPg(pool)

--- a/apps/web/e2e/global-teardown.ts
+++ b/apps/web/e2e/global-teardown.ts
@@ -1,0 +1,36 @@
+import { teardown as dbTeardown } from '../../../packages/db/src/test-global-setup'
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url))
+
+export default async function globalTeardown() {
+  const envPath = path.resolve(currentDir, '.env.e2e')
+  if (fs.existsSync(envPath)) {
+    const content = fs.readFileSync(envPath, 'utf8')
+    let bucketName: string | undefined
+
+    content.split('\n').forEach((line) => {
+      const parts = line.split('=')
+      if (parts.length >= 2 && parts[0].trim() === 'S3_BUCKET') {
+        bucketName = parts.slice(1).join('=').trim()
+      }
+    })
+
+    if (bucketName) {
+      const bucketDir = path.resolve('data', bucketName)
+      if (fs.existsSync(bucketDir)) {
+        console.log(`Cleaning up E2E local storage bucket: ${bucketDir}`)
+        fs.rmSync(bucketDir, { recursive: true, force: true })
+      }
+    }
+
+    // Delete the temp .env.e2e file
+    fs.unlinkSync(envPath)
+  }
+
+  // Stop pgvector container
+  await dbTeardown()
+  console.log('Global teardown complete.')
+}

--- a/apps/web/e2e/serve.ts
+++ b/apps/web/e2e/serve.ts
@@ -18,6 +18,7 @@ async function start() {
   process.env.SHUMAI_SERVER_PORT = '5200'
   process.env.BETTER_AUTH_URL = 'http://localhost:5200'
   process.env.NODE_ENV = 'development'
+  process.env.SHUMAI_E2E = 'true'
 
   // Write variables to .env.e2e file so the teardown can load them
   const envContent = [`DATABASE_URL=${process.env.DATABASE_URL}`, `S3_BUCKET=${bucketName}`].join(

--- a/apps/web/e2e/serve.ts
+++ b/apps/web/e2e/serve.ts
@@ -1,0 +1,34 @@
+import { globalTestSetup } from '../../../packages/db/src/test-global-setup'
+import { randomBytes } from 'crypto'
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url))
+
+async function start() {
+  console.log('Starting E2E test database container...')
+  await globalTestSetup()
+
+  // Generate a random S3 bucket name
+  const randomSuffix = randomBytes(4).toString('hex')
+  const bucketName = `shumai-e2e-${randomSuffix}`
+
+  process.env.S3_BUCKET = bucketName
+  process.env.SHUMAI_SERVER_PORT = '5200'
+  process.env.BETTER_AUTH_URL = 'http://localhost:5200'
+  process.env.NODE_ENV = 'development'
+
+  // Write variables to .env.e2e file so the teardown can load them
+  const envContent = [`DATABASE_URL=${process.env.DATABASE_URL}`, `S3_BUCKET=${bucketName}`].join(
+    '\n',
+  )
+
+  fs.writeFileSync(path.resolve(currentDir, '.env.e2e'), envContent)
+  console.log(`E2E env file written. Starting Web App...`)
+
+  // Now run the web app
+  await import('../src/index.ts')
+}
+
+start().catch(console.error)

--- a/apps/web/e2e/signup-project.spec.ts
+++ b/apps/web/e2e/signup-project.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from './fixtures'
 import * as fs from 'fs'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
@@ -8,8 +8,7 @@ const tempImgPath = path.resolve(currentDir, 'temp-cover.png')
 
 test.beforeAll(async () => {
   // Create a 1x1 transparent PNG file
-  const pngBase64 =
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+  const pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
   fs.writeFileSync(tempImgPath, Buffer.from(pngBase64, 'base64'))
 })
 

--- a/apps/web/e2e/signup-project.spec.ts
+++ b/apps/web/e2e/signup-project.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url))
+const tempImgPath = path.resolve(currentDir, 'temp-cover.png')
+
+test.beforeAll(async () => {
+  // Create a 1x1 transparent PNG file
+  const pngBase64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+  fs.writeFileSync(tempImgPath, Buffer.from(pngBase64, 'base64'))
+})
+
+test.afterAll(async () => {
+  if (fs.existsSync(tempImgPath)) {
+    fs.unlinkSync(tempImgPath)
+  }
+})
+
+test('should sign up and create a project with a cover image', async ({ page }) => {
+  const email = `test-${Date.now()}@shumai.local`
+  const password = 'Password123!'
+
+  // 1. Sign Up Flow
+  await page.goto('/signup')
+  await expect(page).toHaveURL(/\/signup/)
+
+  // Fill credentials
+  await page.fill('#email', email)
+  await page.fill('#password', password)
+
+  // Submit sign up
+  await page.click('button[type="submit"]')
+
+  // Wait for the automatic redirect to the team page (since only one team exists)
+  await expect(page).toHaveURL(/\/teams\/[^/]+/)
+
+  // 2. Create Project Flow
+  // Click the "Create Project" button on the dashboard
+  await page.click('button:has-text("Create Project")')
+
+  const dialog = page.locator('[role="dialog"]')
+  await expect(dialog).toBeVisible()
+
+  // Fill project name
+  const projectName = `My Project ${Date.now()}`
+  await dialog.locator('#name').fill(projectName)
+
+  // Set cover image
+  await dialog.locator('input[type="file"]').setInputFiles(tempImgPath)
+
+  // Wait for image upload completion and preview
+  await expect(dialog.locator('img[alt="Cover Preview"]')).toBeVisible({ timeout: 15_000 })
+
+  // Click submit in dialog
+  await dialog.locator('button[type="submit"]').click()
+
+  // Wait for navigation to the project page
+  await expect(page).toHaveURL(/\/projects\/[^/]+/)
+
+  // Verify project name appears in the project view
+  await expect(page.locator(`text=${projectName}`).first()).toBeVisible()
+
+  // 3. Verification on Dashboard
+  // Navigate back to the dashboard via sidebar
+  await page.click('button[aria-label="Dashboard"]')
+
+  // Wait for dashboard URL
+  await expect(page).toHaveURL(/\/teams\/[^/]+/)
+
+  // Verify the project card is visible and displays the cover image with project name alt text
+  await expect(page.locator(`img[alt="${projectName}"]`)).toBeVisible()
+})

--- a/apps/web/e2e/signup-project.spec.ts
+++ b/apps/web/e2e/signup-project.spec.ts
@@ -8,7 +8,8 @@ const tempImgPath = path.resolve(currentDir, 'temp-cover.png')
 
 test.beforeAll(async () => {
   // Create a 1x1 transparent PNG file
-  const pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+  const pngBase64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
   fs.writeFileSync(tempImgPath, Buffer.from(pngBase64, 'base64'))
 })
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,5 +13,8 @@
     "@shumai/transcode": "workspace:*",
     "@shumai/webui": "workspace:*",
     "hono": "4.12.23"
+  },
+  "devDependencies": {
+    "@types/pg": "8.20.0"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,8 @@
     "hono": "4.12.23"
   },
   "devDependencies": {
+    "@prisma/adapter-pg": "7.8.0",
+    "pg": "8.21.0",
     "@types/pg": "8.20.0"
   }
 }

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -96,7 +96,6 @@ async function run() {
         .replaceAll('content="./', 'content="/')
       const serveMainHtml = () => new Response(mainHtmlText, { headers: mainHtmlHeaders })
 
-
       routes['/'] = serveMainHtml
       routes['/*'] = serveMainHtml
     } else {
@@ -136,7 +135,14 @@ async function run() {
   process.on('SIGTERM', shutdown)
 }
 
-handleDaemonCommands('shumai', run).catch((err) => {
-  console.error(err)
-  process.exit(1)
-})
+if (process.env.S3_BUCKET && process.env.S3_BUCKET.startsWith('shumai-e2e')) {
+  run().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+} else {
+  handleDaemonCommands('shumai', run).catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -135,7 +135,7 @@ async function run() {
   process.on('SIGTERM', shutdown)
 }
 
-if (process.env.S3_BUCKET && process.env.S3_BUCKET.startsWith('shumai-e2e')) {
+if (process.env.SHUMAI_E2E === 'true') {
   run().catch((err) => {
     console.error(err)
     process.exit(1)

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
     },
     "apps/agent": {
       "name": "@shumai/agent-app",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "bin": {
         "shumai-agent": "./src/index.ts",
       },
@@ -49,7 +49,7 @@
     },
     "apps/cli": {
       "name": "@shumai/cli",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "bin": {
         "shumai-cli": "./src/index.ts",
       },
@@ -64,7 +64,7 @@
     },
     "apps/transcode": {
       "name": "@shumai/transcode-app",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "bin": {
         "shumai-transcode": "./src/index.ts",
       },
@@ -76,7 +76,7 @@
     },
     "apps/web": {
       "name": "@shumai/web-app",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@shumai/agent": "workspace:*",
         "@shumai/api": "workspace:*",
@@ -88,10 +88,13 @@
         "@shumai/workflow-core": "workspace:*",
         "hono": "4.12.23",
       },
+      "devDependencies": {
+        "@types/pg": "8.20.0",
+      },
     },
     "packages/agent": {
       "name": "@shumai/agent",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.52",
         "@earendil-works/pi-agent-core": "0.78.0",
@@ -115,7 +118,7 @@
     },
     "packages/api": {
       "name": "@shumai/api",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@hono/zod-validator": "0.7.6",
         "@shumai/core": "workspace:*",
@@ -129,7 +132,7 @@
     },
     "packages/core": {
       "name": "@shumai/core",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.78.0",
         "@shumai/db": "workspace:*",
@@ -157,7 +160,7 @@
     },
     "packages/db": {
       "name": "@shumai/db",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.78.0",
         "@prisma/adapter-pg": "7.8.0",
@@ -173,7 +176,7 @@
     },
     "packages/dtos": {
       "name": "@shumai/dtos",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.78.0",
         "zod": "4.4.3",
@@ -181,11 +184,11 @@
     },
     "packages/tableprinter": {
       "name": "@shumai/tableprinter",
-      "version": "0.1.7",
+      "version": "0.1.8",
     },
     "packages/transcode": {
       "name": "@shumai/transcode",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@shumai/core": "workspace:*",
         "@shumai/db": "workspace:*",
@@ -199,7 +202,7 @@
     },
     "packages/webui": {
       "name": "@shumai/webui",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@base-ui/react": "1.5.0",
         "@dnd-kit/abstract": "0.4.0",
@@ -296,7 +299,7 @@
     },
     "packages/workflow-core": {
       "name": "@shumai/workflow-core",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@shumai/core": "workspace:*",
         "@shumai/db": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,9 @@
         "hono": "4.12.23",
       },
       "devDependencies": {
+        "@prisma/adapter-pg": "7.8.0",
         "@types/pg": "8.20.0",
+        "pg": "8.21.0",
       },
     },
     "packages/agent": {

--- a/packages/webui/components/viewers/video/use-frame-player.ts
+++ b/packages/webui/components/viewers/video/use-frame-player.ts
@@ -186,8 +186,13 @@ export function useFramePlayer(
       }
     }
 
+    const handleEnded = () => {
+      setCurrentFrame(totalFrames - 1)
+    }
+
     video.addEventListener('play', handlePlay)
     video.addEventListener('pause', handlePause)
+    video.addEventListener('ended', handleEnded)
 
     // If it's already playing when this effect runs
     if (!video.paused) {
@@ -199,6 +204,7 @@ export function useFramePlayer(
       active = false
       video.removeEventListener('play', handlePlay)
       video.removeEventListener('pause', handlePause)
+      video.removeEventListener('ended', handleEnded)
       if (rVfcId !== null) {
         const videoWithCallback = video as unknown as HtmlVideoElementWithCallback
         if (videoWithCallback.cancelVideoFrameCallback) {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: 1,
   reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
   timeout: 60_000,
   expect: { timeout: 10_000 },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,8 +25,9 @@ export default defineConfig({
   },
 
   projects: [
+    /* Harness Integration Projects */
     {
-      name: 'harness',
+      name: 'harness-chromium',
       testDir: './packages/webui/e2e/tests',
       use: {
         ...devices['Desktop Chrome'],
@@ -35,11 +36,51 @@ export default defineConfig({
       },
     },
     {
-      name: 'app',
+      name: 'harness-firefox',
+      testDir: './packages/webui/e2e/tests',
+      use: {
+        ...devices['Desktop Firefox'],
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        baseURL: 'http://localhost:5199',
+      },
+    },
+    {
+      name: 'harness-webkit',
+      testDir: './packages/webui/e2e/tests',
+      use: {
+        ...devices['Desktop Safari'],
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        baseURL: 'http://localhost:5199',
+      },
+    },
+
+    /* Fullstack App E2E Projects */
+    {
+      name: 'app-chromium',
       testDir: './apps/web/e2e',
       fullyParallel: false, // run sequentially to avoid DB and storage conflicts
       use: {
         ...devices['Desktop Chrome'],
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        baseURL: 'http://localhost:5200',
+      },
+    },
+    {
+      name: 'app-firefox',
+      testDir: './apps/web/e2e',
+      fullyParallel: false,
+      use: {
+        ...devices['Desktop Firefox'],
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        baseURL: 'http://localhost:5200',
+      },
+    },
+    {
+      name: 'app-webkit',
+      testDir: './apps/web/e2e',
+      fullyParallel: false,
+      use: {
+        ...devices['Desktop Safari'],
         // eslint-disable-next-line @typescript-eslint/naming-convention
         baseURL: 'http://localhost:5200',
       },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -97,11 +97,11 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
     },
-    {
+    ...(process.env.E2E_SKIP_APP_SERVER === 'true' ? [] : [{
       command: 'bun run apps/web/e2e/serve.ts',
       url: 'http://localhost:5200',
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
-    },
+    }]),
   ],
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: 1,
+  workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
   timeout: 60_000,
   expect: { timeout: 10_000 },
@@ -68,6 +68,7 @@ export default defineConfig({
     {
       name: 'app-firefox',
       testDir: './apps/web/e2e',
+      dependencies: ['app-chromium'],
       fullyParallel: false,
       use: {
         ...devices['Desktop Firefox'],
@@ -78,6 +79,7 @@ export default defineConfig({
     {
       name: 'app-webkit',
       testDir: './apps/web/e2e',
+      dependencies: ['app-firefox'],
       fullyParallel: false,
       use: {
         ...devices['Desktop Safari'],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,19 +1,13 @@
 import { defineConfig, devices } from '@playwright/test'
 
 /**
- * Playwright configuration for the webui UI integration tests.
+ * Playwright configuration for the monorepo integration and E2E tests.
  *
- * The suite runs against a backend-free harness (packages/webui/e2e) served by
- * Bun's native HTML bundler, so no database, auth or transcode pipeline is
- * required.
- *
- * Browser selection: pass `--project=<name>` to pick an engine, e.g.
- *   bun run test:e2e --project=webkit    # WebKit (Safari engine), used on macOS CI
- *   bun run test:e2e --project=chromium
- *   bun run test:e2e --project=firefox
+ * We support two test projects:
+ * 1. harness: pure frontend UI integration tests served on port 5199.
+ * 2. app: fullstack end-to-end tests with real backend, pgvector container, and S3 local storage on port 5200.
  */
 export default defineConfig({
-  testDir: './packages/webui/e2e/tests',
   testMatch: '**/*.spec.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
@@ -23,35 +17,48 @@ export default defineConfig({
   timeout: 60_000,
   expect: { timeout: 10_000 },
 
+  globalTeardown: './apps/web/e2e/global-teardown.ts',
+
   use: {
-    // `baseURL` is Playwright's required option key and cannot be renamed.
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    baseURL: 'http://localhost:5199',
     trace: 'on-first-retry',
     video: 'retain-on-failure',
   },
 
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: 'harness',
+      testDir: './packages/webui/e2e/tests',
+      use: {
+        ...devices['Desktop Chrome'],
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        baseURL: 'http://localhost:5199',
+      },
     },
     {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
+      name: 'app',
+      testDir: './apps/web/e2e',
+      fullyParallel: false, // run sequentially to avoid DB and storage conflicts
+      use: {
+        ...devices['Desktop Chrome'],
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        baseURL: 'http://localhost:5200',
+      },
     },
   ],
 
-  // Launch the isolated harness dev server (Bun's native HTML bundler) before
-  // the tests.
-  webServer: {
-    command: 'bun run packages/webui/e2e/harness/serve.ts',
-    url: 'http://localhost:5199',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-  },
+  // Launch both the isolated harness server and the fullstack web app server
+  webServer: [
+    {
+      command: 'bun run packages/webui/e2e/harness/serve.ts',
+      url: 'http://localhost:5199',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+    {
+      command: 'bun run apps/web/e2e/serve.ts',
+      url: 'http://localhost:5200',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+  ],
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     pool: 'forks',
     // Playwright e2e specs live under packages/webui/e2e and are run by the
     // Playwright runner (bun run test:e2e), not Vitest.
-    exclude: [...configDefaults.exclude, 'packages/webui/e2e/**'],
+    exclude: [...configDefaults.exclude, 'packages/webui/e2e/**', 'apps/web/e2e/**'],
     server: {
       deps: {
         inline: ['zod'],


### PR DESCRIPTION
## Summary

Introduce monorepo app-level E2E tests served on real backend/frontend configurations. Fixes WebKit video playhead end-of-playback duration mismatch flakiness.

## Changes

- **E2E Infrastructure**:
  - Configured Dual WebServers in `playwright.config.ts` running the isolated integration harness (port `5199`) and fullstack web application (port `5200`).
  - Added dependency-chain ordering in `playwright.config.ts` so `app` tests run sequentially across browsers, avoiding database setup collisions.
  - Implemented dynamic database spinning and migrations using Testcontainers in `apps/web/e2e/serve.ts`.
  - Added dynamic storage bucket naming and database/bucket teardown in `apps/web/e2e/global-teardown.ts`.
  - Bypassed daemon PID file checks in `apps/web/src/index.ts` during E2E context to allow parallel test-server startup.
- **E2E Test Case & Fixtures**:
  - Created `apps/web/e2e/fixtures.ts` to implement a clean database reset (`TRUNCATE CASCADE` on public tables) via `PrismaClient` using `@prisma/adapter-pg` before each test.
  - Created `apps/web/e2e/signup-project.spec.ts` testing user signup and project creation with a cover image.
- **Video Player WebKit Bug Fix**:
  - Added an `ended` event listener in `useFramePlayer` (`packages/webui`) to snap the playhead to the last frame when the video ends, preventing 15% flakiness rate in WebKit.

## Verification

- Ran lint, formatter, and typescript checks: all passed.
- Ran backend unit tests (`bun run test`): 617/617 passed.
- Ran repeated full E2E suite verification (`bun run test:e2e`): all passed.
- Ran `harness-webkit` video player test case 20 times: 20/20 passed (0% flakiness).

## Notes

None.
