### PR TITLE
feat(docker): install fonts-noto-cjk in runner stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bubblewrap \
     gosu \
     poppler-utils \
+    fonts-noto-cjk \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Adds `fonts-noto-cjk` package to the system dependencies installed in the `runner` stage of the Dockerfile to support Chinese, Japanese, and Korean font rendering in containerized runtime environments.

## Changes

- Added `fonts-noto-cjk` to the `apt-get install` package list in the `runner` stage of [Dockerfile](file:///Users/yiling/Projects/shumai/Dockerfile).

## Verification

Verified that all submission requirements pass:
- `bun run lint` (Passed)
- `bun run format` (Passed)
- `bun run typecheck` (Passed)
- `bun run test` (Passed: 87 test files / 670 tests)
- `bun run test:e2e` (Passed: 30 tests)
- `bun run test:e2e:workflow` (Passed: 6 test files / 32 tests)

## Notes

None.