### PR TITLE
fix(webui): invalidate upload tasks query when upload task starts and completes

### DIFF
--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -540,12 +540,18 @@ export function FileBrowser({
       queryClient.invalidateQueries({
         queryKey: ['search', teamId, assetId],
       })
+      queryClient.invalidateQueries({
+        queryKey: ['teams', teamId, 'upload', 'tasks'],
+      })
 
       // The RPC client returns an object that we cast to the expected type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await uploadFiles(currentFiles, data.presignedUrls as any, data.taskId!)
       queryClient.invalidateQueries({
         queryKey: ['search', teamId, assetId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['teams', teamId, 'upload', 'tasks'],
       })
     },
   })


### PR DESCRIPTION
## Summary

Fixes a bug where upload tasks in the left sidebar would get stuck showing `Uploading` and `41.1 MB / 41.1 MB (9 / 10 files)` even after all files completed uploading.

## Changes

- Invalidated the `['teams', teamId, 'upload', 'tasks']` query in `createUploadTaskMutation.onSuccess` in [file-browser.tsx](file:///Users/yiling/Projects/shumai/packages/webui/components/file-browser/file-browser.tsx) both upon task creation and after `await uploadFiles(...)` resolves.
- This ensures that React Query refetches the latest server task status (`uploaded: 10`, `status: completed`) right after the last file's `confirmUpload` API call finishes, updating the UI badge to `Done` and file count to `10 / 10 files`.

## Verification

- `bun run lint` - PASSED
- `bun run format` - PASSED
- `bun run typecheck` - PASSED
- `bun run test` - PASSED (88 test files, 704 tests)
- `bun run test:e2e` - PASSED (30 tests)
- `bun run test:e2e:workflow` - PASSED (38 tests)

## Notes

None.