### PR TITLE
feat(transcode): add markdown file to pdf proxy support

### DIFF
--- a/apps/cli/src/commands/upload.ts
+++ b/apps/cli/src/commands/upload.ts
@@ -33,6 +33,8 @@ export function getMediaType(filename: string): string {
     '.wav': 'audio/wav',
     '.ogg': 'audio/ogg',
     '.txt': 'text/plain',
+    '.md': 'text/markdown',
+    '.markdown': 'text/markdown',
     '.json': 'application/json',
     '.pdf': 'application/pdf',
     '.zip': 'application/zip',

--- a/packages/agent/src/tools/create-file.ts
+++ b/packages/agent/src/tools/create-file.ts
@@ -34,6 +34,9 @@ function getMimeType(filePath: string): string {
     '.mp4': 'video/mp4',
     '.mov': 'video/quicktime',
     '.pdf': 'application/pdf',
+    '.txt': 'text/plain',
+    '.md': 'text/markdown',
+    '.markdown': 'text/markdown',
   }
   return mimeTypes[ext] || 'application/octet-stream'
 }

--- a/packages/agent/src/tools/create-version.ts
+++ b/packages/agent/src/tools/create-version.ts
@@ -34,6 +34,9 @@ function getMimeType(filePath: string): string {
     '.mp4': 'video/mp4',
     '.mov': 'video/quicktime',
     '.pdf': 'application/pdf',
+    '.txt': 'text/plain',
+    '.md': 'text/markdown',
+    '.markdown': 'text/markdown',
   }
   return mimeTypes[ext] || 'application/octet-stream'
 }

--- a/packages/core/src/utils/mime.test.ts
+++ b/packages/core/src/utils/mime.test.ts
@@ -54,11 +54,15 @@ describe('getProxyType', () => {
     expect(getProxyType('audio/mpeg', 'song.mp3')).toBe('audio')
   })
 
-  it('should detect pdf proxyType only for pdf, csv, and txt files', () => {
+  it('should detect pdf proxyType only for pdf, csv, txt, and markdown files', () => {
     expect(getProxyType('application/pdf', 'doc.pdf')).toBe('pdf')
     expect(getProxyType('text/plain', 'notes.txt')).toBe('pdf')
     expect(getProxyType('text/csv', 'data.csv')).toBe('pdf')
+    expect(getProxyType('text/markdown', 'README.md')).toBe('pdf')
+    expect(getProxyType('text/x-markdown', 'doc.markdown')).toBe('pdf')
     expect(getProxyType(null, 'file.txt')).toBe('pdf')
+    expect(getProxyType(null, 'README.md')).toBe('pdf')
+    expect(getProxyType(null, 'doc.markdown')).toBe('pdf')
   })
 
   it('should return null for unsupported files including office files', () => {

--- a/packages/core/src/utils/mime.ts
+++ b/packages/core/src/utils/mime.ts
@@ -15,9 +15,13 @@ export function getProxyType(
     lowerMediaType === 'application/pdf' ||
     lowerMediaType === 'text/plain' ||
     lowerMediaType === 'text/csv' ||
+    lowerMediaType === 'text/markdown' ||
+    lowerMediaType === 'text/x-markdown' ||
     lowerFilename.endsWith('.pdf') ||
     lowerFilename.endsWith('.txt') ||
-    lowerFilename.endsWith('.csv')
+    lowerFilename.endsWith('.csv') ||
+    lowerFilename.endsWith('.md') ||
+    lowerFilename.endsWith('.markdown')
   ) {
     return 'pdf'
   }

--- a/packages/e2e/workflow/transcode.test.ts
+++ b/packages/e2e/workflow/transcode.test.ts
@@ -700,5 +700,91 @@ describe.each(['local', 'temporal'] as const)(
       expect(mediaInfo.sprite?.key).toContain('sprite.webp')
       expect(mediaInfo.frames).toBeGreaterThan(0)
     }, 50000)
+
+    it('should process markdown (.md) transcode PDF task correctly', async () => {
+      // 1. Create Team, Project, Asset & StorageKey
+      const team = await prisma.team.create({
+        data: { name: 'E2E MD Transcode Team' },
+      })
+
+      const project = await prisma.project.create({
+        data: { name: 'E2E MD Transcode Project', teamId: team.id },
+      })
+
+      const storageKey = await prisma.storageKey.create({
+        data: {
+          key: 'projects/e2e/doc.md',
+          status: 'active',
+        },
+      })
+
+      const asset = await prisma.asset.create({
+        data: {
+          name: 'doc.md',
+          type: 'file',
+          status: 'uploaded',
+          mediaType: 'text/markdown',
+          projectId: project.id,
+          storageKeyId: storageKey.id,
+        },
+      })
+
+      // 2. Seed S3 Storage with Markdown text
+      const mdText = '# Heading\n\nThis is a **markdown** document to be rendered to PDF proxy.'
+      const mdBuffer = Buffer.from(mdText, 'utf-8')
+      await s3Service.putObject(
+        'shumai-e2e-test-bucket-transcode',
+        'projects/e2e/doc.md',
+        mdBuffer,
+        mdBuffer.length,
+        'text/markdown',
+      )
+
+      // 3. Create Workflow Task
+      const task = await prisma.workflowTask.create({
+        data: {
+          type: 'transcode_pdf',
+          status: 'pending',
+          assetId: asset.id,
+          projectId: project.id,
+          teamId: team.id,
+          payload: {
+            projectId: project.id,
+            transcode: {
+              poster: true,
+              sprite: true,
+            },
+          },
+        },
+      })
+
+      // 4. Wait for workflow to complete
+      console.log(
+        `Submitted E2E MD Transcode Workflow Task. ID: ${task.id}. Awaiting completion...`,
+      )
+      const completedTask = await workflowService.executeWait(task, 45000)
+
+      // 5. Verification
+      expect(completedTask.status).toBe('completed')
+
+      const updatedAsset = await prisma.asset.findUnique({
+        where: { id: asset.id },
+      })
+      expect(updatedAsset?.status).toBe(AssetStatus.processed)
+
+      const mediaInfo = updatedAsset?.media as unknown as {
+        proxyType?: string
+        pdfTranscode?: { key: string }
+        poster?: { key: string }
+        sprite?: { key: string }
+        frames?: number
+      }
+      expect(mediaInfo).toBeDefined()
+      expect(mediaInfo.proxyType).toBe('pdf')
+      expect(mediaInfo.pdfTranscode?.key).toBe(`files/${asset.id}/proxy.pdf`)
+      expect(mediaInfo.poster?.key).toContain('poster.webp')
+      expect(mediaInfo.sprite?.key).toContain('sprite.webp')
+      expect(mediaInfo.frames).toBeGreaterThan(0)
+    }, 50000)
   },
 )

--- a/packages/transcode/src/activities/transcode.test.ts
+++ b/packages/transcode/src/activities/transcode.test.ts
@@ -263,6 +263,34 @@ describe('Transcode Activities', () => {
     generatePdfFromTextSpy.mockRestore()
   })
 
+  it('should generate PDF proxy for markdown files in generatePdfProxyActivity', async () => {
+    const asset = await prisma.asset.create({
+      data: { name: 'README.md', type: 'file', status: 'uploaded' },
+    })
+
+    const generatePdfFromTextSpy = vi
+      .spyOn(transcodeService, 'generatePdfFromText')
+      .mockImplementation(async (_inPath, outPath) => {
+        const fs = await import('fs')
+        fs.writeFileSync(outPath, 'fake pdf content from md')
+      })
+
+    const res = await generatePdfProxyActivity({
+      assetId: asset.id,
+      assetKey: 'files/asset1/README.md',
+      filePath: '/tmp/README.md',
+      mediaType: 'text/markdown',
+      filename: 'README.md',
+    })
+
+    expect(res.pdfProxyKey).toBe(`files/${asset.id}/proxy.pdf`)
+    expect(generatePdfFromTextSpy).toHaveBeenCalledWith(
+      '/tmp/README.md',
+      expect.stringContaining('proxy.pdf'),
+    )
+    generatePdfFromTextSpy.mockRestore()
+  })
+
   it('should set file_type to file for unknown types', async () => {
     const asset = await prisma.asset.create({
       data: { name: 'u.xyz', type: 'file', status: 'uploaded' },

--- a/packages/transcode/src/activities/transcode.ts
+++ b/packages/transcode/src/activities/transcode.ts
@@ -503,7 +503,13 @@ export interface GeneratePdfProxyActivityParams {
 export async function generatePdfProxyActivity(
   params: GeneratePdfProxyActivityParams,
 ): Promise<{ pdfProxyKey: string; pdfFilePath: string }> {
-  const isTxt = params.mediaType === 'text/plain' || params.filename.toLowerCase().endsWith('.txt')
+  const isTxt =
+    params.mediaType === 'text/plain' ||
+    params.mediaType === 'text/markdown' ||
+    params.mediaType === 'text/x-markdown' ||
+    params.filename.toLowerCase().endsWith('.txt') ||
+    params.filename.toLowerCase().endsWith('.md') ||
+    params.filename.toLowerCase().endsWith('.markdown')
   const isCsv = params.mediaType === 'text/csv' || params.filename.toLowerCase().endsWith('.csv')
 
   if (!isTxt && !isCsv) {
@@ -529,7 +535,7 @@ export async function generatePdfProxyActivity(
   } catch (err) {
     const { message } = getErrorDetails(err)
     throw ApplicationFailure.create({
-      message: `Failed to generate PDF proxy for text/csv: ${message}`,
+      message: `Failed to generate PDF proxy for text/csv/markdown: ${message}`,
       nonRetryable: true,
       cause: err instanceof Error ? err : undefined,
     })

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -524,7 +524,9 @@ export function FileBrowser({
                         ? 'audio'
                         : f.file.name.endsWith('.pdf') ||
                             f.file.name.endsWith('.txt') ||
-                            f.file.name.endsWith('.csv')
+                            f.file.name.endsWith('.csv') ||
+                            f.file.name.endsWith('.md') ||
+                            f.file.name.endsWith('.markdown')
                           ? 'pdf'
                           : null,
               createdAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary

Adds support for generating PDF proxies for Markdown (`.md`, `.markdown`) files by rendering raw text to PDF, matching the behavior of `.txt` files.

## Changes

- Updated `getProxyType` in `packages/core/src/utils/mime.ts` to return `'pdf'` proxy type for `text/markdown`, `text/x-markdown`, `.md`, and `.markdown` files.
- Updated `generatePdfProxyActivity` in `packages/transcode/src/activities/transcode.ts` to generate PDF proxies for markdown files using `generatePdfFromText`.
- Added optimistic PDF proxyType detection for markdown files in `packages/webui/components/file-browser/file-browser.tsx`.
- Updated MIME mapping in CLI `upload.ts` and agent tools `create-file.ts` / `create-version.ts` to register `text/markdown`.
- Added unit tests in `mime.test.ts` and `transcode.test.ts`, and workflow E2E test in `e2e/workflow/transcode.test.ts`.

## Verification

Ran all mandatory checks simultaneously on the final code state:
- `bun run lint` (passed)
- `bun run format` (passed)
- `bun run typecheck` (passed)
- `bun run test` (passed 671 tests across 87 files)
- `bun run test:e2e` (passed 30 tests)
- `bun run test:e2e:workflow` (passed 34 tests)

## Notes

None.