### PR TITLE
fix(agent): ensure atomic appendEntry and persist leaf entries in DatabaseSessionStorage

### DIFF
--- a/packages/agent/src/database-session-storage.test.ts
+++ b/packages/agent/src/database-session-storage.test.ts
@@ -82,7 +82,18 @@ describe('DatabaseSessionStorage', () => {
 
     expect(await storage.getLeafId()).toBeNull()
 
-    await storage.setLeafId('entry-1')
+    const entry: SessionTreeEntry = {
+      type: 'message',
+      id: 'entry-1',
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'Test' }],
+        timestamp: Date.now(),
+      },
+    }
+    await storage.appendEntry(entry)
     expect(await storage.getLeafId()).toBe('entry-1')
 
     await storage.setLeafId(null)
@@ -502,5 +513,75 @@ describe('DatabaseSessionStorage', () => {
     // 4. Assert that the tools were instantiated using the new comment ID and user ID
     expect(createScreenshotToolSpy).toHaveBeenCalledWith(user.id, 'new-comment-456')
     expect(createAnalyzeImageToolSpy).toHaveBeenCalledWith(user.id, 'new-comment-456')
+  })
+
+  describe('P1 Bug Reproductions', () => {
+    it('should persist a leaf entry and validate targetId when setLeafId is called', async () => {
+      const { agent } = await setupTestData()
+      const storage = await DatabaseSessionStorage.create({ agentId: agent.id })
+
+      const msgEntry: SessionTreeEntry = {
+        type: 'message',
+        id: 'msg-100',
+        parentId: null,
+        timestamp: new Date().toISOString(),
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+          timestamp: Date.now(),
+        },
+      }
+      await storage.appendEntry(msgEntry)
+      expect(await storage.getLeafId()).toBe('msg-100')
+
+      // setLeafId to an existing entry
+      await storage.setLeafId('msg-100')
+
+      // Verify that a 'leaf' entry was appended to database entries
+      const entries = await storage.getEntries()
+      const leafEntries = entries.filter((e) => e.type === 'leaf')
+      expect(leafEntries.length).toBe(1)
+      expect(leafEntries[0]).toMatchObject({
+        type: 'leaf',
+        targetId: 'msg-100',
+      })
+
+      // Calling setLeafId with non-existent targetId should throw not_found error
+      await expect(storage.setLeafId('non-existent-id')).rejects.toThrow(
+        'Entry non-existent-id not found',
+      )
+    })
+
+    it('should execute appendEntry in a single atomic transaction', async () => {
+      const { agent } = await setupTestData()
+      const storage = await DatabaseSessionStorage.create({ agentId: agent.id })
+
+      // Mock prisma.agentSession.update to throw an error during setLeafId inside appendEntry
+      const updateSpy = vi
+        .spyOn(prisma.agentSession, 'update')
+        .mockRejectedValueOnce(new Error('DB Update Failed'))
+
+      const entry: SessionTreeEntry = {
+        type: 'message',
+        id: 'atomic-msg-1',
+        parentId: null,
+        timestamp: new Date().toISOString(),
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Atomic test' }],
+          timestamp: Date.now(),
+        },
+      }
+
+      await expect(storage.appendEntry(entry)).rejects.toThrow('DB Update Failed')
+
+      // Because appendEntry should be atomic, atomic-msg-1 must NOT exist in the database
+      const dbEntry = await prisma.agentSessionEntry.findUnique({
+        where: { id: 'atomic-msg-1' },
+      })
+      expect(dbEntry).toBeNull()
+
+      updateSpy.mockRestore()
+    })
   })
 })

--- a/packages/agent/src/database-session-storage.ts
+++ b/packages/agent/src/database-session-storage.ts
@@ -46,10 +46,30 @@ export class DatabaseSessionStorage implements SessionStorage<DatabaseSessionMet
   }
 
   async setLeafId(leafId: string | null): Promise<void> {
-    await prisma.agentSession.update({
-      where: { id: this.sessionId },
-      data: { leafId },
+    if (leafId === null) {
+      await prisma.agentSession.update({
+        where: { id: this.sessionId },
+        data: { leafId: null },
+      })
+      return
+    }
+
+    const existing = await prisma.agentSessionEntry.findFirst({
+      where: { id: leafId },
     })
+    if (!existing) {
+      throw new Error(`Entry ${leafId} not found`)
+    }
+
+    const currentLeafId = await this.getLeafId()
+    const leafEntry: SessionTreeEntry = {
+      type: 'leaf',
+      id: await this.createEntryId(),
+      parentId: currentLeafId,
+      timestamp: new Date().toISOString(),
+      targetId: leafId,
+    }
+    await this.appendEntry(leafEntry)
   }
 
   async createEntryId(): Promise<string> {
@@ -96,16 +116,21 @@ export class DatabaseSessionStorage implements SessionStorage<DatabaseSessionMet
       }
     }
 
-    await prisma.agentSessionEntry.create({
-      data: {
-        id: entry.id,
-        sessionId: this.sessionId,
-        entry: strippedEntry,
-      },
-    })
+    const targetLeafId = entry.type === 'leaf' ? entry.targetId : entry.id
 
-    // Auto-update leafId on append
-    await this.setLeafId(entry.id)
+    await prisma.$transaction([
+      prisma.agentSessionEntry.create({
+        data: {
+          id: entry.id,
+          sessionId: this.sessionId,
+          entry: strippedEntry,
+        },
+      }),
+      prisma.agentSession.update({
+        where: { id: this.sessionId },
+        data: { leafId: targetLeafId },
+      }),
+    ])
   }
 
   async getEntry(id: string): Promise<SessionTreeEntry | undefined> {


### PR DESCRIPTION
## Summary

Fix P1 correctness and consistency bugs in `DatabaseSessionStorage`: enforce atomic transactions during entry appends and persist leaf navigation entries during `setLeafId`.

## Changes

- **Atomic Transactions**: Wrapped entry creation (`prisma.agentSessionEntry.create`) and active leaf updating (`prisma.agentSession.update`) inside a single `prisma.$transaction([...])` in `appendEntry`.
- **Leaf Entry Persistence & Target Validation**: Updated `setLeafId` to validate that target entries exist in `agentSessionEntry` and append `{ type: 'leaf', targetId: leafId }` tree entries to record branch-switching history.
- **Reproduction & Regression Tests**: Added unit tests in `database-session-storage.test.ts` verifying atomic rollback and leaf entry persistence.

## Verification

- `bun run lint` (passed)
- `bun run format` (passed)
- `bun run typecheck` (passed)
- `bun run test` (89/89 test files passed, 713/713 tests passed)

## Notes

Fixes P1 consistency issues identified during SQLite storage architectural audit.
