### PR TITLE
fix(agent): include skill id in formatSkillsForPrompt

### DIFF
--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -43,6 +43,7 @@ describe('formatSkillsForPrompt', () => {
     // Verify lines and XML elements
     expect(result).toContain('<available_skills>')
     expect(result).toContain('<skill>')
+    expect(result).toContain('<id>skill-1</id>')
     expect(result).toContain('<name>Deploy &amp; Test</name>')
     expect(result).toContain(
       '<description>Deploys code &lt;deploy&gt; and &quot;runs&quot; tests.</description>',

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -373,6 +373,7 @@ export function formatSkillsForPrompt(
   for (const skill of skills) {
     const filePath = path.join(process.cwd(), '.pi', 'skills', skill.id, 'SKILL.md')
     lines.push('  <skill>')
+    lines.push(`    <id>${escapeXml(skill.id)}</id>`)
     lines.push(`    <name>${escapeXml(skill.name)}</name>`)
     lines.push(`    <description>${escapeXml(skill.description || 'No description')}</description>`)
     lines.push(`    <location>${escapeXml(filePath)}</location>`)


### PR DESCRIPTION
## Summary

Fixes a P0 issue where `formatSkillsForPrompt` omitted the `<id>` element for formatted skills. Without the skill ID present in the prompt, the agent could not invoke the `read_skill` tool which requires a `skillId` parameter.

## Changes

- Updated `formatSkillsForPrompt` in `packages/agent/src/index.ts` to include `<id>${escapeXml(skill.id)}</id>` in the formatted XML structure.
- Updated unit tests in `packages/agent/src/index.test.ts` to assert presence of the `<id>` tag in prompt formatting output.

## Verification

- `bun run lint` passed cleanly.
- `bun run format` passed cleanly.
- `bun run typecheck` passed cleanly.
- `bun run test` passed all 29 test files / 222 tests.
- `bun run test:e2e` passed all 30 tests.
- `bun run test:e2e:workflow` passed all 6 test files / 34 tests.

## Notes

None.