### PR TITLE
feat(transcode): add PDF proxy support for TXT and CSV files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,7 @@ We use `prisma-json-types-generator` to enforce strict type-safety for Prisma `J
 
 - Development: Use `bun --bun run prisma migrate dev` to create and apply migrations during development.
 - Production: Use `bun --bun run prisma migrate deploy` to apply pending migrations in production environments.
+- **No Manual Migration Creation**: Never create migration SQL files or directories manually by hand. Always use Prisma CLI commands (e.g. `bun --bun run prisma migrate dev --create-only` to generate a migration template, or `bun --bun run prisma migrate dev`) so Prisma correctly tracks migration metadata and checksums.
 - **No Automatic Dev DB Reset**: Do not run `prisma migrate reset --force` or commands that force-reset the database automatically. If migrations become out of sync or a reset is required, stop executing, report the situation to the user, and present suggested manual cleanup/reset steps for the user to execute.
 
 ### Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,7 @@ We follow Bun's monorepo conventions for dependency management:
 4.  **Workspace Imports**: Use `workspace:*` for internal package dependencies.
 5.  **Clean Root**: The root `package.json` must not contain runtime `dependencies`. It is reserved for shared `devDependencies` and workspace-wide `scripts`.
 6.  **Installation**: Always run `bun install` from the root. Use the `--filter` flag if you only want to update a specific package (e.g., `bun install --filter @shumai/webui`).
+7.  **Adding Packages**: Never edit `package.json` manually to add new dependencies. Always use `bun add` (e.g., `bun add <package> --filter <workspace>`) without specifying an explicit version, letting Bun resolve the correct version.
 
 ## TypeScript Configuration
 

--- a/bun.lock
+++ b/bun.lock
@@ -139,13 +139,14 @@
         "@sinclair/typebox": "0.34.49",
         "adm-zip": "0.5.17",
         "better-auth": "1.6.11",
+        "csv-parse": "7.0.1",
         "date-fns": "4.4.0",
         "dotenv": "16.6.1",
         "dotenv-expand": "13.0.0",
         "extract-zip": "2.0.1",
         "hono": "4.12.23",
         "jittered-fractional-indexing": "1.0.1",
-        "pdfkit": "^0.16.0",
+        "pdfkit": "0.19.1",
         "pino": "10.3.1",
         "sharp": "0.34.5",
         "tweetnacl": "1.0.3",
@@ -156,7 +157,7 @@
       "devDependencies": {
         "@types/adm-zip": "0.5.8",
         "@types/extract-zip": "2.0.3",
-        "@types/pdfkit": "^0.13.9",
+        "@types/pdfkit": "0.17.6",
       },
     },
     "packages/db": {
@@ -1264,7 +1265,7 @@
 
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
-    "@types/pdfkit": ["@types/pdfkit@0.13.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-RDG8Yb1zT7I01FfpwK7nMSA433XWpblMqSCtA5vJlSyavWZb303HUYPCel6JTiDDFqwGLvtAnYbH8N/e0Cb89g=="],
+    "@types/pdfkit": ["@types/pdfkit@0.17.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-tIwzxk2uWKp0Cq9JIluQXJid77lYhF52EsIOwhsMF4iWLA6YneoBR1xVKYYdAysHuepUB0OX4tdwMiUDdGKmig=="],
 
     "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
@@ -1578,9 +1579,9 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
-    "crypto-js": ["crypto-js@4.2.0", "", {}, "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="],
-
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "csv-parse": ["csv-parse@7.0.1", "", {}, "sha512-+2z7Ar0APQ7Uu6fX4cn+pitRmxjZ1WPBcGmZFKmA74FCyi7Et/XZx8cjNQ5CjbZ4HCOxXCOpRBYvYH08Qa003A=="],
 
     "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
 
@@ -2028,7 +2029,7 @@
 
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
-    "jpeg-exif": ["jpeg-exif@1.1.4", "", {}, "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ=="],
+    "js-md5": ["js-md5@0.8.3", "", {}, "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ=="],
 
     "js-sha256": ["js-sha256@0.11.1", "", {}, "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg=="],
 
@@ -2290,7 +2291,7 @@
 
     "pdfjs-dist": ["pdfjs-dist@6.1.200", "", { "optionalDependencies": { "@napi-rs/canvas": "^1.0.0" } }, "sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw=="],
 
-    "pdfkit": ["pdfkit@0.16.0", "", { "dependencies": { "crypto-js": "^4.2.0", "fontkit": "^2.0.4", "jpeg-exif": "^1.1.4", "linebreak": "^1.1.0", "png-js": "^1.0.0" } }, "sha512-oXMxkIqXH4uTAtohWdYA41i/f6i2ReB78uhgizN8H4hJEpgR3/Xjy3iu2InNAuwCIabN3PVs8P1D6G4+W2NH0A=="],
+    "pdfkit": ["pdfkit@0.19.1", "", { "dependencies": { "@noble/ciphers": "^1.0.0", "@noble/hashes": "^1.6.0", "fontkit": "^2.0.4", "js-md5": "^0.8.3", "linebreak": "^1.1.0", "png-js": "^1.1.0" } }, "sha512-6Gzk+wDwTs4VSxsR5rCMTnIl5nlmkye1oWB0l2hDB1EX6ZNSIBroKQEv+2+fPPn+stVjyqzmsqRJVDfB9fo5DA=="],
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
@@ -3123,6 +3124,10 @@
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "pdfkit/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
+    "pdfkit/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "pg-types/postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -145,6 +145,7 @@
         "extract-zip": "2.0.1",
         "hono": "4.12.23",
         "jittered-fractional-indexing": "1.0.1",
+        "pdfkit": "^0.16.0",
         "pino": "10.3.1",
         "sharp": "0.34.5",
         "tweetnacl": "1.0.3",
@@ -155,6 +156,7 @@
       "devDependencies": {
         "@types/adm-zip": "0.5.8",
         "@types/extract-zip": "2.0.3",
+        "@types/pdfkit": "^0.13.9",
       },
     },
     "packages/db": {
@@ -1114,6 +1116,8 @@
 
     "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
 
+    "@swc/helpers": ["@swc/helpers@0.5.23", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw=="],
+
     "@swc/types": ["@swc/types@0.1.26", "", { "dependencies": { "@swc/counter": "^0.1.3" } }, "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
@@ -1259,6 +1263,8 @@
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
+    "@types/pdfkit": ["@types/pdfkit@0.13.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-RDG8Yb1zT7I01FfpwK7nMSA433XWpblMqSCtA5vJlSyavWZb303HUYPCel6JTiDDFqwGLvtAnYbH8N/e0Cb89g=="],
 
     "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
@@ -1470,6 +1476,10 @@
 
     "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
+    "brotli": ["brotli@1.3.3", "", { "dependencies": { "base64-js": "^1.1.2" } }, "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg=="],
+
+    "browserify-zlib": ["browserify-zlib@0.2.0", "", { "dependencies": { "pako": "~1.0.5" } }, "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA=="],
+
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
@@ -1528,6 +1538,8 @@
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
+    "clone": ["clone@2.1.2", "", {}, "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="],
+
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
@@ -1565,6 +1577,8 @@
     "crc32-stream": ["crc32-stream@6.0.0", "", { "dependencies": { "crc-32": "^1.2.0", "readable-stream": "^4.0.0" } }, "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "crypto-js": ["crypto-js@4.2.0", "", {}, "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -1631,6 +1645,8 @@
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "dfa": ["dfa@1.2.0", "", {}, "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
@@ -1783,6 +1799,8 @@
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "fontkit": ["fontkit@2.0.4", "", { "dependencies": { "@swc/helpers": "^0.5.12", "brotli": "^1.3.2", "clone": "^2.1.2", "dfa": "^1.2.0", "fast-deep-equal": "^3.1.3", "restructure": "^3.0.0", "tiny-inflate": "^1.0.3", "unicode-properties": "^1.4.0", "unicode-trie": "^2.0.0" } }, "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
@@ -2010,6 +2028,8 @@
 
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
+    "jpeg-exif": ["jpeg-exif@1.1.4", "", {}, "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ=="],
+
     "js-sha256": ["js-sha256@0.11.1", "", {}, "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -2071,6 +2091,8 @@
     "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "linebreak": ["linebreak@1.1.0", "", { "dependencies": { "base64-js": "0.0.8", "unicode-trie": "^2.0.0" } }, "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ=="],
 
     "loader-runner": ["loader-runner@4.3.2", "", {}, "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w=="],
 
@@ -2248,6 +2270,8 @@
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
+    "pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
@@ -2265,6 +2289,8 @@
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pdfjs-dist": ["pdfjs-dist@6.1.200", "", { "optionalDependencies": { "@napi-rs/canvas": "^1.0.0" } }, "sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw=="],
+
+    "pdfkit": ["pdfkit@0.16.0", "", { "dependencies": { "crypto-js": "^4.2.0", "fontkit": "^2.0.4", "jpeg-exif": "^1.1.4", "linebreak": "^1.1.0", "png-js": "^1.0.0" } }, "sha512-oXMxkIqXH4uTAtohWdYA41i/f6i2ReB78uhgizN8H4hJEpgR3/Xjy3iu2InNAuwCIabN3PVs8P1D6G4+W2NH0A=="],
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
@@ -2305,6 +2331,8 @@
     "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
 
     "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
+
+    "png-js": ["png-js@1.1.0", "", { "dependencies": { "browserify-zlib": "^0.2.0" } }, "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -2427,6 +2455,8 @@
     "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve": ["resolve@2.0.0-next.7", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.2", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ=="],
+
+    "restructure": ["restructure@3.0.2", "", {}, "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw=="],
 
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
@@ -2590,6 +2620,8 @@
 
     "thread-stream": ["thread-stream@4.2.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ=="],
 
+    "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
+
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
@@ -2645,6 +2677,10 @@
     "undici": ["undici@7.27.0", "", {}, "sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "unicode-properties": ["unicode-properties@1.4.1", "", { "dependencies": { "base64-js": "^1.3.0", "unicode-trie": "^2.0.0" } }, "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg=="],
+
+    "unicode-trie": ["unicode-trie@2.0.0", "", { "dependencies": { "pako": "^0.2.5", "tiny-inflate": "^1.0.0" } }, "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
@@ -3050,6 +3086,8 @@
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
+    "browserify-zlib/pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
     "bun-types/@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
 
     "c12/dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
@@ -3077,6 +3115,8 @@
     "jest-worker/@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
 
     "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "linebreak/base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
 
     "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "hono": "4.12.23",
     "jittered-fractional-indexing": "1.0.1",
     "pino": "10.3.1",
+    "pdfkit": "^0.16.0",
     "sharp": "0.34.5",
     "tweetnacl": "1.0.3",
     "ulid": "3.0.2",
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "@types/adm-zip": "0.5.8",
-    "@types/extract-zip": "2.0.3"
+    "@types/extract-zip": "2.0.3",
+    "@types/pdfkit": "^0.13.9"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,20 +6,21 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "dependencies": {
+    "@earendil-works/pi-agent-core": "0.78.0",
     "@shumai/db": "workspace:*",
     "@shumai/dtos": "workspace:*",
-    "@earendil-works/pi-agent-core": "0.78.0",
     "@sinclair/typebox": "0.34.49",
     "adm-zip": "0.5.17",
     "better-auth": "1.6.11",
+    "csv-parse": "7.0.1",
     "date-fns": "4.4.0",
     "dotenv": "16.6.1",
     "dotenv-expand": "13.0.0",
     "extract-zip": "2.0.1",
     "hono": "4.12.23",
     "jittered-fractional-indexing": "1.0.1",
+    "pdfkit": "0.19.1",
     "pino": "10.3.1",
-    "pdfkit": "^0.16.0",
     "sharp": "0.34.5",
     "tweetnacl": "1.0.3",
     "ulid": "3.0.2",
@@ -29,6 +30,6 @@
   "devDependencies": {
     "@types/adm-zip": "0.5.8",
     "@types/extract-zip": "2.0.3",
-    "@types/pdfkit": "^0.13.9"
+    "@types/pdfkit": "0.17.6"
   }
 }

--- a/packages/core/src/asset/asset.ts
+++ b/packages/core/src/asset/asset.ts
@@ -1697,6 +1697,13 @@ export class AssetService {
           'GET',
         )
       }
+      if (media && media.pdfTranscode?.key) {
+        media.pdfTranscode.url = await s3Service.presign(
+          process.env.S3_BUCKET || 'shumai',
+          media.pdfTranscode.key,
+          'GET',
+        )
+      }
 
       const key = latestVersion.storageKey?.key
       if (key) {
@@ -1715,6 +1722,8 @@ export class AssetService {
         }
       }
 
+      const proxyType = (media?.proxyType || null) as 'image' | 'video' | 'audio' | 'pdf' | null
+
       result.push({
         id: a.id,
         name:
@@ -1727,6 +1736,7 @@ export class AssetService {
         targetType: a.type === AssetType.symlink ? a.target?.type : null,
         status: latestVersion.status,
         mediaType: latestVersion.mediaType,
+        proxyType,
         latestChildren,
         preview,
         createdAt: a.createdAt.toISOString(),
@@ -2014,8 +2024,11 @@ export class AssetService {
       )
     }
 
+    const proxyType = (asset.media?.proxyType || null) as 'image' | 'video' | 'audio' | 'pdf' | null
+
     return {
       mediaType: asset.mediaType,
+      proxyType,
       thumbnailUrl,
       originalHeight: asset.media.metadata?.originalHeight,
       originalWidth: asset.media.metadata?.originalWidth,

--- a/packages/core/src/metadata/system_fields.ts
+++ b/packages/core/src/metadata/system_fields.ts
@@ -113,6 +113,23 @@ export const systemFields: Prisma.MetadataFieldCreateInput[] = [
     },
   },
   {
+    key: 'proxy_type',
+    scope: 'SYSTEM',
+    readOnly: true,
+    config: {
+      name: 'Proxy Type',
+      type: 'select',
+      select: {
+        options: [
+          { id: 'image', displayName: 'Image', color: 'system' },
+          { id: 'video', displayName: 'Video', color: 'system' },
+          { id: 'audio', displayName: 'Audio', color: 'system' },
+          { id: 'pdf', displayName: 'PDF', color: 'system' },
+        ],
+      },
+    },
+  },
+  {
     key: 'audio_bit_depth',
     scope: 'SYSTEM',
     readOnly: true,

--- a/packages/core/src/transcode/transcode.test.ts
+++ b/packages/core/src/transcode/transcode.test.ts
@@ -507,8 +507,11 @@ describe('TranscodeService', () => {
         },
       ]
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const sharpSpy = vi.mocked(sharp).mockImplementation((input: any, options?: any) => realSharp(input, options))
+      const sharpSpy = vi
+        .mocked(sharp)
+        .mockImplementation((input: unknown, options?: unknown) =>
+          realSharp(input as Parameters<typeof sharp>[0], options as Parameters<typeof sharp>[1]),
+        )
 
       const outputBuffer = await transcodeService.overlayAnnotationsOnBuffer(
         inputBuffer,
@@ -563,8 +566,11 @@ describe('TranscodeService', () => {
         },
       ]
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const sharpSpy = vi.mocked(sharp).mockImplementation((input: any, options?: any) => realSharp(input, options))
+      const sharpSpy = vi
+        .mocked(sharp)
+        .mockImplementation((input: unknown, options?: unknown) =>
+          realSharp(input as Parameters<typeof sharp>[0], options as Parameters<typeof sharp>[1]),
+        )
 
       const outputBuffer = await transcodeService.overlayAnnotationsOnBuffer(
         inputBuffer,
@@ -590,6 +596,33 @@ describe('TranscodeService', () => {
       expect(r).toBeLessThan(100)
       expect(g).toBeGreaterThan(200)
       expect(b).toBeLessThan(100)
+    })
+
+    it('should generate PDF from text file including CJK characters', async () => {
+      const txtFile = path.join(tempDir, 'test.txt')
+      const pdfFile = path.join(tempDir, 'output.pdf')
+      fs.writeFileSync(txtFile, 'Hello World\n你好世界\nこんにちは世界\n안녕하세요世界')
+
+      await transcodeService.generatePdfFromText(txtFile, pdfFile)
+
+      expect(fs.existsSync(pdfFile)).toBe(true)
+      const stat = fs.statSync(pdfFile)
+      expect(stat.size).toBeGreaterThan(0)
+    })
+
+    it('should generate PDF from CSV file including CJK characters', async () => {
+      const csvFile = path.join(tempDir, 'test.csv')
+      const pdfFile = path.join(tempDir, 'output.pdf')
+      fs.writeFileSync(
+        csvFile,
+        'Name,Age,Country\nHello World,25,USA\n你好世界,30,China\nこんにちは,28,Japan\n안녕하세요,22,Korea',
+      )
+
+      await transcodeService.generatePdfFromCsv(csvFile, pdfFile)
+
+      expect(fs.existsSync(pdfFile)).toBe(true)
+      const stat = fs.statSync(pdfFile)
+      expect(stat.size).toBeGreaterThan(0)
     })
   })
 })

--- a/packages/core/src/transcode/transcode.ts
+++ b/packages/core/src/transcode/transcode.ts
@@ -1,12 +1,13 @@
-import PDFDocument from 'pdfkit'
 import { s3Service } from '@shumai/core/src/s3/s3'
 import { stemFromKey } from '@shumai/core/src/utils/filename'
 import { prisma, WorkflowTaskStatus, WorkflowTaskType } from '@shumai/db'
 import '@shumai/db/src/prisma-json-types'
 import { execFile } from 'child_process'
+import { parse } from 'csv-parse/sync'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
+import PDFDocument from 'pdfkit'
 import sharp from 'sharp'
 import { ulid } from 'ulid'
 import { promisify } from 'util'
@@ -42,59 +43,21 @@ export function findCjkFontPath(): CjkFontConfig | undefined {
 }
 
 export function parseCsvContent(content: string): string[][] {
-  const rows: string[][] = []
-  let currentRow: string[] = []
-  let currentField = ''
-  let insideQuotes = false
-
-  for (let i = 0; i < content.length; i++) {
-    const char = content[i]
-    const nextChar = content[i + 1]
-
-    if (insideQuotes) {
-      if (char === '"' && nextChar === '"') {
-        currentField += '"'
-        i++
-      } else if (char === '"') {
-        insideQuotes = false
-      } else {
-        currentField += char
-      }
-    } else {
-      if (char === '"') {
-        insideQuotes = true
-      } else if (char === ',') {
-        currentRow.push(currentField.trim())
-        currentField = ''
-      } else if (char === '\n' || (char === '\r' && nextChar === '\n')) {
-        if (char === '\r') i++
-        currentRow.push(currentField.trim())
-        if (currentRow.some((f) => f.length > 0)) {
-          rows.push(currentRow)
-        }
-        currentRow = []
-        currentField = ''
-      } else if (char === '\r') {
-        currentRow.push(currentField.trim())
-        if (currentRow.some((f) => f.length > 0)) {
-          rows.push(currentRow)
-        }
-        currentRow = []
-        currentField = ''
-      } else {
-        currentField += char
-      }
-    }
+  try {
+    /* eslint-disable @typescript-eslint/naming-convention */
+    return parse(content, {
+      skip_empty_lines: true,
+      relax_column_count: true,
+      relax_quotes: true,
+      trim: true,
+      delimiter_auto: true,
+    })
+  } catch {
+    return content
+      .split(/\r?\n/)
+      .filter((line) => line.trim().length > 0)
+      .map((line) => line.split(',').map((cell) => cell.trim()))
   }
-
-  if (currentField || currentRow.length > 0) {
-    currentRow.push(currentField.trim())
-    if (currentRow.some((f) => f.length > 0)) {
-      rows.push(currentRow)
-    }
-  }
-
-  return rows
 }
 
 export interface MediaMetadata {

--- a/packages/core/src/transcode/transcode.ts
+++ b/packages/core/src/transcode/transcode.ts
@@ -1,3 +1,4 @@
+import PDFDocument from 'pdfkit'
 import { s3Service } from '@shumai/core/src/s3/s3'
 import { stemFromKey } from '@shumai/core/src/utils/filename'
 import { prisma, WorkflowTaskStatus, WorkflowTaskType } from '@shumai/db'
@@ -12,6 +13,89 @@ import { promisify } from 'util'
 import { dataFormatNames } from './dataFormatNames'
 
 const execFileAsync = promisify(execFile)
+
+export interface CjkFontConfig {
+  fontPath: string
+  fontName?: string
+}
+
+export function findCjkFontPath(): CjkFontConfig | undefined {
+  if (process.env.PDF_CJK_FONT_PATH && fs.existsSync(process.env.PDF_CJK_FONT_PATH)) {
+    return { fontPath: process.env.PDF_CJK_FONT_PATH }
+  }
+  const candidates: { fontPath: string; fontName?: string }[] = [
+    { fontPath: '/System/Library/Fonts/Supplemental/Arial Unicode.ttf' },
+    { fontPath: '/Library/Fonts/Arial Unicode.ttf' },
+    { fontPath: '/System/Library/Fonts/PingFang.ttc', fontName: 'PingFangSC-Regular' },
+    { fontPath: '/System/Library/Fonts/STHeiti Light.ttc', fontName: 'STHeitiSC-Light' },
+    { fontPath: '/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc' },
+    { fontPath: '/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc' },
+    { fontPath: '/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc' },
+    { fontPath: '/usr/share/fonts/truetype/arphic/ukai.ttc' },
+  ]
+  for (const item of candidates) {
+    if (fs.existsSync(item.fontPath)) {
+      return item
+    }
+  }
+  return undefined
+}
+
+export function parseCsvContent(content: string): string[][] {
+  const rows: string[][] = []
+  let currentRow: string[] = []
+  let currentField = ''
+  let insideQuotes = false
+
+  for (let i = 0; i < content.length; i++) {
+    const char = content[i]
+    const nextChar = content[i + 1]
+
+    if (insideQuotes) {
+      if (char === '"' && nextChar === '"') {
+        currentField += '"'
+        i++
+      } else if (char === '"') {
+        insideQuotes = false
+      } else {
+        currentField += char
+      }
+    } else {
+      if (char === '"') {
+        insideQuotes = true
+      } else if (char === ',') {
+        currentRow.push(currentField.trim())
+        currentField = ''
+      } else if (char === '\n' || (char === '\r' && nextChar === '\n')) {
+        if (char === '\r') i++
+        currentRow.push(currentField.trim())
+        if (currentRow.some((f) => f.length > 0)) {
+          rows.push(currentRow)
+        }
+        currentRow = []
+        currentField = ''
+      } else if (char === '\r') {
+        currentRow.push(currentField.trim())
+        if (currentRow.some((f) => f.length > 0)) {
+          rows.push(currentRow)
+        }
+        currentRow = []
+        currentField = ''
+      } else {
+        currentField += char
+      }
+    }
+  }
+
+  if (currentField || currentRow.length > 0) {
+    currentRow.push(currentField.trim())
+    if (currentRow.some((f) => f.length > 0)) {
+      rows.push(currentRow)
+    }
+  }
+
+  return rows
+}
 
 export interface MediaMetadata {
   originalWidth: number
@@ -425,6 +509,132 @@ export class TranscodeService {
       hasAudio: false,
       mimeType: 'application/pdf',
     }
+  }
+
+  async generatePdfFromText(inputFile: string, outputFile: string): Promise<void> {
+    const content = fs.readFileSync(inputFile, 'utf-8')
+    const containsCjk = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff\uac00-\ud7af]/.test(
+      content,
+    )
+    const cjkFont = containsCjk ? findCjkFontPath() : undefined
+
+    return new Promise<void>((resolve, reject) => {
+      const doc = new PDFDocument({
+        size: 'A4',
+        margin: 40,
+        bufferPages: true,
+      })
+      const writeStream = fs.createWriteStream(outputFile)
+      doc.pipe(writeStream)
+
+      if (cjkFont) {
+        if (cjkFont.fontName !== undefined) {
+          doc.font(cjkFont.fontPath, cjkFont.fontName)
+        } else {
+          doc.font(cjkFont.fontPath)
+        }
+      } else {
+        doc.font('Helvetica')
+      }
+      doc.fontSize(10)
+
+      doc.text(content, {
+        lineGap: 3,
+        paragraphGap: 4,
+      })
+
+      doc.end()
+
+      writeStream.on('finish', () => resolve())
+      writeStream.on('error', (err) => reject(err))
+    })
+  }
+
+  async generatePdfFromCsv(inputFile: string, outputFile: string): Promise<void> {
+    const content = fs.readFileSync(inputFile, 'utf-8')
+    const rows = parseCsvContent(content)
+    const containsCjk = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff\uac00-\ud7af]/.test(
+      content,
+    )
+    const cjkFont = containsCjk ? findCjkFontPath() : undefined
+
+    if (rows.length === 0) {
+      rows.push(['(Empty CSV)'])
+    }
+
+    const maxCols = Math.max(...rows.map((r) => r.length))
+    const isLandscape = maxCols > 5
+
+    return new Promise<void>((resolve, reject) => {
+      const doc = new PDFDocument({
+        size: 'A4',
+        layout: isLandscape ? 'landscape' : 'portrait',
+        margin: 30,
+        bufferPages: true,
+      })
+      const writeStream = fs.createWriteStream(outputFile)
+      doc.pipe(writeStream)
+
+      const setFont = () => {
+        if (cjkFont) {
+          if (cjkFont.fontName !== undefined) {
+            doc.font(cjkFont.fontPath, cjkFont.fontName)
+          } else {
+            doc.font(cjkFont.fontPath)
+          }
+        } else {
+          doc.font('Helvetica')
+        }
+        doc.fontSize(9)
+      }
+
+      setFont()
+
+      const pageWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right
+      const colWidth = Math.max(40, pageWidth / maxCols)
+
+      const startX = doc.page.margins.left
+      let startY = doc.page.margins.top
+      const rowHeight = 20
+
+      const drawRow = (row: string[], isHeader: boolean, y: number) => {
+        if (isHeader) {
+          doc.rect(startX, y, colWidth * maxCols, rowHeight).fill('#e0e0e0')
+          doc.fillColor('#000000')
+        }
+        for (let col = 0; col < maxCols; col++) {
+          const text = row[col] || ''
+          const x = startX + col * colWidth
+          doc.rect(x, y, colWidth, rowHeight).stroke('#cccccc')
+          doc.fillColor('#000000').text(text, x + 4, y + 5, {
+            width: colWidth - 8,
+            height: rowHeight - 6,
+            ellipsis: true,
+          })
+        }
+      }
+
+      const headerRow = rows[0]
+      drawRow(headerRow, true, startY)
+      startY += rowHeight
+
+      for (let r = 1; r < rows.length; r++) {
+        if (startY + rowHeight > doc.page.height - doc.page.margins.bottom) {
+          doc.addPage()
+          setFont()
+          startY = doc.page.margins.top
+          drawRow(headerRow, true, startY)
+          startY += rowHeight
+        }
+        drawRow(rows[r], false, startY)
+        startY += rowHeight
+      }
+
+      doc.end()
+
+      writeStream.on('finish', () => resolve())
+      writeStream.on('error', (err) => reject(err))
+    })
   }
 
   async extractAudio(inputFile: string, outputFile: string, bitrate: string): Promise<void> {

--- a/packages/core/src/upload/upload.test.ts
+++ b/packages/core/src/upload/upload.test.ts
@@ -236,7 +236,7 @@ describe('UploadService', () => {
     })
     const asset = await prisma.asset.create({
       data: {
-        name: 'file.txt',
+        name: 'file.json',
         type: AssetType.file,
         project: { connect: { id: projectId } },
         parent: { connect: { id: parentId } },
@@ -247,7 +247,7 @@ describe('UploadService', () => {
             create: { key: 'test-key' },
           },
         },
-        mediaType: 'text/plain',
+        mediaType: 'application/json',
       },
     })
 

--- a/packages/core/src/upload/upload.ts
+++ b/packages/core/src/upload/upload.ts
@@ -303,7 +303,13 @@ export class UploadService {
     const isVideo = asset.mediaType?.startsWith('video/')
     const isImage = asset.mediaType?.startsWith('image/')
     const isAudio = asset.mediaType?.startsWith('audio/')
-    const isPdf = asset.mediaType === 'application/pdf' || asset.name.toLowerCase().endsWith('.pdf')
+    const isPdf =
+      asset.mediaType === 'application/pdf' ||
+      asset.mediaType === 'text/plain' ||
+      asset.mediaType === 'text/csv' ||
+      asset.name.toLowerCase().endsWith('.pdf') ||
+      asset.name.toLowerCase().endsWith('.txt') ||
+      asset.name.toLowerCase().endsWith('.csv')
 
     if (autofillAgent && (isVideo || isImage)) {
       await tx.workflowTask.create({

--- a/packages/db/prisma/migrations/20260719132047_backfill_media_proxy_type/migration.sql
+++ b/packages/db/prisma/migrations/20260719132047_backfill_media_proxy_type/migration.sql
@@ -1,0 +1,32 @@
+-- Backfill media.proxyType for legacy assets
+UPDATE "assets"
+SET "media" = jsonb_set(
+  COALESCE("media"::jsonb, '{}'::jsonb),
+  '{proxyType}',
+  '"video"'::jsonb
+)
+WHERE "media" IS NOT NULL AND "media_type" LIKE 'video/%';
+
+UPDATE "assets"
+SET "media" = jsonb_set(
+  COALESCE("media"::jsonb, '{}'::jsonb),
+  '{proxyType}',
+  '"audio"'::jsonb
+)
+WHERE "media" IS NOT NULL AND "media_type" LIKE 'audio/%';
+
+UPDATE "assets"
+SET "media" = jsonb_set(
+  COALESCE("media"::jsonb, '{}'::jsonb),
+  '{proxyType}',
+  '"image"'::jsonb
+)
+WHERE "media" IS NOT NULL AND "media_type" LIKE 'image/%';
+
+UPDATE "assets"
+SET "media" = jsonb_set(
+  COALESCE("media"::jsonb, '{}'::jsonb),
+  '{proxyType}',
+  '"pdf"'::jsonb
+)
+WHERE "media" IS NOT NULL AND ("media_type" = 'application/pdf' OR "name" ILIKE '%.pdf');

--- a/packages/db/src/prisma-json-types.ts
+++ b/packages/db/src/prisma-json-types.ts
@@ -124,13 +124,20 @@ declare global {
       codec: string
     }
 
+    export interface PdfTranscode {
+      key?: string
+      url?: string
+    }
+
     export interface MediaInfo {
       duration: number
       filesize: number
       frames: number
+      proxyType?: 'image' | 'video' | 'audio' | 'pdf'
       imageTranscodes: ImageTranscode[]
       videoTranscodes: VideoTranscode[]
       videoPreview: VideoTranscode
+      pdfTranscode?: PdfTranscode
       sprite?: SpriteInfo
       poster?: PosterInfo
       thumbnail?: ImageTranscode

--- a/packages/dtos/src/asset.ts
+++ b/packages/dtos/src/asset.ts
@@ -9,6 +9,7 @@ export type AssetInfoPaginatedList = z.infer<typeof assetInfoPaginatedListSchema
 
 export const previewInfoSchema = z.object({
   mediaType: z.string().nullable(),
+  proxyType: z.enum(['image', 'video', 'audio', 'pdf']).nullable().optional(),
   thumbnailUrl: z.string().optional(),
   originalHeight: z.number().optional(),
   originalWidth: z.number().optional(),
@@ -63,6 +64,7 @@ export const assetInfoSchema = z.object({
   targetType: z.string().optional().nullable(),
   status: z.string(),
   mediaType: z.string().nullable(),
+  proxyType: z.enum(['image', 'video', 'audio', 'pdf']).nullable().optional(),
   latestChildren: z.array(childPreviewSchema).optional(),
   preview: previewInfoSchema.nullable().optional(),
   createdAt: z.string(),
@@ -105,6 +107,7 @@ export const assetInfoSchema = z.object({
         )
         .optional(),
       videoPreview: z.object({ url: z.string(), key: z.string().optional() }).optional(),
+      pdfTranscode: z.object({ url: z.string(), key: z.string().optional() }).optional(),
       mimeType: z.string().optional(),
       metadata: mediaMetadataSchema.optional(),
     })

--- a/packages/e2e/workflow/transcode.test.ts
+++ b/packages/e2e/workflow/transcode.test.ts
@@ -602,9 +602,7 @@ describe.each(['local', 'temporal'] as const)(
       })
 
       // 4. Wait for workflow to complete
-      console.log(
-        `Submitted E2E PDF Pages Workflow Task. ID: ${task.id}. Awaiting completion...`,
-      )
+      console.log(`Submitted E2E PDF Pages Workflow Task. ID: ${task.id}. Awaiting completion...`)
       const completedTask = await workflowService.executeWait(task, 45000)
 
       // 5. Verification
@@ -615,6 +613,92 @@ describe.each(['local', 'temporal'] as const)(
       expect(output).toBeDefined()
       expect(output.pages).toBeDefined()
       expect(output.pages.length).toBeGreaterThan(0)
+    }, 50000)
+
+    it('should run transcodeMedia workflow for a TXT asset with CJK text to generate PDF proxy successfully', async () => {
+      // 1. Seed Database
+      const team = await prisma.team.create({
+        data: { name: 'E2E CJK TXT Transcode Team' },
+      })
+
+      const project = await prisma.project.create({
+        data: { name: 'E2E CJK TXT Transcode Project', teamId: team.id },
+      })
+
+      const storageKey = await prisma.storageKey.create({
+        data: {
+          key: 'projects/e2e/cjk-test.txt',
+        },
+      })
+
+      const asset = await prisma.asset.create({
+        data: {
+          name: 'cjk-test.txt',
+          type: 'file',
+          status: 'uploaded',
+          mediaType: 'text/plain',
+          projectId: project.id,
+          storageKeyId: storageKey.id,
+        },
+      })
+
+      // 2. Seed S3 Storage with CJK text
+      const cjkText =
+        'Hello World\n你好世界 (Chinese)\nこんにちは世界 (Japanese)\n안녕하세요世界 (Korean)\nLine 5 of random text.'
+      const txtBuffer = Buffer.from(cjkText, 'utf-8')
+      await s3Service.putObject(
+        'shumai-e2e-test-bucket-transcode',
+        'projects/e2e/cjk-test.txt',
+        txtBuffer,
+        txtBuffer.length,
+        'text/plain',
+      )
+
+      // 3. Create Workflow Task
+      const task = await prisma.workflowTask.create({
+        data: {
+          type: 'transcode_pdf',
+          status: 'pending',
+          assetId: asset.id,
+          projectId: project.id,
+          teamId: team.id,
+          payload: {
+            projectId: project.id,
+            transcode: {
+              poster: true,
+              sprite: true,
+            },
+          },
+        },
+      })
+
+      // 4. Wait for workflow to complete
+      console.log(
+        `Submitted E2E CJK TXT Transcode Workflow Task. ID: ${task.id}. Awaiting completion...`,
+      )
+      const completedTask = await workflowService.executeWait(task, 45000)
+
+      // 5. Verification
+      expect(completedTask.status).toBe('completed')
+
+      const updatedAsset = await prisma.asset.findUnique({
+        where: { id: asset.id },
+      })
+      expect(updatedAsset?.status).toBe(AssetStatus.processed)
+
+      const mediaInfo = updatedAsset?.media as unknown as {
+        proxyType?: string
+        pdfTranscode?: { key: string }
+        poster?: { key: string }
+        sprite?: { key: string }
+        frames?: number
+      }
+      expect(mediaInfo).toBeDefined()
+      expect(mediaInfo.proxyType).toBe('pdf')
+      expect(mediaInfo.pdfTranscode?.key).toBe(`files/${asset.id}/proxy.pdf`)
+      expect(mediaInfo.poster?.key).toContain('poster.webp')
+      expect(mediaInfo.sprite?.key).toContain('sprite.webp')
+      expect(mediaInfo.frames).toBeGreaterThan(0)
     }, 50000)
   },
 )

--- a/packages/transcode/src/activities/transcode.test.ts
+++ b/packages/transcode/src/activities/transcode.test.ts
@@ -20,6 +20,7 @@ import {
   downloadMediaToTmpActivity,
   transcodeImageActivity,
   generateSpriteActivity,
+  generatePdfProxyActivity,
   transcodeVideoChunkActivity,
   deleteS3ObjectActivity,
 } from './transcode'
@@ -59,6 +60,8 @@ vi.mock('@shumai/core/src/transcode/transcode', () => ({
       originalWidth: 800,
       originalHeight: 1000,
     }),
+    generatePdfFromText: vi.fn(),
+    generatePdfFromCsv: vi.fn(),
     createTempDir: vi.fn().mockReturnValue('/tmp'),
     removeDir: vi.fn(),
     takeScreenshots: vi.fn(),
@@ -223,9 +226,37 @@ describe('Transcode Activities', () => {
 
     expect(metadataService.updateAssetMetadata).toHaveBeenCalledWith(
       asset.id,
-      expect.arrayContaining([{ key: 'file_type', value: 'document' }]),
+      expect.arrayContaining([
+        { key: 'file_type', value: 'document' },
+        { key: 'proxy_type', value: 'pdf' },
+      ]),
       true,
     )
+  })
+
+  it('should generate PDF proxy for text/csv files in generatePdfProxyActivity', async () => {
+    const asset = await prisma.asset.create({
+      data: { name: 'test.txt', type: 'file', status: 'uploaded' },
+    })
+
+    const generatePdfFromTextSpy = vi
+      .spyOn(transcodeService, 'generatePdfFromText')
+      .mockImplementation(async (_inPath, outPath) => {
+        const fs = await import('fs')
+        fs.writeFileSync(outPath, 'fake pdf content')
+      })
+
+    const res = await generatePdfProxyActivity({
+      assetId: asset.id,
+      assetKey: 'files/asset1/test.txt',
+      filePath: '/tmp/test.txt',
+      mediaType: 'text/plain',
+      filename: 'test.txt',
+    })
+
+    expect(res.pdfProxyKey).toBe(`files/${asset.id}/proxy.pdf`)
+    expect(generatePdfFromTextSpy).toHaveBeenCalled()
+    generatePdfFromTextSpy.mockRestore()
   })
 
   it('should set file_type to file for unknown types', async () => {

--- a/packages/transcode/src/activities/transcode.ts
+++ b/packages/transcode/src/activities/transcode.ts
@@ -59,10 +59,26 @@ export async function getMediaInfoActivity(params: {
             ? 'document'
             : 'file'
 
+    const isPdf =
+      params.mediaType === 'application/pdf' ||
+      params.mediaType === 'text/plain' ||
+      params.mediaType === 'text/csv'
+
+    const proxyType: 'image' | 'video' | 'audio' | 'pdf' | undefined = isVideo
+      ? 'video'
+      : isAudio
+        ? 'audio'
+        : isImage
+          ? 'image'
+          : isPdf || isDocument
+            ? 'pdf'
+            : undefined
+
     const mediaInfo: PrismaJson.MediaInfo = {
       duration: 0,
       filesize: 0,
       frames: 0,
+      proxyType,
       imageTranscodes: [],
       videoTranscodes: [],
       videoPreview: { width: 0, height: 0 },
@@ -80,6 +96,9 @@ export async function getMediaInfoActivity(params: {
     const metadataUpdates: { key: string; value: string | number }[] = [
       { key: 'file_type', value: fileType },
     ]
+    if (proxyType) {
+      metadataUpdates.push({ key: 'proxy_type', value: proxyType })
+    }
 
     if (isVideo) {
       const info = await transcodeService.getVideoInfo(params.filePath)
@@ -163,7 +182,7 @@ export async function getMediaInfoActivity(params: {
         { key: 'resolution_width', value: info.originalWidth },
         { key: 'resolution_height', value: info.originalHeight },
       )
-    } else if (params.mediaType === 'application/pdf') {
+    } else if (isPdf || isDocument) {
       const info = await transcodeService.getPdfInfo(params.filePath)
       mediaInfo.frames = info.totalFrames
       mediaInfo.metadata = {
@@ -420,7 +439,7 @@ export async function generateSpriteActivity(params: GenerateSpriteActivityParam
   const posterFile = path.join(tmpDir, 'poster.webp')
 
   try {
-    if (params.mediaInfo.mimeType === 'application/pdf') {
+    if (params.mediaInfo.proxyType === 'pdf' || params.mediaInfo.mimeType === 'application/pdf') {
       const pdfRes = await transcodeService.generatePdfSprite(
         params.filePath,
         spriteFile,
@@ -482,6 +501,50 @@ export async function generateSpriteActivity(params: GenerateSpriteActivityParam
   } finally {
     if (fs.existsSync(spriteFile)) fs.unlinkSync(spriteFile)
     if (fs.existsSync(posterFile)) fs.unlinkSync(posterFile)
+  }
+}
+
+export interface GeneratePdfProxyActivityParams {
+  assetId: string
+  assetKey: string
+  filePath: string
+  mediaType: string
+  filename: string
+}
+
+export async function generatePdfProxyActivity(
+  params: GeneratePdfProxyActivityParams,
+): Promise<{ pdfProxyKey: string; pdfFilePath: string }> {
+  const isTxt = params.mediaType === 'text/plain' || params.filename.toLowerCase().endsWith('.txt')
+  const isCsv = params.mediaType === 'text/csv' || params.filename.toLowerCase().endsWith('.csv')
+
+  if (!isTxt && !isCsv) {
+    return { pdfProxyKey: params.assetKey, pdfFilePath: params.filePath }
+  }
+
+  const bucket = process.env.S3_BUCKET || 'shumai'
+  const pdfProxyKey = `files/${params.assetId}/proxy.pdf`
+  const tmpDir = path.dirname(params.filePath)
+  const pdfFilePath = path.join(tmpDir, 'proxy.pdf')
+
+  try {
+    if (isCsv) {
+      await transcodeService.generatePdfFromCsv(params.filePath, pdfFilePath)
+    } else {
+      await transcodeService.generatePdfFromText(params.filePath, pdfFilePath)
+    }
+
+    const buffer = fs.readFileSync(pdfFilePath)
+    await s3Service.putObject(bucket, pdfProxyKey, buffer, buffer.length, 'application/pdf')
+
+    return { pdfProxyKey, pdfFilePath }
+  } catch (err) {
+    const { message } = getErrorDetails(err)
+    throw ApplicationFailure.create({
+      message: `Failed to generate PDF proxy for text/csv: ${message}`,
+      nonRetryable: true,
+      cause: err instanceof Error ? err : undefined,
+    })
   }
 }
 

--- a/packages/transcode/src/workflows/transcode-pdf.test.ts
+++ b/packages/transcode/src/workflows/transcode-pdf.test.ts
@@ -34,6 +34,9 @@ describe('transcodePdfWorkflow', () => {
     downloadMediaToTmpActivity: Object.assign(vi.fn(), {
       _activityName: 'downloadMediaToTmpActivity',
     }),
+    generatePdfProxyActivity: Object.assign(vi.fn(), {
+      _activityName: 'generatePdfProxyActivity',
+    }),
     cleanupTmpDirActivity: Object.assign(vi.fn(), { _activityName: 'cleanupTmpDirActivity' }),
     createEmbeddingTaskIfEnabledActivity: Object.assign(vi.fn(), {
       _activityName: 'createEmbeddingTaskIfEnabledActivity',
@@ -59,6 +62,10 @@ describe('transcodePdfWorkflow', () => {
     mockActivities.downloadMediaToTmpActivity.mockResolvedValue({
       filePath: '/tmp/doc.pdf',
       tmpDir: '/tmp',
+    })
+    mockActivities.generatePdfProxyActivity.mockResolvedValue({
+      pdfProxyKey: 'document.pdf',
+      pdfFilePath: '/tmp/doc.pdf',
     })
   })
 

--- a/packages/transcode/src/workflows/transcode-pdf.ts
+++ b/packages/transcode/src/workflows/transcode-pdf.ts
@@ -22,6 +22,7 @@ export async function transcodePdfWorkflow(task: WorkflowTask): Promise<void> {
       generateSpriteActivity,
       updateAssetMediaActivity,
       downloadMediaToTmpActivity,
+      generatePdfProxyActivity,
       createEmbeddingTaskIfEnabledActivity,
     } = getActivities()
 
@@ -35,12 +36,22 @@ export async function transcodePdfWorkflow(task: WorkflowTask): Promise<void> {
     const download = await executeActivity(workerQueue, downloadMediaToTmpActivity, {
       assetKey: key,
     })
-    const { filePath } = download
+    let currentFilePath = download.filePath
     tmpDir = download.tmpDir
+
+    const pdfProxy = await executeActivity(workerQueue, generatePdfProxyActivity, {
+      assetId: asset.id,
+      assetKey: key,
+      filePath: currentFilePath,
+      mediaType: asset.mediaType || '',
+      filename: asset.name || '',
+    })
+
+    currentFilePath = pdfProxy.pdfFilePath
 
     const spec = task.payload?.transcode || {}
     const mediaInfo = await executeActivity(workerQueue, getMediaInfoActivity, {
-      filePath,
+      filePath: currentFilePath,
       assetId: asset.id,
       mediaType: asset.mediaType || '',
     })
@@ -50,6 +61,9 @@ export async function transcodePdfWorkflow(task: WorkflowTask): Promise<void> {
       downloadUrl: '',
       filesizeInBytes: 0,
       codec: '',
+    }
+    mediaInfo.pdfTranscode = {
+      key: pdfProxy.pdfProxyKey,
     }
 
     if (spec.sprite || spec.poster) {
@@ -68,7 +82,7 @@ export async function transcodePdfWorkflow(task: WorkflowTask): Promise<void> {
 
       const spriteResult = await executeActivity(workerQueue, generateSpriteActivity, {
         assetKey: key,
-        filePath,
+        filePath: currentFilePath,
         spriteSpec,
         posterSpec,
         mediaInfo,

--- a/packages/webui/components/file-browser/file-preview.tsx
+++ b/packages/webui/components/file-browser/file-preview.tsx
@@ -4,8 +4,10 @@ import { formatTime } from '../viewers/video/utils'
 
 type FilePreviewItem = {
   type?: string | null
+  proxyType?: 'image' | 'video' | 'audio' | 'pdf' | null
   preview?: {
     mediaType?: string | null
+    proxyType?: 'image' | 'video' | 'audio' | 'pdf' | null
     spriteUrl?: string
     thumbnailUrl?: string
     originalWidth?: number
@@ -21,9 +23,10 @@ interface FilePreviewProps {
 }
 
 export const FilePreview = ({ item, showDuration = false }: FilePreviewProps) => {
-  const isVideo = item.preview?.mediaType?.startsWith('video/')
-  const isAudio = item.preview?.mediaType?.startsWith('audio/')
-  const isPdf = item.preview?.mediaType === 'application/pdf'
+  const proxyType = item.preview?.proxyType || item.proxyType
+  const isVideo = proxyType === 'video'
+  const isAudio = proxyType === 'audio'
+  const isPdf = proxyType === 'pdf'
   const hasDuration = isVideo || isAudio
   const duration = item.preview?.duration
   const pageCount = item.preview?.pageCount

--- a/packages/webui/components/viewers/image/index.tsx
+++ b/packages/webui/components/viewers/image/index.tsx
@@ -5,7 +5,7 @@ import { CompareImagePane } from './compare-image-pane'
 export const imageTypeDefinition: FileTypeDefinition = {
   id: 'image',
   name: 'Image',
-  match: (file) => !!file.mediaType?.startsWith('image/'),
+  match: (file) => file.proxyType === 'image',
   viewer: ImageViewer,
   comparePane: CompareImagePane,
   commentsConfig: {

--- a/packages/webui/components/viewers/pdf/index.tsx
+++ b/packages/webui/components/viewers/pdf/index.tsx
@@ -4,7 +4,7 @@ import PdfViewer from './pdf-viewer'
 export const pdfTypeDefinition: FileTypeDefinition = {
   id: 'pdf',
   name: 'PDF',
-  match: (file) => file.mediaType === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf'),
+  match: (file) => file.proxyType === 'pdf',
   viewer: PdfViewer,
   commentsConfig: {
     hasTimestamp: true,

--- a/packages/webui/components/viewers/pdf/pdf-viewer.tsx
+++ b/packages/webui/components/viewers/pdf/pdf-viewer.tsx
@@ -132,7 +132,7 @@ export const PdfViewer = React.forwardRef<MediaController, FileViewerProps>(
       }
     }, [])
 
-    const fileUrl = file.media?.original?.downloadUrl
+    const fileUrl = file.media?.pdfTranscode?.url || file.media?.original?.downloadUrl
 
     // Load PDF Document
     useEffect(() => {

--- a/packages/webui/components/viewers/video/index.tsx
+++ b/packages/webui/components/viewers/video/index.tsx
@@ -5,7 +5,7 @@ import { CompareVideoPane } from './compare-video-pane'
 export const videoTypeDefinition: FileTypeDefinition = {
   id: 'video',
   name: 'Video',
-  match: (file) => !!file.mediaType?.startsWith('video/') || !!file.mediaType?.startsWith('audio/'),
+  match: (file) => file.proxyType === 'video' || file.proxyType === 'audio',
   viewer: VideoViewer,
   comparePane: CompareVideoPane,
   commentsConfig: {


### PR DESCRIPTION
## Summary

Add support for transcoding `.txt` and `.csv` files into PDF proxies using PDFKit. Introduce `ProxyType` enum field on assets to simplify WebUI viewer selection across list and detail views.

## Changes

- **Database & Prisma**: Added `ProxyType` enum (`image`, `video`, `audio`, `pdf`) and `proxyType` column to `Asset` model with SQL migration to populate legacy assets.
- **DTOs & Prisma JSON**: Added `proxyType` and `pdfTranscode` (`{ key: string; url?: string }`) to asset DTOs and `MediaInfo`.
- **Transcode Service (`packages/core`)**: Added `generatePdfFromText` and `generatePdfFromCsv` using `pdfkit` with dynamic TTF font discovery to support CJK text rendering.
- **Transcode Activities & Workflows (`packages/transcode`)**: Added `generatePdfProxyActivity` to transcode `.txt`/`.csv` files into `files/${assetId}/proxy.pdf` and generate sprites, poster thumbnails, and page count.
- **Post-Upload Workflows (`packages/core`)**: Included `.txt` and `.csv` files in the `isPdf` trigger condition to dispatch `PdfTranscoder`.
- **Asset Mapping (`packages/core`)**: Presigned `media.pdfTranscode.key` into `media.pdfTranscode.url` and populated `proxyType` in `AssetInfo` and `PreviewInfo`.
- **Frontend WebUI (`packages/webui`)**: Updated `pdfTypeDefinition`, `videoTypeDefinition`, `imageTypeDefinition`, `PdfViewer`, and `FilePreview` to inspect `file.proxyType` directly.
- **Tests**: Added unit tests for `generatePdfFromText` and `generatePdfFromCsv`, activity tests for `generatePdfProxyActivity`, and workflow E2E tests for CJK text transcoding.

## Verification

- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test`
- `bun run test:e2e`
- `bun run test:e2e:workflow`

All checks passed simultaneously.

## Notes

None.