### PR TITLE
fix(webui): show right sidebar by default on file detail page

### DIFF
--- a/packages/webui/stores/ui.ts
+++ b/packages/webui/stores/ui.ts
@@ -34,7 +34,7 @@ export const useUiStore = create<UiState>()(
       setFileViewLeftSidebarCollapsed: (collapsed) =>
         set({ fileViewLeftSidebarCollapsed: collapsed }),
 
-      fileViewRightSidebarCollapsed: true,
+      fileViewRightSidebarCollapsed: false,
       setFileViewRightSidebarCollapsed: (collapsed) =>
         set({ fileViewRightSidebarCollapsed: collapsed }),
 


### PR DESCRIPTION
## Summary

Default the file view right sidebar state (`fileViewRightSidebarCollapsed`) to `false` in `useUiStore` so that the right sidebar is visible by default when opening a file detail page.

## Changes

- Changed `fileViewRightSidebarCollapsed` initial value from `true` to `false` in `packages/webui/stores/ui.ts`.

## Verification

- `bun run lint` (Passed)
- `bun run format` (Passed)
- `bun run typecheck` (Passed)
- `bun run test` (88 test files, 704 passed)
- `bun run test:e2e` (30 passed)
- `bun run test:e2e:workflow` (6 test files, 38 passed)

## Notes

None.