### PR TITLE
fix(asset): exclude soft-deleted children from latestChildren preview

### DIFF
--- a/packages/core/src/asset/asset.ts
+++ b/packages/core/src/asset/asset.ts
@@ -102,6 +102,7 @@ export class AssetService {
             metadataValues: true,
             storageKey: true,
             children: {
+              where: { isDeleted: false },
               include: { creator: true, metadataValues: true, storageKey: true },
               take: 3,
               orderBy: { sortIndex: 'asc' },
@@ -109,6 +110,7 @@ export class AssetService {
           },
         },
         children: {
+          where: { isDeleted: false },
           include: { creator: true, metadataValues: true, storageKey: true },
           take: 3,
           orderBy: { sortIndex: 'asc' },
@@ -661,6 +663,7 @@ export class AssetService {
                 metadataValues: true,
                 storageKey: true,
                 children: {
+                  where: { isDeleted: false },
                   include: { creator: true, metadataValues: true, storageKey: true },
                   take: 3,
                   orderBy: { sortIndex: 'asc' },
@@ -668,6 +671,7 @@ export class AssetService {
               },
             },
             children: {
+              where: { isDeleted: false },
               include: { creator: true, metadataValues: true, storageKey: true },
               take: 3,
               orderBy: { sortIndex: 'asc' },
@@ -745,6 +749,7 @@ export class AssetService {
               metadataValues: true,
               storageKey: true,
               children: {
+                where: { isDeleted: false },
                 include: { creator: true, metadataValues: true, storageKey: true },
                 take: 3,
                 orderBy: { sortIndex: 'asc' },
@@ -752,6 +757,7 @@ export class AssetService {
             },
           },
           children: {
+            where: { isDeleted: false },
             include: { creator: true, metadataValues: true, storageKey: true },
             take: 3,
             orderBy: { sortIndex: 'asc' },
@@ -794,6 +800,7 @@ export class AssetService {
             metadataValues: true,
             storageKey: true,
             children: {
+              where: { isDeleted: false },
               include: { creator: true, metadataValues: true, storageKey: true },
               take: 3,
               orderBy: { sortIndex: 'asc' },
@@ -801,6 +808,7 @@ export class AssetService {
           },
         },
         children: {
+          where: { isDeleted: false },
           include: { creator: true, metadataValues: true, storageKey: true },
           take: 3,
           orderBy: { sortIndex: 'asc' },
@@ -936,6 +944,7 @@ export class AssetService {
             metadataValues: true,
             storageKey: true,
             children: {
+              where: { isDeleted: false },
               include: { creator: true, metadataValues: true, storageKey: true },
               take: 3,
               orderBy: { sortIndex: 'asc' },
@@ -943,6 +952,7 @@ export class AssetService {
           },
         },
         children: {
+          where: { isDeleted: false },
           include: { creator: true, metadataValues: true, storageKey: true },
           take: 3,
           orderBy: { sortIndex: 'asc' },
@@ -1641,6 +1651,7 @@ export class AssetService {
         folderForPreview.children
       ) {
         for (const child of folderForPreview.children) {
+          if (child.isDeleted) continue
           let previewAsset = child as Asset
           let mediaType = child.mediaType
 

--- a/packages/core/src/search/search.test.ts
+++ b/packages/core/src/search/search.test.ts
@@ -7,6 +7,7 @@ import { metadataService } from '@shumai/core/src/metadata/metadata'
 import { workflowService } from '@shumai/workflow-core'
 
 import { AssetType } from '@shumai/db'
+import { assetService } from '@shumai/core/src/asset/asset'
 
 describe('SearchService', () => {
   setupTestDbHooks()
@@ -557,6 +558,57 @@ describe('SearchService', () => {
       isSemantic: false,
     })
     expect(resultWithSymlink.data.find((a) => a.id === symlink.id)).toBeDefined()
+  })
+
+  it('excludes soft-deleted (trashed) files from latestChildren when searching folders', async () => {
+    const { rootFolder } = await setupBasicAssets()
+
+    const subfolder = await prisma.asset.create({
+      data: {
+        name: 'subfolder',
+        type: AssetType.folder,
+        projectId: rootFolder.projectId,
+        parentId: rootFolder.id,
+        status: 'uploaded',
+      },
+    })
+
+    const childFile1 = await prisma.asset.create({
+      data: {
+        name: 'child1.txt',
+        type: AssetType.file,
+        projectId: rootFolder.projectId,
+        parentId: subfolder.id,
+        status: 'uploaded',
+        sortIndex: 'a0',
+      },
+    })
+
+    await prisma.asset.create({
+      data: {
+        name: 'child2.txt',
+        type: AssetType.file,
+        projectId: rootFolder.projectId,
+        parentId: subfolder.id,
+        status: 'uploaded',
+        sortIndex: 'a1',
+      },
+    })
+
+    await assetService.deleteAssets([childFile1.id])
+
+    const result = await searchService.search(rootFolder.id, {
+      recursively: false,
+      assetType: 'folder',
+      operator: 'AND',
+      conditions: [],
+      isSemantic: false,
+    })
+
+    const searchedSubfolder = result.data.find((a) => a.id === subfolder.id)
+    expect(searchedSubfolder).toBeDefined()
+
+    expect(searchedSubfolder?.latestChildren?.length).toBe(1)
   })
 
   describe('Semantic Search with multiple chunks and distance ordering', () => {


### PR DESCRIPTION
## Summary

Fixes a bug where soft-deleted (trashed) files were included in the `latestChildren` preview array when searching folders via `POST /folders/:folderId/search` or fetching folder asset details.

## Changes

- Updated Prisma relation queries in `AssetService` (`listAssetsByIds`, `getAsset`, `listFolderAssets`, `createAsset`, `updateAsset`) to include `where: { isDeleted: false }` for `children` and `target.children`.
- Added defensive check `if (child.isDeleted) continue` in `toAssetInfos` when mapping `folderForPreview.children` to `latestChildren`.
- Added unit test in `packages/core/src/search/search.test.ts` verifying soft-deleted files are excluded from `latestChildren`.

## Verification

- `bun run lint` passed
- `bun run format` passed
- `bun run typecheck` passed
- `bun run test` passed
- `bun run test:e2e` passed
- `bun run test:e2e:workflow` passed