### PR TITLE
fix(agent): pass latest version asset from version stack to prompt builder

### DIFF
--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -596,6 +596,45 @@ describe('Agent Database Activities Integration', () => {
       const fetchedComment = await getCommentActivity(comment.id)
       expect(fetchedComment?.id).toBe(comment.id)
     })
+
+    it('should resolve version stack asset to its latest version file', async () => {
+      const stack = await prisma.asset.create({
+        data: {
+          name: 'Stack',
+          type: AssetType.version_stack,
+          status: AssetStatus.uploaded,
+          projectId: project.id,
+        },
+      })
+
+      await prisma.asset.create({
+        data: {
+          name: 'v1.png',
+          type: AssetType.file,
+          mediaType: 'image/png',
+          status: AssetStatus.uploaded,
+          projectId: project.id,
+          parentId: stack.id,
+          sortIndex: 'a1',
+        },
+      })
+
+      const v2 = await prisma.asset.create({
+        data: {
+          name: 'v2.png',
+          type: AssetType.file,
+          mediaType: 'image/png',
+          status: AssetStatus.uploaded,
+          projectId: project.id,
+          parentId: stack.id,
+          sortIndex: 'a0',
+        },
+      })
+
+      const fetchedAsset = await getAssetActivity(stack.id)
+      expect(fetchedAsset?.id).toBe(v2.id)
+      expect(fetchedAsset?.name).toBe('v2.png')
+    })
   })
 
   describe('getAssetPathContextActivity', () => {

--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -763,7 +763,7 @@ export async function getAgentAutofillContextActivity(params: {
 }
 
 export async function getAssetActivity(assetId: string) {
-  return prisma.asset.findUnique({
+  const asset = await prisma.asset.findUnique({
     where: { id: assetId },
     include: {
       storageKey: true,
@@ -774,6 +774,30 @@ export async function getAssetActivity(assetId: string) {
       },
     },
   })
+
+  if (asset && asset.type === AssetType.version_stack) {
+    const latestVersion = await prisma.asset.findFirst({
+      where: { parentId: asset.id, isDeleted: false },
+      orderBy: { sortIndex: 'asc' },
+      include: {
+        storageKey: true,
+        project: {
+          include: {
+            team: true,
+          },
+        },
+      },
+    })
+
+    if (latestVersion) {
+      return {
+        ...latestVersion,
+        project: latestVersion.project ?? asset.project,
+      }
+    }
+  }
+
+  return asset
 }
 
 export async function getCommentActivity(commentId: string) {

--- a/packages/agent/src/workflows/agent-chat.test.ts
+++ b/packages/agent/src/workflows/agent-chat.test.ts
@@ -516,4 +516,55 @@ describe('Agent Chat Workflow', () => {
       }),
     )
   })
+
+  it('should handle version stack asset by building instructions with resolved latest version asset details', async () => {
+    mockActivities.getAssetActivity.mockImplementation(async (id: string) => {
+      if (id === 'vs-1') {
+        return {
+          id: 'v2-latest',
+          project: { teamId: 't1' },
+          type: 'file',
+          name: 'latest-video.mp4',
+          mediaType: 'video/mp4',
+          media: { proxyType: 'video', duration: 42 },
+          parentId: 'vs-1',
+        }
+      }
+      return null
+    })
+
+    const task = await prisma.workflowTask.create({
+      data: {
+        type: 'chat',
+        status: 'pending',
+        assetId: 'vs-1',
+        payload: {
+          projectId: 'p1',
+          agent: {
+            prompt: 'Explain this version stack video',
+            sessionId: 'session-vs-123',
+            agentId: 'b1',
+          },
+        },
+      },
+    })
+
+    await agentChat(task)
+
+    const expectedInstruction = new AgentChatPromptBuilder('v2-latest')
+      .withContinuation(true)
+      .withPathContext('Path: folder/subfolder/file.png')
+      .withAssetDetails('latest-video.mp4', 'video/mp4', 42, undefined, 'video')
+      .build()
+
+    expect(mockActivities.agentChatActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 't1',
+        agentId: 'b1',
+        message: 'Explain this version stack video',
+        agentsInstruction: expectedInstruction,
+        sessionId: 'session-vs-123',
+      }),
+    )
+  })
 })

--- a/packages/e2e/workflow/agent-chat.test.ts
+++ b/packages/e2e/workflow/agent-chat.test.ts
@@ -325,4 +325,133 @@ describe.each(['local', 'temporal'] as const)('Workflow E2E - agentChat (executo
       'direct-session-456',
     )
   }, 50000)
+
+  it('should run agentChat workflow with version stack asset successfully', async () => {
+    const team = await prisma.team.create({
+      data: { name: 'E2E Version Stack Team' },
+    })
+
+    const project = await prisma.project.create({
+      data: { name: 'E2E Version Stack Project', teamId: team.id },
+    })
+
+    const agentUser = await prisma.user.create({
+      data: {
+        name: 'E2E VS Agent User',
+        email: 'e2e-vs-agent@shumai.ai',
+        type: 'agent',
+      },
+    })
+
+    await prisma.teamMember.create({
+      data: {
+        teamId: team.id,
+        userId: agentUser.id,
+        role: 'editor',
+      },
+    })
+
+    const provider = await prisma.provider.create({
+      data: {
+        name: 'google',
+        teamId: team.id,
+        config: { api: 'google-generative-ai', apiKey: 'dummy-google-api-key' },
+      },
+    })
+
+    const model = await prisma.model.create({
+      data: {
+        modelId: 'gemini',
+        name: 'Gemini',
+        providerId: provider.id,
+        config: {
+          input: ['text', 'image'],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 8192,
+          maxTokens: 2048,
+          reasoning: false,
+        },
+      },
+    })
+
+    await prisma.agent.create({
+      data: {
+        id: agentUser.id,
+        teamId: team.id,
+        type: 'chat',
+        enabled: true,
+        providerId: provider.id,
+        modelId: model.id,
+        config: {
+          provider: 'google',
+          model: 'gemini',
+        },
+      },
+    })
+
+    const versionStack = await prisma.asset.create({
+      data: {
+        name: 'VersionStack Container',
+        type: 'version_stack',
+        status: 'uploaded',
+        projectId: project.id,
+      },
+    })
+
+    await prisma.asset.create({
+      data: {
+        name: 'version-1.png',
+        type: 'file',
+        status: 'uploaded',
+        mediaType: 'image/png',
+        projectId: project.id,
+        parentId: versionStack.id,
+        sortIndex: 'a0',
+      },
+    })
+
+    const regularUser = await prisma.user.create({
+      data: {
+        name: 'Regular User 3',
+        email: 'user3@example.com',
+        type: 'human',
+      },
+    })
+
+    await prisma.agentSession.create({
+      data: {
+        id: 'vs-session-789',
+        agentId: agentUser.id,
+        userId: regularUser.id,
+        cwd: process.cwd(),
+        assetId: versionStack.id,
+      },
+    })
+
+    const task = await prisma.workflowTask.create({
+      data: {
+        type: 'chat',
+        status: 'pending',
+        assetId: versionStack.id,
+        projectId: project.id,
+        teamId: team.id,
+        payload: {
+          projectId: project.id,
+          agent: {
+            agentId: agentUser.id,
+            sessionId: 'vs-session-789',
+            prompt: 'Explain this version stack file',
+            userId: regularUser.id,
+          },
+        },
+      },
+    })
+
+    const completedTask = await workflowService.executeWait(task, 45000)
+
+    expect(completedTask.status).toBe('completed')
+    expect((completedTask.output as unknown as { sessionId: string })?.sessionId).toBe(
+      'vs-session-789',
+    )
+  }, 50000)
 })

--- a/packages/workflow-core/src/activities/task.ts
+++ b/packages/workflow-core/src/activities/task.ts
@@ -1,5 +1,5 @@
 import { prisma } from '@shumai/db'
-import { WorkflowTaskStatus, AssetStatus, Prisma } from '@shumai/db'
+import { WorkflowTaskStatus, AssetStatus, AssetType, Prisma } from '@shumai/db'
 
 export async function getTranscodeWorkerQueueActivity(): Promise<string> {
   return 'transcode_queue'
@@ -20,7 +20,7 @@ export async function getAssetStatusActivity(params: {
 }
 
 export async function getAssetActivity(assetId: string) {
-  return prisma.asset.findUnique({
+  const asset = await prisma.asset.findUnique({
     where: { id: assetId },
     include: {
       storageKey: true,
@@ -31,6 +31,30 @@ export async function getAssetActivity(assetId: string) {
       },
     },
   })
+
+  if (asset && asset.type === AssetType.version_stack) {
+    const latestVersion = await prisma.asset.findFirst({
+      where: { parentId: asset.id, isDeleted: false },
+      orderBy: { sortIndex: 'asc' },
+      include: {
+        storageKey: true,
+        project: {
+          include: {
+            team: true,
+          },
+        },
+      },
+    })
+
+    if (latestVersion) {
+      return {
+        ...latestVersion,
+        project: latestVersion.project ?? asset.project,
+      }
+    }
+  }
+
+  return asset
 }
 
 export interface UpdateTaskStatusParams {


### PR DESCRIPTION
## Summary

When chatting with the AI agent regarding a Version Stack asset, `getAssetActivity` previously returned the `version_stack` container proxy asset record, which lacks media metadata (`mediaType`, `duration`, `totalPages`, `proxyType`, etc.). This caused `AgentChatPromptBuilder` to receive empty details and construct incomplete prompt instructions.

This PR updates `getAssetActivity` in both `@shumai/agent` and `@shumai/workflow-core` so that when an asset is a `version_stack`, it queries and returns the latest version child asset in the stack (ordered by `sortIndex: 'asc'`), ensuring the agent prompt is populated with accurate file and media details.

## Changes

- Updated `getAssetActivity` in `packages/agent/src/activities/agent.ts` and `packages/workflow-core/src/activities/task.ts` to resolve a `version_stack` asset to its latest child version asset.
- Preserved `project` and `team` information when resolving the version stack to its child asset.
- Added unit tests in `packages/agent/src/activities/agent.test.ts` and `packages/agent/src/workflows/agent-chat.test.ts`.
- Added E2E workflow test coverage in `packages/e2e/workflow/agent-chat.test.ts` for version stack chat execution in both local and temporal modes.

## Verification

- `bun run lint` passed clean.
- `bun run format` passed clean.
- `bun run typecheck` passed clean.
- `bun run test` passed all 87 test files (676 tests).
- `bun run test:e2e` passed all 30 Playwright tests.
- `bun run test:e2e:workflow` passed all 36 workflow E2E tests across local and temporal executors.

## Notes

None.