### PR TITLE
feat(web): register pdf.worker route in production

### DIFF
--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -1,5 +1,6 @@
 import { loadEnvConfig } from '@shumai/core/src/env-loader'
-import { join } from 'node:path'
+import { readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 loadEnvConfig(process.cwd(), process.env.NODE_ENV !== 'production')
 
 import index from '@shumai/webui/index.html'
@@ -82,6 +83,27 @@ async function run() {
         const routePath = file.path.startsWith('.') ? file.path.slice(1) : file.path
         const filePath = join(import.meta.dir, file.path)
         routes[routePath] = () => new Response(Bun.file(filePath), { headers: file.headers })
+      }
+
+      const sampleFile = bundle.files[0]?.path || bundle.index || ''
+      const bundleDir = join(import.meta.dir, dirname(sampleFile))
+      try {
+        const dirFiles = readdirSync(bundleDir)
+        const pdfWorkerFile = dirFiles.find((f) => f.startsWith('pdf.worker'))
+        if (pdfWorkerFile) {
+          const routePath = '/' + pdfWorkerFile
+          const filePath = join(bundleDir, pdfWorkerFile)
+          const bunFile = Bun.file(filePath)
+          routes[routePath] = () =>
+            new Response(bunFile, {
+              headers: {
+                'content-type': 'text/javascript;charset=utf-8',
+                etag: `"${bunFile.size}-${bunFile.lastModified}"`,
+              },
+            })
+        }
+      } catch (err) {
+        console.warn('Failed to register pdf.worker route:', err)
       }
 
       const mainHtmlPath = join(import.meta.dir, bundle.index)

--- a/packages/webui/components/viewers/pdf/pdf-viewer.tsx
+++ b/packages/webui/components/viewers/pdf/pdf-viewer.tsx
@@ -9,7 +9,13 @@ import { PdfControlBar } from './pdf-control-bar'
 import pdfworker from '@/ui/public/pdf.worker.min.mjs' with { type: 'file' }
 
 if (typeof window !== 'undefined' && pdfjsLib.GlobalWorkerOptions) {
-  pdfjsLib.GlobalWorkerOptions.workerSrc = pdfworker
+  const workerPath =
+    typeof pdfworker === 'string'
+      ? pdfworker.startsWith('/')
+        ? pdfworker
+        : '/' + pdfworker.replace(/^\.\//, '')
+      : pdfworker
+  pdfjsLib.GlobalWorkerOptions.workerSrc = workerPath
 }
 
 export const PdfViewer = React.forwardRef<MediaController, FileViewerProps>(

--- a/packages/webui/components/viewers/pdf/pdf-viewer.tsx
+++ b/packages/webui/components/viewers/pdf/pdf-viewer.tsx
@@ -6,9 +6,7 @@ import React, { useCallback, useEffect, useImperativeHandle, useRef, useState } 
 import { FileViewerProps, MediaController } from '../types'
 import { PdfControlBar } from './pdf-control-bar'
 
-const { default: pdfworker } = await import('@/ui/public/pdf.worker.min.mjs', {
-  with: { type: 'file' },
-})
+import pdfworker from '@/ui/public/pdf.worker.min.mjs' with { type: 'file' }
 
 if (typeof window !== 'undefined' && pdfjsLib.GlobalWorkerOptions) {
   pdfjsLib.GlobalWorkerOptions.workerSrc = pdfworker


### PR DESCRIPTION
## Summary

Fixes serving the PDF.js worker file in production mode and normalizes the worker URL to be root-relative.

## Changes

- In `apps/web/src/index.ts`: added manual route registration for `pdf.worker` in production mode by scanning the common bundle output directory for files prefixed with `pdf.worker`.
- In `packages/webui/components/viewers/pdf/pdf-viewer.tsx`: normalized `pdfjsLib.GlobalWorkerOptions.workerSrc` to always be root-relative (prefixed with `/`), avoiding duplicate or invalid relative requests from nested sub-routes.

## Verification

- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test` (80 files, 646 passed)
- `bun run test:e2e` (30 passed)
- `bun run test:e2e:workflow` (28 passed)

## Notes

None.