### PR TITLE
feat(chat): track context asset changes and update agent context

### DIFF
--- a/packages/agent/src/workflows/agent-chat-prompt-builder.test.ts
+++ b/packages/agent/src/workflows/agent-chat-prompt-builder.test.ts
@@ -150,4 +150,18 @@ describe('AgentChatPromptBuilder', () => {
     expect(result).toContain('Attached Files:\n- file1.txt')
     expect(result).toContain('Referenced Workspace Assets:\n- folder1')
   })
+
+  it('should include location change context block in continuation mode when asset has changed', () => {
+    const builder = new AgentChatPromptBuilder('a2')
+      .withContinuation(true)
+      .withAssetChanged(true)
+      .withAssetDetails('new-folder', 'folder', undefined, undefined, 'folder')
+      .withPathContext('projects/my-proj/new-folder')
+    const result = builder.build()
+
+    expect(result).toContain('[Context: User Navigated to a New Location]')
+    expect(result).toContain('New Location Asset ID: a2')
+    expect(result).toContain('File Name: new-folder')
+    expect(result).toContain('Asset Path Context:\nprojects/my-proj/new-folder')
+  })
 })

--- a/packages/agent/src/workflows/agent-chat-prompt-builder.ts
+++ b/packages/agent/src/workflows/agent-chat-prompt-builder.ts
@@ -19,6 +19,7 @@ export class AgentChatPromptBuilder {
   private referencedAssets: string[] = []
 
   private isContinuation = false
+  private hasAssetChanged = false
 
   constructor(assetId: string) {
     this.assetId = assetId
@@ -26,6 +27,11 @@ export class AgentChatPromptBuilder {
 
   withContinuation(isContinuation: boolean): this {
     this.isContinuation = isContinuation
+    return this
+  }
+
+  withAssetChanged(hasAssetChanged?: boolean): this {
+    this.hasAssetChanged = !!hasAssetChanged
     return this
   }
 
@@ -80,8 +86,27 @@ export class AgentChatPromptBuilder {
 
     if (this.isContinuation) {
       let instruction = ''
+      if (this.hasAssetChanged) {
+        instruction += `[Context: User Navigated to a New Location]\nNew Location Asset ID: ${this.assetId}`
+        if (this.assetName) {
+          instruction += `\nFile Name: ${this.assetName}`
+        }
+        if (effectiveType) {
+          const type = getSimpleMediaType(effectiveType)
+          instruction += `\nFile Type: ${type}`
+          if (type === 'video' && this.videoDuration !== undefined) {
+            instruction += `\nVideo Length: ${this.videoDuration.toFixed(2)} seconds`
+          } else if (type === 'pdf' && this.totalPages !== undefined) {
+            instruction += `\nTotal Pages: ${this.totalPages}`
+          }
+        }
+        if (this.pathContext) {
+          instruction += `\n\nAsset Path Context:\n${this.pathContext}`
+        }
+      }
       if (this.commentTimestamp !== undefined) {
         const type = getSimpleMediaType(effectiveType)
+        if (instruction) instruction += '\n\n'
         if (type === 'pdf') {
           instruction += `Comment Page: ${Math.round(this.commentTimestamp)}`
         } else {
@@ -89,7 +114,8 @@ export class AgentChatPromptBuilder {
         }
       }
       if (this.attachedFiles.length > 0 || this.referencedAssets.length > 0) {
-        instruction += `\n\n[Context: New Attached Files & Referenced Assets]`
+        if (instruction) instruction += '\n\n'
+        instruction += `[Context: New Attached Files & Referenced Assets]`
         if (this.attachedFiles.length > 0) {
           instruction += `\nAttached Files:\n${this.attachedFiles.join('\n')}`
         }

--- a/packages/agent/src/workflows/agent-chat.ts
+++ b/packages/agent/src/workflows/agent-chat.ts
@@ -165,6 +165,7 @@ export async function agentChat(task: WorkflowTask): Promise<void> {
     const proxyType = (asset.media as PrismaJson.MediaInfo | null)?.proxyType
     const instruction = new AgentChatPromptBuilder(asset.id)
       .withContinuation(!isNewChat)
+      .withAssetChanged(payload.agent?.hasAssetChanged)
       .withPathContext(pathContext)
       .withAssetDetails(asset.name, asset.mediaType, duration, totalPages, proxyType)
       .withCommentTimestamp(commentTimestamp)

--- a/packages/core/src/chat/chat.test.ts
+++ b/packages/core/src/chat/chat.test.ts
@@ -155,6 +155,51 @@ describe('ChatService', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const taskPayload = task?.payload as any
     expect(taskPayload?.agent?.prompt).toBe('second message')
+    expect(taskPayload?.agent?.hasAssetChanged).toBe(false)
+  })
+
+  it('should update session assetId and set hasAssetChanged when continuing chat with a new contextAssetId', async () => {
+    const { user, team, project, rootFolder } = await setupBasicData()
+
+    const newFolder = await prisma.asset.create({
+      data: {
+        name: 'new_folder',
+        type: 'folder',
+        status: 'processed',
+        projectId: project.id,
+        parentId: rootFolder.id,
+      },
+    })
+
+    // Start session on rootFolder
+    const { sessionId } = await chatService.startOrContinueChat(user, team.id, {
+      agentId: 'test-agent-id',
+      textPrompt: 'message in root folder',
+      projectId: project.id,
+      contextAssetId: rootFolder.id,
+    })
+
+    const sessionBefore = await prisma.agentSession.findUnique({ where: { id: sessionId } })
+    expect(sessionBefore?.assetId).toBe(rootFolder.id)
+
+    // Continue session on newFolder
+    const { taskId: nextTaskId } = await chatService.startOrContinueChat(user, team.id, {
+      agentId: 'test-agent-id',
+      textPrompt: 'message after switching to new folder',
+      sessionId,
+      contextAssetId: newFolder.id,
+    })
+
+    // Verify session assetId updated
+    const sessionAfter = await prisma.agentSession.findUnique({ where: { id: sessionId } })
+    expect(sessionAfter?.assetId).toBe(newFolder.id)
+
+    // Verify task payload has assetId set to newFolder.id and hasAssetChanged is true
+    const task = await prisma.workflowTask.findUnique({ where: { id: nextTaskId } })
+    expect(task?.assetId).toBe(newFolder.id)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const taskPayload = task?.payload as any
+    expect(taskPayload?.agent?.hasAssetChanged).toBe(true)
   })
 
   it('should inject context of referenced assets and attached files', async () => {

--- a/packages/core/src/chat/chat.ts
+++ b/packages/core/src/chat/chat.ts
@@ -185,6 +185,7 @@ export class ChatService {
 
     // 2. Project / Asset scoping resolution
     let targetAssetId = ''
+    let hasAssetChanged = false
 
     if (passedSessionId) {
       const session = await this.prismaClient.agentSession.findUnique({
@@ -194,7 +195,18 @@ export class ChatService {
       if (!session) throw new Error('Session not found')
       if (session.userId !== user.id) throw new Error('Unauthorized session access')
       if (!session.assetId) throw new Error('Session has no associated asset')
-      targetAssetId = session.assetId
+
+      if (contextAssetId && contextAssetId !== session.assetId) {
+        const contextAsset = await this.prismaClient.asset.findUnique({
+          where: { id: contextAssetId },
+          include: { project: true },
+        })
+        if (!contextAsset) throw new Error('Context asset not found')
+        targetAssetId = contextAssetId
+        hasAssetChanged = true
+      } else {
+        targetAssetId = session.assetId
+      }
     } else {
       // Start a new session
       if (contextAssetId) {
@@ -269,10 +281,13 @@ export class ChatService {
         if (!sessionExists) throw new Error('Session not found')
         if (sessionExists.userId !== user.id) throw new Error('Unauthorized session access')
 
-        // Update the session's agentId to match the selected agent
+        // Update the session's agentId and assetId (if location changed)
         await tx.agentSession.update({
           where: { id: activeSessionId },
-          data: { agentId },
+          data: {
+            agentId,
+            ...(hasAssetChanged ? { assetId: targetAssetId } : {}),
+          },
         })
       } else {
         const newSession = await tx.agentSession.create({
@@ -307,6 +322,7 @@ export class ChatService {
               sessionId: activeSessionId,
               userId: user.id,
               isNewChat: !passedSessionId,
+              hasAssetChanged,
             },
           },
         },

--- a/packages/db/src/prisma-json-types.ts
+++ b/packages/db/src/prisma-json-types.ts
@@ -308,6 +308,7 @@ declare global {
       attachedFiles?: string[]
       assetIds?: string[]
       isNewChat?: boolean
+      hasAssetChanged?: boolean
     }
 
     // ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Updates chat session handling so that when a user navigates to a new file or folder (`contextAssetId`) during an ongoing chat session, the location change is tracked, the session's `assetId` is updated in the database, and a location change context block is appended to the agent's instructions as a custom session context entry.

## Changes

- Updated `AgentTaskPayload` in `packages/db/src/prisma-json-types.ts` to support the `hasAssetChanged` boolean flag.
- Modified `startOrContinueChat` in `packages/core/src/chat/chat.ts` to compare `contextAssetId` against `session.assetId` when continuing an existing chat. If different, it updates `session.assetId`, assigns the new asset to `WorkflowTask.assetId`, and sets `hasAssetChanged: true`.
- Updated `AgentChatPromptBuilder` in `packages/agent/src/workflows/agent-chat-prompt-builder.ts` to support `withAssetChanged` and generate a `[Context: User Navigated to a New Location]` block in continuation mode when location changes.
- Chained `withAssetChanged` in `packages/agent/src/workflows/agent-chat.ts`.
- Added unit tests in `agent-chat-prompt-builder.test.ts` and `chat.test.ts`.

## Verification

Ran all required quality and test suites:
- `bun run lint` (PASSED)
- `bun run format` (PASSED)
- `bun run typecheck` (PASSED)
- `bun run test` (PASSED, 87/87 test files, 673/673 tests passed)
- `bun run test:e2e` (PASSED, 30/30 tests passed)
- `bun run test:e2e:workflow` (PASSED, 6/6 test files, 34/34 tests passed)

## Notes

No breaking changes or schema alterations required.