### PR TITLE
fix(webui): refresh file list and detail when agent executes asset creation tools

### DIFF
--- a/packages/webui/components/chatbot-sidebar.tsx
+++ b/packages/webui/components/chatbot-sidebar.tsx
@@ -13,7 +13,7 @@ import { useChatbotStore } from '@/ui/stores/chatbot'
 import { useTeamContextStore } from '@/ui/stores/team-context'
 import { useDroppable } from '@dnd-kit/react'
 import type { ChatMessage } from '@shumai/dtos'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   ArrowLeft,
   ArrowUp,
@@ -26,7 +26,7 @@ import {
   Trash2,
   Wrench,
 } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import Markdown from 'react-markdown'
 import { formatTimeAgo } from '../lib/time'
 
@@ -171,9 +171,20 @@ export function ChatbotSidebar({ projectId, contextAssetId }: ChatbotSidebarProp
     }
   }, [isHistoryMode, fetchHistorySessions, teamId])
 
+  const queryClient = useQueryClient()
+
+  const handleAssetMutation = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['search'] })
+    queryClient.invalidateQueries({ queryKey: ['folders'] })
+    queryClient.invalidateQueries({ queryKey: ['files'] })
+    queryClient.invalidateQueries({ queryKey: ['file'] })
+    queryClient.invalidateQueries({ queryKey: ['version_stacks'] })
+    queryClient.invalidateQueries({ queryKey: ['projects'] })
+  }, [queryClient])
+
   const handleSend = () => {
     if (!inputText.trim() || isStreaming || !teamId) return
-    sendMessage(teamId, inputText, projectId, contextAssetId)
+    sendMessage(teamId, inputText, projectId, contextAssetId, handleAssetMutation)
     setInputText('')
   }
 

--- a/packages/webui/stores/chatbot.test.ts
+++ b/packages/webui/stores/chatbot.test.ts
@@ -259,4 +259,44 @@ describe('useChatbotStore', () => {
     expect(finalState.messages[0].id).toBe('context-display-ulid')
     expect(finalState.messages[1].id).toBe('user-msg-ulid')
   })
+
+  it('should invoke onAssetMutation callback when asset creation tool result arrives', async () => {
+    const mockEvents = [
+      'data: {"type":"session","sessionId":"sess-123"}\n\n',
+      'data: {"type":"entry","entry":{"id":"user-msg-ulid","role":"user","content":[{"type":"text","text":"create a file"}],"timestamp":123}}\n\n',
+      'data: {"type":"entry","entry":{"id":"tool-res-ulid","role":"toolResult","toolName":"create_file","isError":false,"content":"File created","timestamp":124}}\n\n',
+      'data: {"type":"done","status":"completed"}\n\n',
+    ]
+
+    let eventIdx = 0
+    const mockReader = {
+      read: vi.fn(async () => {
+        if (eventIdx < mockEvents.length) {
+          const value = new TextEncoder().encode(mockEvents[eventIdx++])
+          return { done: false, value }
+        }
+        return { done: true, value: undefined }
+      }),
+    }
+
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: vi.fn(() => 'sess-123'),
+      },
+      body: {
+        getReader: () => mockReader,
+      },
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(client.api.teams[':teamId'].chat.$post).mockResolvedValue(mockResponse as any)
+
+    const onAssetMutation = vi.fn()
+    await useChatbotStore
+      .getState()
+      .sendMessage('team-123', 'create a file', 'proj-123', undefined, onAssetMutation)
+
+    expect(onAssetMutation).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/webui/stores/chatbot.ts
+++ b/packages/webui/stores/chatbot.ts
@@ -42,6 +42,7 @@ interface ChatbotState {
     text: string,
     projectId: string,
     contextAssetId?: string,
+    onAssetMutation?: () => void,
   ) => Promise<void>
   abortActiveSession: (teamId: string) => Promise<void>
 }
@@ -151,7 +152,7 @@ export const useChatbotStore = create<ChatbotState>((set) => ({
     })
   },
 
-  sendMessage: async (teamId, text, projectId, contextAssetId) => {
+  sendMessage: async (teamId, text, projectId, contextAssetId, onAssetMutation) => {
     const state = useChatbotStore.getState()
     if (state.isStreaming) return
 
@@ -251,6 +252,16 @@ export const useChatbotStore = create<ChatbotState>((set) => ({
                 }
               } else if (data.type === 'entry') {
                 const entry = data.entry as ChatMessage
+                const entryObj = entry as unknown as Record<string, unknown>
+                if (
+                  entryObj.role === 'toolResult' &&
+                  typeof entryObj.toolName === 'string' &&
+                  ['create_file', 'create_folder', 'create_version'].includes(entryObj.toolName) &&
+                  !entryObj.isError
+                ) {
+                  onAssetMutation?.()
+                }
+
                 set((s) => {
                   const isExisting = s.messages.some((m) => m.id === entry.id)
                   // Replace temp/optimistic message when the real counterpart streams back


### PR DESCRIPTION
## Summary

Fixes a bug where the File List Page and File Detail Page were not refreshed after an agent executed asset creation tools (`create_file`, `create_folder`, `create_version`) in the right sidebar agent chat panel.

## Changes

- Updated `sendMessage` in `packages/webui/stores/chatbot.ts` to accept an optional `onAssetMutation` callback and trigger it when receiving a successful `toolResult` entry for `create_file`, `create_folder`, or `create_version`.
- Updated `ChatbotSidebar` in `packages/webui/components/chatbot-sidebar.tsx` to pass a `handleAssetMutation` callback that invalidates React Query caches (`search`, `folders`, `files`, `file`, `version_stacks`, `projects`).
- Added unit test in `packages/webui/stores/chatbot.test.ts` to verify that `onAssetMutation` is called upon receiving asset creation tool result entries.

## Verification

- `bun run lint` passed cleanly.
- `bun run format` passed cleanly.
- `bun run typecheck` passed cleanly.
- `bun run test packages/webui/stores/chatbot.test.ts` (all 6 tests passed).

## Notes

None.