### PR TITLE
fix(provider): preserve model ids on provider update

### DIFF
--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from 'vitest'
-import { formatSkillsForPrompt, createAgentSession, getModelFromDb, type DbProviderInfo } from './index'
+import {
+  formatSkillsForPrompt,
+  createAgentSession,
+  getModelFromDb,
+  type DbProviderInfo,
+} from './index'
 import { createSandboxedBashTool } from './tools/sandboxed-bash'
 import { SandboxManager, type SandboxAskCallback } from '@anthropic-ai/sandbox-runtime'
 import { prisma } from '@shumai/db'

--- a/packages/core/src/provider/provider.test.ts
+++ b/packages/core/src/provider/provider.test.ts
@@ -1,5 +1,6 @@
 import { setupTestDbHooks } from '@shumai/db/test'
 import { teamService } from '@shumai/core/src/team/team'
+import { agentService } from '@shumai/core/src/agent/agent'
 import { providerService } from './provider'
 import { describe, expect, it } from 'vitest'
 import { ProviderConfigSerializable, providerModelSchema } from '@shumai/dtos'
@@ -147,5 +148,46 @@ describe('ProviderService', () => {
     await providerService.delete(team.id, provider.id)
     const afterDelete = await providerService.listByTeam(team.id)
     expect(afterDelete.find((p) => p.id === provider.id)).toBeUndefined()
+  })
+
+  it('should preserve model IDs and linked agent modelId when updating provider config', async () => {
+    const team = await teamService.ensureDefaultTeam()
+    await providerService.initBuiltinProviders(team.id)
+
+    const providers = await providerService.listByTeam(team.id)
+    const googleProvider = providers.find((p) => p.name === 'google')
+    expect(googleProvider).toBeDefined()
+
+    const initialModels = await providerService.listModelsByProvider(team.id, googleProvider!.id)
+    expect(initialModels.length).toBeGreaterThan(0)
+    const initialModelId = initialModels[0].id
+
+    // Create an agent pointing to the google provider and first model
+    const agent = await agentService.createAgent({
+      teamId: team.id,
+      name: 'Google Agent',
+      type: 'chat',
+      enabled: true,
+      thinkingLevel: 'off',
+      providerId: googleProvider!.id,
+      modelId: initialModelId,
+    })
+    expect(agent?.modelId).toBe(initialModelId)
+
+    // Update provider config (e.g. API key) with the same model list
+    const newConfig: ProviderConfigSerializable = {
+      ...googleProvider!.config,
+      apiKey: 'new-google-api-key',
+    }
+    await providerService.update(team.id, googleProvider!.id, newConfig, initialModels)
+
+    // Verify model IDs were preserved
+    const updatedModels = await providerService.listModelsByProvider(team.id, googleProvider!.id)
+    expect(updatedModels[0].id).toBe(initialModelId)
+
+    // Verify agent's modelId is still linked and not nulled out
+    const updatedAgents = await agentService.listAgents({ teamId: team.id })
+    const updatedAgent = updatedAgents.find((a) => a.id === agent!.id)
+    expect(updatedAgent?.modelId).toBe(initialModelId)
   })
 })

--- a/packages/core/src/provider/provider.ts
+++ b/packages/core/src/provider/provider.ts
@@ -111,23 +111,51 @@ export class ProviderService {
     models: ProviderModel[],
   ) {
     return this.prismaClient.$transaction(async (tx) => {
-      // Delete all existing models for this provider
-      await tx.model.deleteMany({
+      const existingModels = await tx.model.findMany({
         where: { providerId: id },
       })
 
-      // Update provider and recreate models
+      const existingByModelId = new Map(existingModels.map((m) => [m.modelId, m]))
+      const incomingModelIds = new Set(models.map((m) => m.modelId))
+
+      // Delete models that are no longer in the incoming list
+      const modelsToDelete = existingModels.filter((m) => !incomingModelIds.has(m.modelId))
+      if (modelsToDelete.length > 0) {
+        await tx.model.deleteMany({
+          where: {
+            id: { in: modelsToDelete.map((m) => m.id) },
+          },
+        })
+      }
+
+      // Update existing models or create new ones
+      for (const m of models) {
+        const existing = existingByModelId.get(m.modelId)
+        if (existing) {
+          await tx.model.update({
+            where: { id: existing.id },
+            data: {
+              name: m.name,
+              config: m.config,
+            },
+          })
+        } else {
+          await tx.model.create({
+            data: {
+              providerId: id,
+              modelId: m.modelId,
+              name: m.name,
+              config: m.config,
+            },
+          })
+        }
+      }
+
+      // Update provider config
       return tx.provider.update({
         where: { id, teamId },
         data: {
           config,
-          models: {
-            create: models.map((m) => ({
-              modelId: m.modelId,
-              name: m.name,
-              config: m.config,
-            })),
-          },
         },
         include: { models: true },
       })


### PR DESCRIPTION
## Summary

Preserve existing `Model` database records and primary key ULIDs when updating a provider's configuration.

## Changes

- Updated `ProviderService.update()` in `packages/core/src/provider/provider.ts` to reconcile and upsert models instead of bulk-deleting all provider models.
- Added a unit test in `packages/core/src/provider/provider.test.ts` verifying that model primary keys and linked `Agent.modelId` references are preserved when provider settings are updated.

## Verification

- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test`
- `bun run test:e2e`
- `bun run test:e2e:workflow`

## Notes

None.