### PR TITLE
fix(search): fix buildSqlCondition date range, numeric metadata, and string parsing bugs

### DIFF
--- a/packages/core/src/search/search.test.ts
+++ b/packages/core/src/search/search.test.ts
@@ -127,6 +127,7 @@ describe('SearchService', () => {
     // String fields
     await createWithMeta('str-apple', { text: 'apple' })
     await createWithMeta('str-banana', { text: 'banana' })
+    await createWithMeta('sku-1-2', { sku: '1-2' })
 
     // Number fields
     await createWithMeta('num-10', { num: 10 })
@@ -181,6 +182,7 @@ describe('SearchService', () => {
         val: 'str-apple',
         expected: [
           'str-banana',
+          'sku-1-2',
           'num-10',
           'num-20',
           'bool-true',
@@ -200,6 +202,7 @@ describe('SearchService', () => {
         val: 'apple',
         expected: [
           'str-banana',
+          'sku-1-2',
           'num-10',
           'num-20',
           'bool-true',
@@ -220,6 +223,7 @@ describe('SearchService', () => {
         expected: [
           'str-apple',
           'str-banana',
+          'sku-1-2',
           'num-10',
           'num-20',
           'bool-true',
@@ -235,12 +239,14 @@ describe('SearchService', () => {
 
       // String Metadata
       { field: 'text', op: 'eq', val: 'apple', expected: ['str-apple'] },
+      { field: 'sku', op: 'eq', val: '1-2', expected: ['sku-1-2'] },
       {
         field: 'text',
         op: 'neq',
         val: 'apple',
         expected: [
           'str-banana',
+          'sku-1-2',
           'num-10',
           'num-20',
           'bool-true',
@@ -258,6 +264,7 @@ describe('SearchService', () => {
         op: 'isEmpty',
         val: null,
         expected: [
+          'sku-1-2',
           'num-10',
           'num-20',
           'bool-true',
@@ -281,6 +288,7 @@ describe('SearchService', () => {
         expected: [
           'str-apple',
           'str-banana',
+          'sku-1-2',
           'num-20',
           'bool-true',
           'bool-false',
@@ -293,6 +301,7 @@ describe('SearchService', () => {
         ],
       },
       { field: 'num', op: 'gt', val: 15, expected: ['num-20'] },
+      { field: 'num', op: 'gt', val: 100, expected: [] },
       { field: 'num', op: 'lt', val: 15, expected: ['num-10'] },
       { field: 'num', op: 'gte', val: 20, expected: ['num-20'] },
       { field: 'num', op: 'lte', val: 10, expected: ['num-10'] },
@@ -314,6 +323,7 @@ describe('SearchService', () => {
         expected: [
           'str-apple',
           'str-banana',
+          'sku-1-2',
           'num-10',
           'num-20',
           'bool-true',
@@ -332,6 +342,7 @@ describe('SearchService', () => {
         expected: [
           'str-apple',
           'str-banana',
+          'sku-1-2',
           'num-10',
           'num-20',
           'bool-true',
@@ -346,6 +357,7 @@ describe('SearchService', () => {
 
       // Date Metadata
       { field: 'date', op: 'eq', val: 'today', expected: ['date-today'] },
+      { field: 'date', op: 'lte', val: 'today', expected: ['date-today', 'date-yesterday'] },
       { field: 'date', op: 'isWithin', val: 'today', expected: ['date-today'] },
       { field: 'date', op: 'lt', val: 'today', expected: ['date-yesterday'] },
       { field: 'date', op: 'gt', val: 'yesterday', expected: ['date-today'] },
@@ -358,6 +370,7 @@ describe('SearchService', () => {
         expected: [
           'str-apple',
           'str-banana',
+          'sku-1-2',
           'num-10',
           'num-20',
           'bool-true',
@@ -378,6 +391,47 @@ describe('SearchService', () => {
         expected: [
           'str-apple',
           'str-banana',
+          'sku-1-2',
+          'num-10',
+          'num-20',
+          'bool-true',
+          'bool-false',
+          'multi-a-b',
+          'multi-b-c',
+          'date-today',
+          'date-yesterday',
+          'name-contains-test',
+          'nothing',
+        ],
+      },
+      {
+        field: 'createdAt',
+        op: 'eq',
+        val: 'today',
+        expected: [
+          'str-apple',
+          'str-banana',
+          'sku-1-2',
+          'num-10',
+          'num-20',
+          'bool-true',
+          'bool-false',
+          'multi-a-b',
+          'multi-b-c',
+          'date-today',
+          'date-yesterday',
+          'name-contains-test',
+          'nothing',
+        ],
+      },
+      {
+        field: 'createdAt',
+        op: 'lte',
+        val: 'today',
+        expected: [
+          'str-apple',
+          'str-banana',
+          'sku-1-2',
           'num-10',
           'num-20',
           'bool-true',

--- a/packages/core/src/search/sql-query-builder.test.ts
+++ b/packages/core/src/search/sql-query-builder.test.ts
@@ -35,4 +35,76 @@ describe('SqlQueryBuilder', () => {
     const builder = new SqlQueryBuilder().select(Prisma.sql`id`)
     expect(() => builder.build()).toThrow('FROM clause is required')
   })
+
+  describe('Bug Reproduction Tests for buildSqlCondition', () => {
+    it('Bug 1: createdAt eq date should match full day range (>= startOfDay AND <= endOfDay)', () => {
+      const builder = new SqlQueryBuilder()
+        .from(Prisma.sql`assets a`)
+        .addSearchConditions('AND', [{ field: 'createdAt', operator: 'eq', value: '2026-07-22' }])
+
+      const query = builder.build()
+      expect(query.text).toBe(
+        'SELECT * FROM assets a WHERE (a."created_at" >= $1 AND a."created_at" <= $2)',
+      )
+      const startVal = query.values[0] as Date
+      const endVal = query.values[1] as Date
+      expect(startVal.getHours()).toBe(0)
+      expect(startVal.getMinutes()).toBe(0)
+      expect(startVal.getSeconds()).toBe(0)
+      expect(endVal.getHours()).toBe(23)
+      expect(endVal.getMinutes()).toBe(59)
+      expect(endVal.getSeconds()).toBe(59)
+    })
+
+    it('Bug 2: createdAt lte date should use end-of-day timestamp (23:59:59.999)', () => {
+      const builder = new SqlQueryBuilder()
+        .from(Prisma.sql`assets a`)
+        .addSearchConditions('AND', [{ field: 'createdAt', operator: 'lte', value: '2026-07-22' }])
+
+      const query = builder.build()
+      expect(query.text).toBe('SELECT * FROM assets a WHERE (a."created_at" <= $1)')
+      const endVal = query.values[0] as Date
+      expect(endVal.getHours()).toBe(23)
+      expect(endVal.getMinutes()).toBe(59)
+      expect(endVal.getSeconds()).toBe(59)
+    })
+
+    it('Bug 3: custom metadata numeric query should ONLY query number_value', () => {
+      const builder = new SqlQueryBuilder()
+        .from(Prisma.sql`assets a`)
+        .addSearchConditions('AND', [{ field: 'rating', operator: 'gt', value: 100 }])
+
+      const query = builder.build()
+      expect(query.text).toBe(
+        'SELECT * FROM assets a WHERE (a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = $1 AND number_value > $2))',
+      )
+      expect(query.values).toEqual(['rating', 100])
+    })
+
+    it('Bug 4: isDate should not misclassify dash-separated non-date string values like "1-2"', () => {
+      const builder = new SqlQueryBuilder()
+        .from(Prisma.sql`assets a`)
+        .addSearchConditions('AND', [{ field: 'sku', operator: 'eq', value: '1-2' }])
+
+      const query = builder.build()
+      expect(query.text).toBe(
+        'SELECT * FROM assets a WHERE (a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = $1 AND string_value = $2))',
+      )
+      expect(query.values).toEqual(['sku', '1-2'])
+    })
+
+    it('Bug 5: custom field names with special characters are safely parameterized', () => {
+      const builder = new SqlQueryBuilder()
+        .from(Prisma.sql`assets a`)
+        .addSearchConditions('AND', [
+          { field: 'custom_field"test', operator: 'eq', value: 'hello' },
+        ])
+
+      const query = builder.build()
+      expect(query.text).toBe(
+        'SELECT * FROM assets a WHERE (a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = $1 AND string_value = $2))',
+      )
+      expect(query.values).toEqual(['custom_field"test', 'hello'])
+    })
+  })
 })

--- a/packages/core/src/search/sql-query-builder.ts
+++ b/packages/core/src/search/sql-query-builder.ts
@@ -101,7 +101,7 @@ export class SqlQueryBuilder {
   private isDate(value: unknown): boolean {
     if (value instanceof Date) return true
     if (typeof value !== 'string') return false
-    const valStr = value.toLowerCase()
+    const valStr = value.trim().toLowerCase()
     const relativeKeywords = [
       'today',
       'yesterday',
@@ -111,11 +111,14 @@ export class SqlQueryBuilder {
       'one month ago',
       'one month from now',
     ]
-    if (relativeKeywords.includes(valStr) || valStr.match(/\d+\s+days?\s+(ago|from\s+now)/)) {
+    if (relativeKeywords.includes(valStr) || valStr.match(/^\d+\s+days?\s+(ago|from\s+now)$/)) {
       return true
     }
+    if (!valStr.match(/^\d{4}-\d{2}-\d{2}/)) {
+      return false
+    }
     const d = new Date(value)
-    return !isNaN(d.getTime()) && value.includes('-')
+    return !isNaN(d.getTime())
   }
 
   private toDate(value: unknown): Date {
@@ -123,12 +126,8 @@ export class SqlQueryBuilder {
   }
 
   private toDateBound(value: unknown, bound: 'start' | 'end'): Date {
-    const d = this.parseRelativeDate(value)
-    if (d instanceof Date) return d
-    if (d && 'gte' in d && 'lte' in d) {
-      return bound === 'start' ? d.gte! : d.lte!
-    }
-    return new Date(value as string)
+    const range = this.parseDateRange(value)
+    return bound === 'start' ? range.start : range.end
   }
 
   private parseDateRange(value: unknown): { start: Date; end: Date } {
@@ -137,6 +136,11 @@ export class SqlQueryBuilder {
       return { start: d.gte!, end: d.lte! }
     }
     const date = d instanceof Date ? d : new Date(value as string)
+    const valStr = typeof value === 'string' ? value : ''
+    const hasTime = valStr.includes('T') || valStr.includes(':')
+    if (hasTime) {
+      return { start: date, end: date }
+    }
     const start = new Date(date)
     start.setHours(0, 0, 0, 0)
     const end = new Date(date)
@@ -239,18 +243,8 @@ export class SqlQueryBuilder {
   }
 
   private buildSqlCondition(field: string, operator: string, value: unknown): Prisma.Sql | null {
-    const colName =
-      field === 'sizeByte' || field === 'size_byte'
-        ? 'size_byte'
-        : field === 'createdAt' || field === 'created_at'
-          ? 'created_at'
-          : field === 'updatedAt' || field === 'updated_at'
-            ? 'updated_at'
-            : field
-
-    const dbCol = Prisma.raw(`a."${colName}"`)
-
     if (field === 'name') {
+      const dbCol = Prisma.raw(`a."name"`)
       const valStr = String(value)
       switch (operator) {
         case 'eq':
@@ -271,6 +265,7 @@ export class SqlQueryBuilder {
     }
 
     if (field === 'sizeByte' || field === 'size_byte') {
+      const dbCol = Prisma.raw(`a."size_byte"`)
       const valNum = Number(value)
       switch (operator) {
         case 'eq':
@@ -296,12 +291,17 @@ export class SqlQueryBuilder {
       field === 'created_at' ||
       field === 'updated_at'
     ) {
-      const valDate = this.toDate(value)
+      const colName = field === 'createdAt' || field === 'created_at' ? 'created_at' : 'updated_at'
+      const dbCol = Prisma.raw(`a."${colName}"`)
       switch (operator) {
-        case 'eq':
-          return Prisma.sql`${dbCol} = ${valDate}`
-        case 'neq':
-          return Prisma.sql`${dbCol} != ${valDate}`
+        case 'eq': {
+          const range = this.parseDateRange(value)
+          return Prisma.sql`${dbCol} >= ${range.start} AND ${dbCol} <= ${range.end}`
+        }
+        case 'neq': {
+          const range = this.parseDateRange(value)
+          return Prisma.sql`(${dbCol} < ${range.start} OR ${dbCol} > ${range.end})`
+        }
         case 'gt':
           return Prisma.sql`${dbCol} > ${this.toDateBound(value, 'end')}`
         case 'gte':
@@ -333,14 +333,42 @@ export class SqlQueryBuilder {
         const matchSql = this.buildEavValueMatch(value)
         return Prisma.sql`a.id NOT IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field}) OR a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND NOT (${matchSql}))`
       }
-      case 'gt':
-        return Prisma.sql`a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND (number_value > ${Number(value)} OR date_value > ${this.toDateBound(value, 'end')}))`
-      case 'gte':
-        return Prisma.sql`a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND (number_value >= ${Number(value)} OR date_value >= ${this.toDateBound(value, 'start')}))`
-      case 'lt':
-        return Prisma.sql`a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND (number_value < ${Number(value)} OR date_value < ${this.toDateBound(value, 'start')}))`
-      case 'lte':
-        return Prisma.sql`a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND (number_value <= ${Number(value)} OR date_value <= ${this.toDateBound(value, 'end')}))`
+      case 'gt': {
+        if (
+          typeof value === 'number' ||
+          (typeof value === 'string' && !isNaN(Number(value)) && !this.isDate(value))
+        ) {
+          return Prisma.sql`a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND number_value > ${Number(value)})`
+        }
+        return Prisma.sql`a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND date_value > ${this.toDateBound(value, 'end')})`
+      }
+      case 'gte': {
+        if (
+          typeof value === 'number' ||
+          (typeof value === 'string' && !isNaN(Number(value)) && !this.isDate(value))
+        ) {
+          return Prisma.sql`a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND number_value >= ${Number(value)})`
+        }
+        return Prisma.sql`a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND date_value >= ${this.toDateBound(value, 'start')})`
+      }
+      case 'lt': {
+        if (
+          typeof value === 'number' ||
+          (typeof value === 'string' && !isNaN(Number(value)) && !this.isDate(value))
+        ) {
+          return Prisma.sql`a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND number_value < ${Number(value)})`
+        }
+        return Prisma.sql`a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND date_value < ${this.toDateBound(value, 'start')})`
+      }
+      case 'lte': {
+        if (
+          typeof value === 'number' ||
+          (typeof value === 'string' && !isNaN(Number(value)) && !this.isDate(value))
+        ) {
+          return Prisma.sql`a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND number_value <= ${Number(value)})`
+        }
+        return Prisma.sql`a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND date_value <= ${this.toDateBound(value, 'end')})`
+      }
       case 'contains':
         return Prisma.sql`a.id IN (SELECT asset_id FROM asset_metadata_values WHERE field_key = ${field} AND string_value ILIKE ${'%' + String(value) + '%'})`
       case 'notContains':


### PR DESCRIPTION
## Summary

Fixes multiple logic bugs in `SqlQueryBuilder.buildSqlCondition` and helper functions that caused incorrect SQL query generation for date equality, upper-bound date limits, numeric EAV metadata range queries, and non-date string metadata values.

## Changes

- **Date `eq` / `neq` Filtering**: Updated timestamp filtering (`createdAt`, `updatedAt`, `created_at`, `updated_at`) to match full-day ranges (`>= startOfDay AND <= endOfDay`) for equality checks rather than exact midnight `00:00:00.000`.
- **Upper Date Bounds (`toDateBound`)**: Resolved whole-day date upper bounds (`bound === 'end'`) to end-of-day timestamps (`23:59:59.999`).
- **EAV Metadata Range Queries**: Separated numeric range comparisons (`number_value`) from date comparisons (`date_value`), eliminating invalid `date_value > 1970-01-01` clauses during numeric metadata queries.
- **`isDate` Heuristics**: Restricted `isDate` recognition to ISO date formats and relative keywords, preventing dash-separated non-date strings (e.g. `'1-2'`) from being parsed as dates.
- **Column Identifier Safety**: Scoped `Prisma.raw` column identifier construction strictly inside validated system column branches.
- **Tests & Matrix Coverage**: Added unit tests in `sql-query-builder.test.ts` and extended operator matrix tests in `search.test.ts`.

## Verification

- `bun run lint` (Passed)
- `bun run format` (Passed)
- `bun run typecheck` (Passed)
- `bun run test` (All 87 test files / 685 tests passed, including `sql-query-builder.test.ts` and `search.test.ts`)
- `bun run test:e2e` (Passed 30/30)
- `bun run test:e2e:workflow` (Passed 36/36)

## Notes

None.