### PR TITLE
fix(transcode): mark pdfkit as external and extract for docker runtime

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -34,6 +34,7 @@ await Bun.build({
     '@temporalio/client',
     '@temporalio/worker',
     '@temporalio/workflow',
+    'pdfkit',
   ],
   // compile: {
   //   outfile: 'Shumai',

--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -33,6 +33,7 @@ const commonExternal = [
   '@temporalio/client',
   '@temporalio/worker',
   '@temporalio/workflow',
+  'pdfkit',
   'prisma',
   'zod',
 ]

--- a/scripts/extract-runtime-deps.ts
+++ b/scripts/extract-runtime-deps.ts
@@ -13,6 +13,7 @@ const depsToExtract = [
   '@temporalio/client',
   '@temporalio/worker',
   '@temporalio/workflow',
+  'pdfkit',
   'prisma',
   'sharp',
 ]


### PR DESCRIPTION
## Summary

Fixes `ApplicationFailure: Failed to generate PDF proxy for text/csv: ENOENT: no such file or directory, open '/app/node_modules/.bun/pdfkit@0.19.1/node_modules/pdfkit/js/data/Helvetica.afm'` when transcoding text/CSV files to PDF in Docker compose.

## Changes

- Marked `pdfkit` as external in `build.ts` and `scripts/build-npm.ts`.
- Added `pdfkit` to `depsToExtract` in `scripts/extract-runtime-deps.ts` so `runner-package.json` installs `pdfkit` and its `.afm` font data files into `/app/node_modules` during the Docker runner stage.

## Verification

- `bun run lint` (passed, 0 warnings/errors)
- `bun run format` (passed)
- `bun run typecheck` (passed, 0 errors)
- `bun run test` (passed, 313 unit tests passed)
- `bun run build.ts` (passed)

## Notes

None.