### PR TITLE
refactor(agent): remove implicit agent mention trigger in comment threads

### DIFF
--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -333,7 +333,6 @@ export interface AgentChatParams {
   sessionId: string
   userId?: string
   userCommentId?: string | null
-  explicitMention?: boolean
   context: AgentExecutionContext
   attachedAssets?: Array<{ id: string; name: string; type: string }>
 }

--- a/packages/agent/src/workflows/agent-chat-prompt-builder.test.ts
+++ b/packages/agent/src/workflows/agent-chat-prompt-builder.test.ts
@@ -2,19 +2,11 @@ import { describe, it, expect } from 'vitest'
 import { AgentChatPromptBuilder } from './agent-chat-prompt-builder'
 
 describe('AgentChatPromptBuilder', () => {
-  it('should build prompt with baseline configurations (implicit mention, other asset type)', () => {
+  it('should build prompt with baseline configurations', () => {
     const builder = new AgentChatPromptBuilder('a1')
     const result = builder.build()
 
     expect(result).toContain('The user is discussing an asset with ID: a1.')
-    expect(result).toContain('The user did not explicitly mention you')
-  })
-
-  it('should build prompt with explicit mention', () => {
-    const builder = new AgentChatPromptBuilder('a1').withExplicitMention(true)
-    const result = builder.build()
-
-    expect(result).toContain('The user explicitly mentioned you')
   })
 
   it('should build prompt with path context', () => {
@@ -105,7 +97,6 @@ describe('AgentChatPromptBuilder', () => {
 
   it('should build prompt with all fields combined', () => {
     const builder = new AgentChatPromptBuilder('a1')
-      .withExplicitMention(true)
       .withPathContext('src/main.ts')
       .withAssetDetails('movie.mp4', 'video/mp4', 12.34, undefined, 'video')
       .withCommentTimestamp(8.2)
@@ -118,7 +109,6 @@ describe('AgentChatPromptBuilder', () => {
     expect(result).toContain('Comment Timestamp: 8.20 seconds')
     expect(result).toContain('Asset Path Context:\nsrc/main.ts')
     expect(result).toContain("call the 'screenshot' tool")
-    expect(result).toContain('The user explicitly mentioned you')
   })
 
   it('should build prompt with attached files and referenced assets', () => {

--- a/packages/agent/src/workflows/agent-chat-prompt-builder.ts
+++ b/packages/agent/src/workflows/agent-chat-prompt-builder.ts
@@ -14,7 +14,6 @@ export class AgentChatPromptBuilder {
   private totalPages?: number
   private commentTimestamp?: number
   private pathContext?: string
-  private explicitMention = false
   private attachedFiles: string[] = []
   private referencedAssets: string[] = []
   private userInfo?: { name: string; role: string }
@@ -81,11 +80,6 @@ export class AgentChatPromptBuilder {
     if (second !== undefined && second !== null) {
       this.commentTimestamp = second
     }
-    return this
-  }
-
-  withExplicitMention(explicitMention?: boolean): this {
-    this.explicitMention = !!explicitMention
     return this
   }
 
@@ -178,12 +172,6 @@ export class AgentChatPromptBuilder {
       } else if (type === 'pdf') {
         instruction += `\n\nIf you need to view pages of the PDF document, call the 'read_pdf_pages' tool. You must specify the 'start' (page number) and 'end' (page number) parameters. Maximum 20 pages allowed per call.`
       }
-    }
-
-    if (this.explicitMention) {
-      instruction += `\n\nThe user explicitly mentioned you in their message. You MUST reply to this message.`
-    } else {
-      instruction += `\n\nThe user did not explicitly mention you, but is replying in a thread where you are the participant. Let's decide if you should reply or not. If the user is not directly addressing you or doesn't need a response from you, you may choose to not reply. To choose not to reply, respond with exactly and only the text: __NO_REPLY__.`
     }
 
     if (this.userInfo) {

--- a/packages/agent/src/workflows/agent-chat.test.ts
+++ b/packages/agent/src/workflows/agent-chat.test.ts
@@ -99,7 +99,7 @@ describe('Agent Chat Workflow', () => {
         assetId: 'a1',
         payload: {
           projectId: 'p1',
-          agent: { userCommentId: 'c1', agentId: 'b1', explicitMention: true },
+          agent: { userCommentId: 'c1', agentId: 'b1' },
         },
       },
     })
@@ -140,7 +140,6 @@ describe('Agent Chat Workflow', () => {
       .withPathContext('Path: folder/subfolder/file.png')
       .withAssetDetails('test-file.png', 'image/png', undefined, undefined, 'image')
       .withCommentTimestamp(null)
-      .withExplicitMention(true)
       .build()
 
     expect(mockActivities.agentChatActivity).toHaveBeenCalledWith(
@@ -207,7 +206,6 @@ describe('Agent Chat Workflow', () => {
       .withPathContext('Path: folder/subfolder/file.png')
       .withAssetDetails('test-file.png', 'image/png', undefined)
       .withCommentTimestamp(null)
-      .withExplicitMention(false)
       .build()
 
     expect(mockActivities.agentChatActivity).toHaveBeenCalledWith(
@@ -219,52 +217,6 @@ describe('Agent Chat Workflow', () => {
 
     // Verify session name generation is skipped
     expect(mockActivities.generateSessionNameActivity).not.toHaveBeenCalled()
-  })
-
-  it('should delete placeholder comment and finish when AI responds with __NO_REPLY__', async () => {
-    mockActivities.agentChatActivity.mockResolvedValue({
-      text: '__NO_REPLY__',
-      sessionId: 'session-123',
-    })
-
-    const task = await prisma.workflowTask.create({
-      data: {
-        type: 'chat',
-        status: 'pending',
-        assetId: 'a1',
-        payload: {
-          projectId: 'p1',
-          agent: { userCommentId: 'c1', agentId: 'b1', explicitMention: false },
-        },
-      },
-    })
-
-    await agentChat(task)
-
-    // Verify instruction contains not explicitly mentioned instructions
-    const expectedInstruction3 = new AgentChatPromptBuilder('a1')
-      .withPathContext('Path: folder/subfolder/file.png')
-      .withAssetDetails('test-file.png', 'image/png', undefined, undefined, 'image')
-      .withCommentTimestamp(null)
-      .withExplicitMention(false)
-      .build()
-
-    expect(mockActivities.agentChatActivity).toHaveBeenCalledWith(
-      expect.objectContaining({
-        agentsInstruction: expectedInstruction3,
-      }),
-    )
-
-    // Verify placeholder comment is deleted
-    expect(mockActivities.deleteCommentActivity).toHaveBeenCalledWith('comment-placeholder-id')
-    expect(mockActivities.updateCommentActivity).not.toHaveBeenCalled()
-
-    // Verify task still completes successfully
-    expect(mockActivities.updateTaskStatusActivity).toHaveBeenCalledWith({
-      taskId: task.id,
-      status: 'completed',
-      output: { sessionId: 'session-123' },
-    })
   })
 
   it('should collect S3 keys for image attachments from the user comment', async () => {
@@ -315,7 +267,6 @@ describe('Agent Chat Workflow', () => {
       .withPathContext('Path: folder/subfolder/file.png')
       .withAssetDetails('test-file.png', 'image/png', undefined, undefined, 'image')
       .withCommentTimestamp(null)
-      .withExplicitMention(false)
       .build()
 
     expect(mockActivities.agentChatActivity).toHaveBeenCalledWith(
@@ -358,7 +309,6 @@ describe('Agent Chat Workflow', () => {
       .withPathContext('Path: folder/subfolder/file.png')
       .withAssetDetails('test-asset', 'video/mp4', 10)
       .withCommentTimestamp(null)
-      .withExplicitMention(false)
       .build()
 
     expect(mockActivities.agentChatActivity).toHaveBeenCalledWith(
@@ -472,7 +422,6 @@ describe('Agent Chat Workflow', () => {
             prompt: 'chatbot prompt',
             attachedFiles: ['file-attachment-1'],
             assetIds: ['referenced-asset-1'],
-            explicitMention: true,
           },
         },
       },
@@ -490,7 +439,6 @@ describe('Agent Chat Workflow', () => {
       .withPathContext('folder/subfolder/file.png')
       .withAssetDetails('test-file.png', 'image/png', undefined)
       .withCommentTimestamp(undefined)
-      .withExplicitMention(true)
       .withAttachedFiles([
         '- Name: attachment.png (ID: file-attachment-1, Type: file, Media Type: image/png, Project ID: p1, Path: attachment.png)',
       ])
@@ -511,7 +459,6 @@ describe('Agent Chat Workflow', () => {
         sessionId: 'session-direct-123',
         userId: undefined,
         userCommentId: undefined,
-        explicitMention: true,
         context: { agent: { id: 'b1' } },
         attachedAssets: [
           { id: 'file-attachment-1', name: 'attachment.png', type: 'file' },

--- a/packages/agent/src/workflows/agent-chat.ts
+++ b/packages/agent/src/workflows/agent-chat.ts
@@ -14,7 +14,6 @@ export async function agentChat(task: WorkflowTask): Promise<void> {
     updateCommentActivity,
     updateTaskUsageActivity,
     getAgentWorkerQueueActivity,
-    deleteCommentActivity,
     initializeAgentSessionActivity,
     getAssetPathContextActivity,
     generateSessionNameActivity,
@@ -178,7 +177,6 @@ export async function agentChat(task: WorkflowTask): Promise<void> {
       .withPathContext(pathContext)
       .withAssetDetails(asset.name, asset.mediaType, duration, totalPages, proxyType)
       .withCommentTimestamp(commentTimestamp)
-      .withExplicitMention(payload.agent?.explicitMention)
       .withAttachedFiles(attachedFileDetailsList)
       .withReferencedAssets(referencedAssetDetailsList)
 
@@ -208,7 +206,6 @@ export async function agentChat(task: WorkflowTask): Promise<void> {
       sessionId,
       userId: payload.agent?.userId,
       userCommentId: userCommentId || undefined,
-      explicitMention: payload.agent?.explicitMention,
       context,
       attachedAssets,
     })
@@ -227,15 +224,11 @@ export async function agentChat(task: WorkflowTask): Promise<void> {
 
     // 7. Update Placeholder Comment
     if (placeholderCommentId) {
-      if (aiResult.text.trim() === '__NO_REPLY__') {
-        await executeActivity(agentWorkerQueue, deleteCommentActivity, placeholderCommentId)
-      } else {
-        await executeActivity(agentWorkerQueue, updateCommentActivity, {
-          commentId: placeholderCommentId,
-          message: aiResult.text,
-          sessionId: aiResult.sessionId,
-        })
-      }
+      await executeActivity(agentWorkerQueue, updateCommentActivity, {
+        commentId: placeholderCommentId,
+        message: aiResult.text,
+        sessionId: aiResult.sessionId,
+      })
     }
 
     // 8. Update Usage

--- a/packages/core/src/asset/asset.test.ts
+++ b/packages/core/src/asset/asset.test.ts
@@ -1144,7 +1144,6 @@ describe('AssetService', () => {
     const p1 = tasksRule1[0].payload
     expect(p1?.agent?.agentId).toBe(agent.id)
     expect(p1?.agent?.sessionId).toBeUndefined()
-    expect(p1?.agent?.explicitMention).toBe(true)
     expect(p1?.agent?.userId).toBe(user.id)
 
     // Rule 2: user mentions agent in reply, and root is not an agent comment
@@ -1163,7 +1162,6 @@ describe('AssetService', () => {
     const p2 = tasksRule2[0].payload
     expect(p2?.agent?.agentId).toBe(agent.id)
     expect(p2?.agent?.sessionId).toBeUndefined()
-    expect(p2?.agent?.explicitMention).toBe(true)
     expect(p2?.agent?.userId).toBe(user.id)
 
     // Create a root user comment
@@ -1195,7 +1193,7 @@ describe('AssetService', () => {
       },
     })
 
-    // Rule 3a: any user creates a reply directly to the agent comment, no explicit mention
+    // Rule 3a: any user creates a reply directly to the agent comment, no explicit mention -> NO task created
     const reply3a = await assetService.createComment({
       assetId: file.id,
       userId: user.id,
@@ -1216,12 +1214,7 @@ describe('AssetService', () => {
         payload: { path: ['agent', 'userCommentId'], equals: reply3a.id },
       },
     })
-    expect(tasksRule3a.length).toBe(1)
-    const p3a = tasksRule3a[0].payload
-    expect(p3a?.agent?.agentId).toBe(botUser.id)
-    expect(p3a?.agent?.sessionId).toBe('test-session-rule3')
-    expect(p3a?.agent?.explicitMention).toBe(false)
-    expect(p3a?.agent?.userId).toBe(user.id)
+    expect(tasksRule3a.length).toBe(0)
 
     // Rule 3b: any user creates a reply directly to the agent comment, explicitly mentions agent
     const reply3b = await assetService.createComment({
@@ -1248,7 +1241,6 @@ describe('AssetService', () => {
     const p3b = tasksRule3b[0].payload
     expect(p3b?.agent?.agentId).toBe(botUser.id)
     expect(p3b?.agent?.sessionId).toBe('test-session-rule3')
-    expect(p3b?.agent?.explicitMention).toBe(true)
     expect(p3b?.agent?.userId).toBe(user.id)
   })
 

--- a/packages/core/src/asset/asset.ts
+++ b/packages/core/src/asset/asset.ts
@@ -1323,8 +1323,7 @@ export class AssetService {
         const isRootAgent = !!rootSessionId || parentComment.creator?.type === 'agent'
         const rootAgentId = parentComment.creatorId
 
-        if (isRootAgent && rootAgentId) {
-          const explicitMention = mentionedAgentIds.has(rootAgentId)
+        if (isRootAgent && rootAgentId && mentionedAgentIds.has(rootAgentId)) {
           await tx.workflowTask.create({
             data: {
               assetId: a.id,
@@ -1338,7 +1337,6 @@ export class AssetService {
                   userCommentId: comment.id,
                   agentId: rootAgentId,
                   sessionId: rootSessionId || undefined,
-                  explicitMention,
                   userId: req.userId,
                 },
               },
@@ -1373,7 +1371,6 @@ export class AssetService {
                 agent: {
                   userCommentId: comment.id,
                   agentId: agentId,
-                  explicitMention: true,
                   userId: req.userId,
                 },
               },

--- a/packages/core/src/chat/chat.ts
+++ b/packages/core/src/chat/chat.ts
@@ -317,7 +317,6 @@ export class ChatService {
               imageUrls: resolvedImageUrls,
               attachedFiles,
               assetIds,
-              explicitMention: true,
               agentId,
               sessionId: activeSessionId,
               userId: user.id,

--- a/packages/db/src/prisma-json-types.ts
+++ b/packages/db/src/prisma-json-types.ts
@@ -302,7 +302,6 @@ declare global {
       userId?: string
       sessionId?: string
       userCommentId?: string
-      explicitMention?: boolean
       prompt?: string
       imageUrls?: string[]
       attachedFiles?: string[]


### PR DESCRIPTION
## Summary

Removes the implicit agent mention trigger and prompt instructions in comment thread replies so that AI Agents are only triggered when explicitly mentioned by a user (via `<@agent_id>`).

## Changes

- Updated `packages/core/src/asset/asset.ts` to only trigger agent workflow tasks on comment thread replies when the user explicitly `@mentions` the root agent.
- Simplified `AgentChatPromptBuilder` in `packages/agent/src/workflows/agent-chat-prompt-builder.ts` by removing `explicitMention` handling and the `__NO_REPLY__` prompt instruction.
- Simplified `agent-chat.ts` workflow by removing `__NO_REPLY__` comment deletion logic.
- Cleaned up obsolete `explicitMention` fields from payload shapes and activity parameter interfaces across `chat.ts`, `agent.ts` activity, and `prisma-json-types.ts`.
- Updated unit tests in `asset.test.ts`, `agent-chat.test.ts`, and `agent-chat-prompt-builder.test.ts`.

## Verification

- `bun run lint` passed cleanly.
- `bun run format` passed cleanly.
- `bun run typecheck` passed cleanly.
- `bun run test` passed cleanly (716 unit tests).
- `bun run test:e2e:workflow` passed cleanly (42 workflow tests across Local & Temporal executors).
- `bun run test:e2e` passed cleanly (30 Playwright E2E tests across Chromium, Firefox, WebKit).

## Notes

None.