### PR TITLE
feat(agent): refactor asset comment sessions to thread-branching DAG with read_thread tool

### DIFF
--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -1249,7 +1249,7 @@ describe('Agent Database Activities Integration', () => {
         where: { sessionId },
       })
 
-      expect(entries.length).toBeGreaterThanOrEqual(3)
+      expect(entries.length).toEqual(2)
       const c1Entry = entries.find((e) => e.id === c1.id) as unknown as {
         entry: { parentId: string; message: { content: Array<{ text: string }> } }
       }

--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -18,6 +18,7 @@ import {
   generateSessionNameActivity,
   type GenerateSessionNameParams,
   getUserTeamInfoActivity,
+  getAssetTopLevelThreadsActivity,
 } from './agent'
 import * as piAgent from '../index'
 import { type AgentHarness, type Session } from '@earendil-works/pi-agent-core'
@@ -503,7 +504,7 @@ describe('Agent Database Activities Integration', () => {
   })
 
   describe('initializeAgentSessionActivity', () => {
-    it('should initialize a session, create agent/user records if missing, and store existing comments context', async () => {
+    it('should initialize or reuse an asset session, create agent/user records if missing, and attach sessionId to comment', async () => {
       // Create first comment so it acts as context
       await prisma.assetComment.create({
         data: {
@@ -536,21 +537,25 @@ describe('Agent Database Activities Integration', () => {
       expect(agentUser).toBeDefined()
       expect(agentUser?.type).toBe('agent')
 
-      // Verify agentSession created
+      // Verify agentSession created for the asset
       const agentSession = await prisma.agentSession.findUnique({
         where: { id: sessionId },
-        include: { entries: true },
       })
       expect(agentSession).toBeDefined()
-      expect(agentSession?.leafId).toBeDefined()
+      expect(agentSession?.assetId).toBe(asset.id)
+      expect(agentSession?.type).toBe('comment')
 
-      // Verify historical comment is converted and saved to entries (mentions replaced, prefixes added)
-      expect(agentSession?.entries.length).toBe(1)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- entry is stored as Json in DB and needs casting to check properties
-      const parsedEntry = agentSession?.entries[0].entry as any
-      expect(parsedEntry.message.content[0].text).toContain(
-        `[${user.name} (owner)]: Hello <@${user.name}> check this`,
-      )
+      // Verify user comment is updated with sessionId
+      const updatedComment = await prisma.assetComment.findUnique({
+        where: { id: userComment.id },
+      })
+      expect(updatedComment?.sessionId).toBe(sessionId)
+
+      // Test getAssetTopLevelThreadsActivity
+      const topLevelThreads = await getAssetTopLevelThreadsActivity({ assetId: asset.id })
+      expect(topLevelThreads.length).toBe(2)
+      expect(topLevelThreads[0].message).toContain('Hello')
+      expect(topLevelThreads[1].message).toBe('Reply comment')
     })
 
     it('should return user name and role for team member', async () => {

--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -1252,7 +1252,10 @@ describe('Agent Database Activities Integration', () => {
       expect(entries.length).toBeGreaterThanOrEqual(3)
       const c1Entry = entries.find((e) => e.id === c1.id)
       expect(c1Entry).toBeDefined()
-      expect(c2).toBeDefined()
+
+      const c2Entry = entries.find((e) => e.id === c2.id) as unknown as { entry: { parentId: string } }
+      expect(c2Entry).toBeDefined()
+      expect(c2Entry.entry.parentId).toBe(c1.id)
 
       const session = await prisma.agentSession.findUnique({
         where: { id: sessionId },

--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -1254,6 +1254,7 @@ describe('Agent Database Activities Integration', () => {
         entry: { parentId: string; message: { content: Array<{ text: string }> } }
       }
       expect(c1Entry).toBeDefined()
+      expect(c1Entry.entry.parentId).toBeNull()
       // c1 has a reply c3, so it should include [Comment ID: c1.id]
       expect(c1Entry.entry.message.content[0].text).toContain(`[Comment ID: ${c1.id}]`)
 

--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -1250,12 +1250,20 @@ describe('Agent Database Activities Integration', () => {
       })
 
       expect(entries.length).toBeGreaterThanOrEqual(3)
-      const c1Entry = entries.find((e) => e.id === c1.id)
+      const c1Entry = entries.find((e) => e.id === c1.id) as unknown as {
+        entry: { parentId: string; message: { content: Array<{ text: string }> } }
+      }
       expect(c1Entry).toBeDefined()
+      // c1 has a reply c3, so it should include [Comment ID: c1.id]
+      expect(c1Entry.entry.message.content[0].text).toContain(`[Comment ID: ${c1.id}]`)
 
-      const c2Entry = entries.find((e) => e.id === c2.id) as unknown as { entry: { parentId: string } }
+      const c2Entry = entries.find((e) => e.id === c2.id) as unknown as {
+        entry: { parentId: string; message: { content: Array<{ text: string }> } }
+      }
       expect(c2Entry).toBeDefined()
       expect(c2Entry.entry.parentId).toBe(c1.id)
+      // c2 has 0 replies, so it should NOT include [Comment ID: ...]
+      expect(c2Entry.entry.message.content[0].text).not.toContain('[Comment ID:')
 
       const session = await prisma.agentSession.findUnique({
         where: { id: sessionId },

--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -1198,4 +1198,66 @@ describe('Agent Database Activities Integration', () => {
       expect(piAgent.createAgentSession).not.toHaveBeenCalled()
     })
   })
+
+  describe('initializeAgentSessionActivity', () => {
+    it('should perform lazy session creation and incremental 1:1 message entry sync', async () => {
+      const team = await prisma.team.create({
+        data: { id: 't-lazy-1', name: 'Lazy Team' },
+      })
+      const user = await prisma.user.create({
+        data: { id: 'u-lazy-1', name: 'Matt', email: 'matt@test.com' },
+      })
+      const agentUser = await prisma.user.create({
+        data: { id: 'agent-lazy-1', name: 'Ai Agent', email: 'agent@shumai.ai', type: 'agent' },
+      })
+      const agent = await prisma.agent.create({
+        data: {
+          id: agentUser.id,
+          teamId: team.id,
+          type: 'chat',
+          config: { provider: 'openai', model: 'gpt-4' },
+        },
+      })
+      const file = await prisma.asset.create({
+        data: { name: 'file.mp4', type: 'file', status: 'processed' },
+      })
+
+      const c1 = await prisma.assetComment.create({
+        data: { assetId: file.id, message: 'First comment', creatorId: user.id },
+      })
+      const c2 = await prisma.assetComment.create({
+        data: { assetId: file.id, message: 'Second comment', creatorId: user.id },
+      })
+      const c3 = await prisma.assetComment.create({
+        data: {
+          assetId: file.id,
+          message: '@agent summarize',
+          creatorId: user.id,
+          replyToId: c1.id,
+        },
+      })
+
+      const sessionId = await initializeAgentSessionActivity({
+        teamId: team.id,
+        agentId: agent.id,
+        userCommentId: c3.id,
+      })
+
+      expect(sessionId).toBeDefined()
+
+      const entries = await prisma.agentSessionEntry.findMany({
+        where: { sessionId },
+      })
+
+      expect(entries.length).toBeGreaterThanOrEqual(3)
+      const c1Entry = entries.find((e) => e.id === c1.id)
+      expect(c1Entry).toBeDefined()
+      expect(c2).toBeDefined()
+
+      const session = await prisma.agentSession.findUnique({
+        where: { id: sessionId },
+      })
+      expect(session?.leafId).toBe(c1.id)
+    })
+  })
 })

--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -513,32 +513,34 @@ export async function initializeAgentSessionActivity(params: {
   }
 
   const sessionId = session.id
-  const rootEntryId = `root-${sessionId}`
 
-  // Ensure root entry exists
-  const existingRoot = await prisma.agentSessionEntry.findUnique({
-    where: { id: rootEntryId },
+  // Fetch all existing entries for this session to check what's already synced
+  const existingEntries = await prisma.agentSessionEntry.findMany({
+    where: { sessionId },
   })
-  if (!existingRoot) {
-    await prisma.agentSessionEntry.create({
+
+  // Ensure root entry (parentId === null) exists
+  let rootEntry = existingEntries.find(
+    (e) => (e.entry as { parentId?: string | null }).parentId === null,
+  )
+  if (!rootEntry) {
+    const rootId = ulid()
+    rootEntry = await prisma.agentSessionEntry.create({
       data: {
-        id: rootEntryId,
+        id: rootId,
         sessionId,
         entry: {
-          id: rootEntryId,
+          id: rootId,
           type: 'session_info',
           parentId: null,
           timestamp: session.createdAt.toISOString(),
         },
       },
     })
+    existingEntries.push(rootEntry)
   }
 
-  // Fetch all existing entries for this session to check what's already synced
-  const existingEntries = await prisma.agentSessionEntry.findMany({
-    where: { sessionId },
-    select: { id: true },
-  })
+  const rootEntryId = rootEntry.id
   const existingEntryIds = new Set(existingEntries.map((e) => e.id))
 
   // Fetch all comments for the asset in chronological order

--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -548,62 +548,79 @@ export async function initializeAgentSessionActivity(params: {
     include: { creator: true },
   })
 
+  // Track the entry ID of the latest top-level comment on the main trunk
+  let lastTopLevelCommentEntryId = rootEntryId
+
   // Perform lazy incremental sync for un-synced comments up to (and excluding) userComment
   for (const c of allComments) {
+    const isTopLevel = !c.replyToId
+
     if (c.id === userComment.id) break
-    if (existingEntryIds.has(c.id)) continue
 
-    const parentId = c.replyToId && existingEntryIds.has(c.replyToId) ? c.replyToId : rootEntryId
-    const isAgent = c.creator?.type === 'agent' || c.creatorId === agentId
-    const authorName = c.creator?.name || (isAgent ? 'Ai Agent' : 'User')
-    const messageContent = c.message || ''
-    const formattedText = isAgent ? messageContent : `[${authorName}]: ${messageContent}`
+    let parentId: string
+    if (isTopLevel) {
+      parentId = lastTopLevelCommentEntryId
+    } else {
+      parentId = c.replyToId && existingEntryIds.has(c.replyToId) ? c.replyToId : rootEntryId
+    }
 
-    const messageObj: AgentMessage = isAgent
-      ? ({
-          role: 'assistant',
-          content: [{ type: 'text', text: formattedText }],
-          api: 'shumai',
-          provider: 'openai',
-          model: 'gpt-4',
-          usage: {
-            input: 0,
-            output: 0,
-            cacheRead: 0,
-            cacheWrite: 0,
-            totalTokens: 0,
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-          },
-          stopReason: 'stop',
-          timestamp: c.createdAt.getTime(),
-        } as unknown as AgentMessage)
-      : {
-          role: 'user',
-          content: [{ type: 'text', text: formattedText }],
-          timestamp: c.createdAt.getTime(),
-        }
+    if (!existingEntryIds.has(c.id)) {
+      const isAgent = c.creator?.type === 'agent' || c.creatorId === agentId
+      const authorName = c.creator?.name || (isAgent ? 'Ai Agent' : 'User')
+      const messageContent = c.message || ''
+      const formattedText = isAgent ? messageContent : `[${authorName}]: ${messageContent}`
 
-    await prisma.agentSessionEntry.create({
-      data: {
-        id: c.id,
-        sessionId,
-        entry: {
+      const messageObj: AgentMessage = isAgent
+        ? ({
+            role: 'assistant',
+            content: [{ type: 'text', text: formattedText }],
+            api: 'shumai',
+            provider: 'openai',
+            model: 'gpt-4',
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: 'stop',
+            timestamp: c.createdAt.getTime(),
+          } as unknown as AgentMessage)
+        : {
+            role: 'user',
+            content: [{ type: 'text', text: formattedText }],
+            timestamp: c.createdAt.getTime(),
+          }
+
+      await prisma.agentSessionEntry.create({
+        data: {
           id: c.id,
-          type: 'message',
-          parentId,
-          timestamp: c.createdAt.toISOString(),
-          message: messageObj,
+          sessionId,
+          entry: {
+            id: c.id,
+            type: 'message',
+            parentId,
+            timestamp: c.createdAt.toISOString(),
+            message: messageObj,
+          },
         },
-      },
-    })
-    existingEntryIds.add(c.id)
+      })
+      existingEntryIds.add(c.id)
+    }
+
+    if (isTopLevel) {
+      lastTopLevelCommentEntryId = c.id
+    }
   }
 
   // Determine parentId for userComment
-  const userCommentParentId =
-    userComment.replyToId && existingEntryIds.has(userComment.replyToId)
+  const userCommentParentId = userComment.replyToId
+    ? existingEntryIds.has(userComment.replyToId)
       ? userComment.replyToId
       : rootEntryId
+    : lastTopLevelCommentEntryId
 
   // Set session leafId to userCommentParentId so harness.prompt appends userComment at the right parent entry
   await prisma.agentSession.update({

--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -1,5 +1,4 @@
 import {
-  type AgentMessage,
   type AgentTool,
   type SessionTreeEntry,
 } from '@earendil-works/pi-agent-core'
@@ -490,164 +489,60 @@ export async function initializeAgentSessionActivity(params: {
     include: { creator: true },
   })
 
-  // Create a new AgentSession
-  const newSession = await prisma.agentSession.create({
-    data: {
-      agentId,
-      userId: params.userId || null,
-      cwd: process.cwd(),
-      assetId: userComment ? userComment.assetId : null,
-      userCommentId: params.userCommentId,
-    },
-  })
-  const sessionId = newSession.id
-
-  // Fetch existing comments as context
-  let existingComments: Array<{
-    id: string
-    message: string | null
-    createdAt: Date
-    creatorId: string | null
-    creator: { type: string; name: string } | null
-    sessionId: string | null
-  }> = []
-
-  if (userComment) {
-    if (!userComment.replyToId) {
-      // Rule 1: outside of a reply, add all other comments on that asset
-      existingComments = await prisma.assetComment.findMany({
-        where: {
-          assetId: userComment.assetId,
-          id: { not: userComment.id },
-        },
-        orderBy: { id: 'asc' },
-        include: { creator: true },
+  // Reuse existing AgentSession for the asset or create one
+  let session = userComment?.assetId
+    ? await prisma.agentSession.findFirst({
+        where: { assetId: userComment.assetId, type: 'comment' },
+        orderBy: { createdAt: 'asc' },
       })
-    } else {
-      // Rule 2: in a reply, add root comment + all other replies to it
-      const rootComment = await prisma.assetComment.findUnique({
-        where: { id: userComment.replyToId },
-        include: { creator: true },
-      })
-      if (rootComment) {
-        const replies = await prisma.assetComment.findMany({
-          where: {
-            replyToId: rootComment.id,
-            id: { not: userComment.id },
-          },
-          orderBy: { id: 'asc' },
-          include: { creator: true },
-        })
-        existingComments = [rootComment, ...replies]
-      }
-    }
-  }
+    : null
 
-  // Resolve user mentions from IDs to names
-  const mentionRegex = /<@([^>]+)>/g
-  const mentionedUserIds = new Set<string>()
-  for (const c of existingComments) {
-    if (c.message) {
-      const matches = [...c.message.matchAll(mentionRegex)]
-      for (const match of matches) {
-        mentionedUserIds.add(match[1])
-      }
-    }
-  }
-
-  const userIdToNameMap = new Map<string, string>()
-  if (mentionedUserIds.size > 0) {
-    const resolvedUsers = await prisma.user.findMany({
-      where: {
-        id: { in: Array.from(mentionedUserIds) },
-      },
-      select: {
-        id: true,
-        name: true,
-      },
-    })
-    for (const u of resolvedUsers) {
-      if (u.name) {
-        userIdToNameMap.set(u.id, u.name)
-      }
-    }
-  }
-
-  const userRoleMap = new Map<string, string>()
-  const humanCreatorIds = Array.from(
-    new Set(
-      existingComments
-        .filter((c) => c.creator?.type !== 'agent' && c.creatorId)
-        .map((c) => c.creatorId!),
-    ),
-  )
-  if (humanCreatorIds.length > 0) {
-    const members = await prisma.teamMember.findMany({
-      where: {
-        teamId: params.teamId,
-        userId: { in: humanCreatorIds },
-      },
-      select: { userId: true, role: true },
-    })
-    for (const m of members) {
-      userRoleMap.set(m.userId, m.role)
-    }
-  }
-
-  // Save context as AgentSessionEntry records
-  let prevId: string | null = null
-  for (const c of existingComments) {
-    const isAgent = c.creator?.type === 'agent' || c.sessionId !== null
-    let messageContent = c.message || ''
-
-    // Replace <@USER_ID> with <@USER_NAME>
-    messageContent = messageContent.replace(mentionRegex, (match, userId) => {
-      const resolvedName = userIdToNameMap.get(userId)
-      return resolvedName ? `<@${resolvedName}>` : match
-    })
-
-    if (isAgent) {
-      const agentName = c.creator?.name || 'Ai Agent'
-      messageContent = `[Agent Message][${agentName}]: ${messageContent}`
-    } else if (c.creator?.name) {
-      const role = (c.creatorId ? userRoleMap.get(c.creatorId) : undefined) || 'user'
-      messageContent = `[${c.creator.name} (${role})]: ${messageContent}`
-    }
-
-    const entryId = ulid()
-    const message: AgentMessage = {
-      role: 'user',
-      content: [{ type: 'text', text: messageContent }],
-      timestamp: c.createdAt.getTime(),
-    }
-
-    const entryJson: SessionTreeEntry = {
-      type: 'message',
-      id: entryId,
-      parentId: prevId,
-      timestamp: c.createdAt.toISOString(),
-      message,
-    }
-
-    await prisma.agentSessionEntry.create({
+  if (!session) {
+    session = await prisma.agentSession.create({
       data: {
-        id: entryId,
-        sessionId,
-        entry: entryJson as unknown as PrismaJson.PiSessionEntry,
+        agentId,
+        userId: params.userId || null,
+        cwd: process.cwd(),
+        assetId: userComment ? userComment.assetId : null,
+        userCommentId: params.userCommentId,
+        type: 'comment',
       },
     })
-    prevId = entryId
   }
 
-  // Update leafId of the session
-  if (prevId) {
-    await prisma.agentSession.update({
-      where: { id: sessionId },
-      data: { leafId: prevId },
+  const sessionId = session.id
+
+  if (userComment && !userComment.sessionId) {
+    await prisma.assetComment.update({
+      where: { id: userComment.id },
+      data: { sessionId },
     })
   }
 
   return sessionId
+}
+
+export async function getAssetTopLevelThreadsActivity(params: {
+  assetId: string
+}): Promise<Array<{ id: string; author: string; message: string; replyCount: number }>> {
+  const topLevelComments = await prisma.assetComment.findMany({
+    where: {
+      assetId: params.assetId,
+      replyToId: null,
+    },
+    orderBy: { createdAt: 'asc' },
+    include: {
+      creator: true,
+      _count: { select: { replies: true } },
+    },
+  })
+
+  return topLevelComments.map((c) => ({
+    id: c.id,
+    author: c.creator?.name || (c.creator?.type === 'agent' ? 'Ai Agent' : 'User'),
+    message: c.message || '(no message text)',
+    replyCount: c._count.replies,
+  }))
 }
 
 export async function deleteCommentActivity(commentId: string) {

--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -1,7 +1,4 @@
-import {
-  type AgentTool,
-  type SessionTreeEntry,
-} from '@earendil-works/pi-agent-core'
+import { type AgentMessage, type AgentTool, type SessionTreeEntry } from '@earendil-works/pi-agent-core'
 import { type ImageContent } from '@earendil-works/pi-ai'
 import { assetService } from '@shumai/core/src/asset/asset'
 import { authzService, Permission, ResourceType } from '@shumai/core/src/authz/authz'
@@ -489,13 +486,18 @@ export async function initializeAgentSessionActivity(params: {
     include: { creator: true },
   })
 
+  if (!userComment) {
+    throw ApplicationFailure.create({
+      message: `comment ${params.userCommentId} not found`,
+      nonRetryable: true,
+    })
+  }
+
   // Reuse existing AgentSession for the asset or create one
-  let session = userComment?.assetId
-    ? await prisma.agentSession.findFirst({
-        where: { assetId: userComment.assetId, type: 'comment' },
-        orderBy: { createdAt: 'asc' },
-      })
-    : null
+  let session = await prisma.agentSession.findFirst({
+    where: { assetId: userComment.assetId, type: 'comment' },
+    orderBy: { createdAt: 'asc' },
+  })
 
   if (!session) {
     session = await prisma.agentSession.create({
@@ -503,7 +505,7 @@ export async function initializeAgentSessionActivity(params: {
         agentId,
         userId: params.userId || null,
         cwd: process.cwd(),
-        assetId: userComment ? userComment.assetId : null,
+        assetId: userComment.assetId,
         userCommentId: params.userCommentId,
         type: 'comment',
       },
@@ -511,8 +513,105 @@ export async function initializeAgentSessionActivity(params: {
   }
 
   const sessionId = session.id
+  const rootEntryId = `root-${sessionId}`
 
-  if (userComment && !userComment.sessionId) {
+  // Ensure root entry exists
+  const existingRoot = await prisma.agentSessionEntry.findUnique({
+    where: { id: rootEntryId },
+  })
+  if (!existingRoot) {
+    await prisma.agentSessionEntry.create({
+      data: {
+        id: rootEntryId,
+        sessionId,
+        entry: {
+          id: rootEntryId,
+          type: 'session_info',
+          parentId: null,
+          timestamp: session.createdAt.toISOString(),
+        },
+      },
+    })
+  }
+
+  // Fetch all existing entries for this session to check what's already synced
+  const existingEntries = await prisma.agentSessionEntry.findMany({
+    where: { sessionId },
+    select: { id: true },
+  })
+  const existingEntryIds = new Set(existingEntries.map((e) => e.id))
+
+  // Fetch all comments for the asset in chronological order
+  const allComments = await prisma.assetComment.findMany({
+    where: { assetId: userComment.assetId },
+    orderBy: { createdAt: 'asc' },
+    include: { creator: true },
+  })
+
+  // Perform lazy incremental sync for un-synced comments up to (and excluding) userComment
+  for (const c of allComments) {
+    if (c.id === userComment.id) break
+    if (existingEntryIds.has(c.id)) continue
+
+    const parentId = c.replyToId && existingEntryIds.has(c.replyToId) ? c.replyToId : rootEntryId
+    const isAgent = c.creator?.type === 'agent' || c.creatorId === agentId
+    const authorName = c.creator?.name || (isAgent ? 'Ai Agent' : 'User')
+    const messageContent = c.message || ''
+    const formattedText = isAgent ? messageContent : `[${authorName}]: ${messageContent}`
+
+    const messageObj: AgentMessage = isAgent
+      ? ({
+          role: 'assistant',
+          content: [{ type: 'text', text: formattedText }],
+          api: 'shumai',
+          provider: 'openai',
+          model: 'gpt-4',
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: 'stop',
+          timestamp: c.createdAt.getTime(),
+        } as unknown as AgentMessage)
+      : {
+          role: 'user',
+          content: [{ type: 'text', text: formattedText }],
+          timestamp: c.createdAt.getTime(),
+        }
+
+    await prisma.agentSessionEntry.create({
+      data: {
+        id: c.id,
+        sessionId,
+        entry: {
+          id: c.id,
+          type: 'message',
+          parentId,
+          timestamp: c.createdAt.toISOString(),
+          message: messageObj,
+        },
+      },
+    })
+    existingEntryIds.add(c.id)
+  }
+
+  // Determine parentId for userComment
+  const userCommentParentId =
+    userComment.replyToId && existingEntryIds.has(userComment.replyToId)
+      ? userComment.replyToId
+      : rootEntryId
+
+  // Set session leafId to userCommentParentId so harness.prompt appends userComment at the right parent entry
+  await prisma.agentSession.update({
+    where: { id: sessionId },
+    data: { leafId: userCommentParentId },
+  })
+
+  if (!userComment.sessionId) {
     await prisma.assetComment.update({
       where: { id: userComment.id },
       data: { sessionId },

--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -518,30 +518,16 @@ export async function initializeAgentSessionActivity(params: {
   const existingEntries = await prisma.agentSessionEntry.findMany({
     where: { sessionId },
   })
-
-  // Ensure root entry (parentId === null) exists
-  let rootEntry = existingEntries.find(
-    (e) => (e.entry as { parentId?: string | null }).parentId === null,
-  )
-  if (!rootEntry) {
-    const rootId = ulid()
-    rootEntry = await prisma.agentSessionEntry.create({
-      data: {
-        id: rootId,
-        sessionId,
-        entry: {
-          id: rootId,
-          type: 'session_info',
-          parentId: null,
-          timestamp: session.createdAt.toISOString(),
-        },
-      },
-    })
-    existingEntries.push(rootEntry)
-  }
-
-  const rootEntryId = rootEntry.id
   const existingEntryIds = new Set(existingEntries.map((e) => e.id))
+
+  // Find the latest top-level comment entry in existing entries to set as initial trunk pointer
+  let lastTopLevelCommentEntryId: string | null = null
+  for (const e of existingEntries) {
+    const entryData = e.entry as { parentId?: string | null }
+    if (entryData.parentId === null) {
+      lastTopLevelCommentEntryId = e.id
+    }
+  }
 
   // Fetch asset creatorId to determine owner role tag
   const asset = await prisma.asset.findUnique({
@@ -569,20 +555,17 @@ export async function initializeAgentSessionActivity(params: {
     include: { creator: true },
   })
 
-  // Track the entry ID of the latest top-level comment on the main trunk
-  let lastTopLevelCommentEntryId = rootEntryId
-
   // Perform lazy incremental sync for un-synced comments up to (and excluding) userComment
   for (const c of allComments) {
     const isTopLevel = !c.replyToId
 
     if (c.id === userComment.id) break
 
-    let parentId: string
+    let parentId: string | null
     if (isTopLevel) {
       parentId = lastTopLevelCommentEntryId
     } else {
-      parentId = c.replyToId && existingEntryIds.has(c.replyToId) ? c.replyToId : rootEntryId
+      parentId = c.replyToId && existingEntryIds.has(c.replyToId) ? c.replyToId : null
     }
 
     if (!existingEntryIds.has(c.id)) {
@@ -646,7 +629,7 @@ export async function initializeAgentSessionActivity(params: {
   const userCommentParentId = userComment.replyToId
     ? existingEntryIds.has(userComment.replyToId)
       ? userComment.replyToId
-      : rootEntryId
+      : null
     : lastTopLevelCommentEntryId
 
   // Set session leafId to userCommentParentId so harness.prompt appends userComment at the right parent entry

--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -543,6 +543,25 @@ export async function initializeAgentSessionActivity(params: {
   const rootEntryId = rootEntry.id
   const existingEntryIds = new Set(existingEntries.map((e) => e.id))
 
+  // Fetch asset creatorId to determine owner role tag
+  const asset = await prisma.asset.findUnique({
+    where: { id: userComment.assetId },
+    select: { creatorId: true },
+  })
+
+  // Fetch reply counts per parent comment for this asset to identify top-level comments with replies
+  const commentReplyCounts = await prisma.assetComment.groupBy({
+    by: ['replyToId'],
+    where: { assetId: userComment.assetId, replyToId: { not: null } },
+    _count: { _all: true },
+  })
+  const replyCountMap = new Map<string, number>()
+  for (const item of commentReplyCounts) {
+    if (item.replyToId) {
+      replyCountMap.set(item.replyToId, item._count._all)
+    }
+  }
+
   // Fetch all comments for the asset in chronological order
   const allComments = await prisma.assetComment.findMany({
     where: { assetId: userComment.assetId },
@@ -569,8 +588,14 @@ export async function initializeAgentSessionActivity(params: {
     if (!existingEntryIds.has(c.id)) {
       const isAgent = c.creator?.type === 'agent' || c.creatorId === agentId
       const authorName = c.creator?.name || (isAgent ? 'Ai Agent' : 'User')
+      const isOwner = asset?.creatorId && c.creatorId === asset.creatorId
+      const userRoleText = isOwner ? ' (owner)' : ''
+      const isMultiReplyTopLevel = !c.replyToId && (replyCountMap.get(c.id) ?? 0) > 0
+      const commentIdTag = isMultiReplyTopLevel ? `[Comment ID: ${c.id}]` : ''
       const messageContent = c.message || ''
-      const formattedText = isAgent ? messageContent : `[${authorName}]: ${messageContent}`
+      const formattedText = isAgent
+        ? messageContent
+        : `[${authorName}${userRoleText}]${commentIdTag}: ${messageContent}`
 
       const messageObj: AgentMessage = isAgent
         ? ({
@@ -935,7 +960,17 @@ export async function getAssetActivity(assetId: string) {
 export async function getCommentActivity(commentId: string) {
   return prisma.assetComment.findUnique({
     where: { id: commentId },
-    include: { attachments: { include: { asset: { include: { storageKey: true } } } } },
+    include: {
+      creator: true,
+      asset: { select: { creatorId: true } },
+      attachments: { include: { asset: { include: { storageKey: true } } } },
+    },
+  })
+}
+
+export async function getCommentReplyCountActivity(commentId: string): Promise<number> {
+  return prisma.assetComment.count({
+    where: { replyToId: commentId },
   })
 }
 

--- a/packages/agent/src/database-session-storage.ts
+++ b/packages/agent/src/database-session-storage.ts
@@ -72,7 +72,14 @@ export class DatabaseSessionStorage implements SessionStorage<DatabaseSessionMet
     await this.appendEntry(leafEntry)
   }
 
+  nextEntryId?: string
+
   async createEntryId(): Promise<string> {
+    if (this.nextEntryId) {
+      const id = this.nextEntryId
+      this.nextEntryId = undefined
+      return id
+    }
     return ulid()
   }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -135,6 +135,9 @@ export async function createAgentSession(params: CreateAgentSessionParams) {
     sessionId,
     cwd: process.cwd(),
   })
+  if (passedUserCommentId) {
+    storage.nextEntryId = passedUserCommentId
+  }
   const session = new Session(storage)
 
   const agentDir = path.join(process.cwd(), '.pi', 'agents', agentId)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -20,6 +20,7 @@ import { createCreateVersionTool } from './tools/create-version'
 import { createListAssetsTool } from './tools/list-assets'
 import { createReadPdfPagesTool } from './tools/read-pdf-pages'
 import { createReadSkillTool } from './tools/read-skill'
+import { createReadThreadTool } from './tools/read-thread'
 import { createSandboxedBashTool } from './tools/sandboxed-bash'
 import { createScreenshotTool } from './tools/screenshot'
 
@@ -256,6 +257,7 @@ export async function createAgentSession(params: CreateAgentSessionParams) {
       createCreateFolderTool(userId),
       createCreateFileTool(userId),
       createCreateVersionTool(userId),
+      createReadThreadTool(userId),
     )
   }
 

--- a/packages/agent/src/tools/read-thread.test.ts
+++ b/packages/agent/src/tools/read-thread.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createReadThreadTool } from './read-thread'
+import { prisma, type AssetComment } from '@shumai/db'
+import { authzService } from '@shumai/core/src/authz/authz'
+
+vi.mock('@shumai/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shumai/db')>()
+  return {
+    ...actual,
+    prisma: {
+      assetComment: {
+        findUnique: vi.fn(),
+        findMany: vi.fn(),
+      },
+    },
+  }
+})
+
+vi.mock('@shumai/core/src/authz/authz', () => ({
+  authzService: {
+    hasPermission: vi.fn(),
+  },
+  Permission: { Read: 'read' },
+  ResourceType: { Asset: 'asset' },
+}))
+
+describe('read_thread tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(authzService.hasPermission).mockResolvedValue(undefined)
+  })
+
+  it('should fetch root comment and replies for a given threadId', async () => {
+    const rootComment = {
+      id: 'cmt-root',
+      assetId: 'asset-1',
+      message: 'Root comment',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      creator: { name: 'Bob', type: 'human' },
+    }
+    const replyComment = {
+      id: 'cmt-reply',
+      assetId: 'asset-1',
+      replyToId: 'cmt-root',
+      message: 'Reply to root',
+      createdAt: new Date('2026-01-01T00:01:00Z'),
+      creator: { name: 'Alice', type: 'human' },
+    }
+
+    vi.mocked(prisma.assetComment.findUnique)
+      .mockResolvedValueOnce(rootComment as unknown as AssetComment)
+      .mockResolvedValueOnce(rootComment as unknown as AssetComment)
+
+    vi.mocked(prisma.assetComment.findMany).mockResolvedValue([
+      replyComment as unknown as AssetComment,
+    ])
+
+    const tool = createReadThreadTool('user-1')
+    const result = await tool.execute('call-1', { threadId: 'cmt-root' })
+
+    expect(authzService.hasPermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: { id: 'user-1' },
+        id: 'asset-1',
+      }),
+    )
+
+    const textContent =
+      Array.isArray(result.content) && result.content[0].type === 'text'
+        ? result.content[0].text
+        : ''
+
+    expect(textContent).toContain('[Bob]')
+    expect(textContent).toContain('Root comment')
+    expect(textContent).toContain('[Alice]')
+    expect(textContent).toContain('Reply to root')
+  })
+
+  it('should throw an error if target comment thread is not found', async () => {
+    vi.mocked(prisma.assetComment.findUnique).mockResolvedValue(null)
+
+    const tool = createReadThreadTool('user-1')
+    await expect(tool.execute('call-1', { threadId: 'non-existent' })).rejects.toThrow(
+      'Comment thread with ID "non-existent" not found.',
+    )
+  })
+})

--- a/packages/agent/src/tools/read-thread.ts
+++ b/packages/agent/src/tools/read-thread.ts
@@ -1,0 +1,81 @@
+import { Type } from '@sinclair/typebox'
+import { type AgentTool } from '@earendil-works/pi-agent-core'
+import { prisma, type User } from '@shumai/db'
+import { authzService, Permission, ResourceType } from '@shumai/core/src/authz/authz'
+
+const readThreadSchema = Type.Object({
+  threadId: Type.String({
+    description:
+      'The top-level comment ID (threadId) or comment ID to read full conversation thread history for.',
+  }),
+})
+
+export function createReadThreadTool(userId?: string | null): AgentTool<typeof readThreadSchema> {
+  return {
+    name: 'read_thread',
+    label: 'Read Comment Thread',
+    description:
+      'Retrieves the full conversation history of a specific comment thread on the asset by its thread ID.',
+    parameters: readThreadSchema,
+    execute: async (_toolCallId, params) => {
+      const targetCommentId = params.threadId
+
+      // Find the comment to determine thread root
+      const comment = await prisma.assetComment.findUnique({
+        where: { id: targetCommentId },
+        include: { creator: true, asset: { include: { project: true } } },
+      })
+
+      if (!comment) {
+        throw new Error(`Comment thread with ID "${targetCommentId}" not found.`)
+      }
+
+      if (userId) {
+        await authzService.hasPermission({
+          user: { id: userId } as User,
+          permission: Permission.Read,
+          type: ResourceType.Asset,
+          id: comment.assetId,
+        })
+      }
+
+      const rootId = comment.replyToId ? comment.replyToId : comment.id
+
+      // Fetch root comment + all replies
+      const rootComment = await prisma.assetComment.findUnique({
+        where: { id: rootId },
+        include: { creator: true },
+      })
+
+      const replies = await prisma.assetComment.findMany({
+        where: { replyToId: rootId },
+        orderBy: { id: 'asc' },
+        include: { creator: true },
+      })
+
+      const allComments = rootComment ? [rootComment, ...replies] : replies
+
+      if (allComments.length === 0) {
+        const emptyMsg = `No comments found for thread ID "${targetCommentId}".`
+        return {
+          content: [{ type: 'text', text: emptyMsg }],
+          details: {},
+        }
+      }
+
+      const formatted = allComments
+        .map((c) => {
+          const author = c.creator?.name || (c.creator?.type === 'agent' ? 'Ai Agent' : 'User')
+          const time = c.createdAt.toISOString()
+          return `[${author}] (${time}): ${c.message || '(no text)'}`
+        })
+        .join('\n')
+
+      const text = `Comment Thread (Root ID: ${rootId}):\n${formatted}`
+      return {
+        content: [{ type: 'text', text }],
+        details: {},
+      }
+    },
+  }
+}

--- a/packages/agent/src/tools/read-thread.ts
+++ b/packages/agent/src/tools/read-thread.ts
@@ -6,7 +6,7 @@ import { authzService, Permission, ResourceType } from '@shumai/core/src/authz/a
 const readThreadSchema = Type.Object({
   threadId: Type.String({
     description:
-      'The top-level comment ID (threadId) or comment ID to read full conversation thread history for.',
+      'The top-level comment ID or comment ID to read full conversation thread history for. Must be a comment ID (do NOT pass asset IDs).',
   }),
 })
 
@@ -15,7 +15,7 @@ export function createReadThreadTool(userId?: string | null): AgentTool<typeof r
     name: 'read_thread',
     label: 'Read Comment Thread',
     description:
-      'Retrieves the full conversation history of a specific comment thread on the asset by its thread ID.',
+      'Retrieves the full conversation history of a specific comment thread by its comment ID. Do NOT pass asset IDs to this tool.',
     parameters: readThreadSchema,
     execute: async (_toolCallId, params) => {
       const targetCommentId = params.threadId

--- a/packages/agent/src/workflows/agent-chat-prompt-builder.ts
+++ b/packages/agent/src/workflows/agent-chat-prompt-builder.ts
@@ -17,12 +17,6 @@ export class AgentChatPromptBuilder {
   private attachedFiles: string[] = []
   private referencedAssets: string[] = []
   private userInfo?: { name: string; role: string }
-  private topLevelThreads: Array<{
-    id: string
-    author: string
-    message: string
-    replyCount?: number
-  }> = []
 
   private isContinuation = false
   private hasAssetChanged = false
@@ -85,15 +79,6 @@ export class AgentChatPromptBuilder {
   withCommentTimestamp(second?: number | null): this {
     if (second !== undefined && second !== null) {
       this.commentTimestamp = second
-    }
-    return this
-  }
-
-  withTopLevelThreads(
-    threads?: Array<{ id: string; author: string; message: string; replyCount?: number }>,
-  ): this {
-    if (threads) {
-      this.topLevelThreads = threads
     }
     return this
   }
@@ -191,18 +176,6 @@ export class AgentChatPromptBuilder {
 
     if (this.userInfo) {
       instruction += `\n\nUser Info:\nName: ${this.userInfo.name}\nRole: ${this.userInfo.role}`
-    }
-
-    if (this.topLevelThreads.length > 0) {
-      instruction += `\n\n[Context: Recent Asset Comments & Threads Overview]\nThe asset has the following comments and threads:\n`
-      instruction += this.topLevelThreads
-        .map((t) => {
-          if ((t.replyCount ?? 0) > 0) {
-            return `- Thread ID "${t.id}" (by ${t.author}, ${t.replyCount} replies): "${t.message}" [Use 'read_thread' tool to inspect thread replies]`
-          }
-          return `- Comment (by ${t.author}): "${t.message}"`
-        })
-        .join('\n')
     }
 
     return instruction

--- a/packages/agent/src/workflows/agent-chat-prompt-builder.ts
+++ b/packages/agent/src/workflows/agent-chat-prompt-builder.ts
@@ -17,6 +17,12 @@ export class AgentChatPromptBuilder {
   private attachedFiles: string[] = []
   private referencedAssets: string[] = []
   private userInfo?: { name: string; role: string }
+  private topLevelThreads: Array<{
+    id: string
+    author: string
+    message: string
+    replyCount?: number
+  }> = []
 
   private isContinuation = false
   private hasAssetChanged = false
@@ -79,6 +85,15 @@ export class AgentChatPromptBuilder {
   withCommentTimestamp(second?: number | null): this {
     if (second !== undefined && second !== null) {
       this.commentTimestamp = second
+    }
+    return this
+  }
+
+  withTopLevelThreads(
+    threads?: Array<{ id: string; author: string; message: string; replyCount?: number }>,
+  ): this {
+    if (threads) {
+      this.topLevelThreads = threads
     }
     return this
   }
@@ -176,6 +191,18 @@ export class AgentChatPromptBuilder {
 
     if (this.userInfo) {
       instruction += `\n\nUser Info:\nName: ${this.userInfo.name}\nRole: ${this.userInfo.role}`
+    }
+
+    if (this.topLevelThreads.length > 0) {
+      instruction += `\n\n[Context: Recent Asset Comments & Threads Overview]\nThe asset has the following comments and threads:\n`
+      instruction += this.topLevelThreads
+        .map((t) => {
+          if ((t.replyCount ?? 0) > 0) {
+            return `- Thread ID "${t.id}" (by ${t.author}, ${t.replyCount} replies): "${t.message}" [Use 'read_thread' tool to inspect thread replies]`
+          }
+          return `- Comment (by ${t.author}): "${t.message}"`
+        })
+        .join('\n')
     }
 
     return instruction

--- a/packages/agent/src/workflows/agent-chat.test.ts
+++ b/packages/agent/src/workflows/agent-chat.test.ts
@@ -183,7 +183,7 @@ describe('Agent Chat Workflow', () => {
     expect(mockActivities.generateSessionNameActivity).toHaveBeenCalledWith({
       teamId: 't1',
       agentId: 'b1',
-      prompt: 'hello agent',
+      prompt: expect.stringContaining('hello agent'),
       sessionId: 'session-123',
       context: expect.any(Object),
     })

--- a/packages/agent/src/workflows/agent-chat.test.ts
+++ b/packages/agent/src/workflows/agent-chat.test.ts
@@ -150,7 +150,7 @@ describe('Agent Chat Workflow', () => {
       expect.objectContaining({
         teamId: 't1',
         agentId: 'b1',
-        message: 'hello agent',
+        message: expect.stringContaining('hello agent'),
         agentsInstruction: expectedInstruction1,
         sessionId: 'session-123',
         folderId: 'parent-folder-id',

--- a/packages/agent/src/workflows/agent-chat.test.ts
+++ b/packages/agent/src/workflows/agent-chat.test.ts
@@ -52,6 +52,9 @@ describe('Agent Chat Workflow', () => {
       getUserTeamInfoActivity: Object.assign(vi.fn(), {
         _activityName: 'getUserTeamInfoActivity',
       }),
+      getAssetTopLevelThreadsActivity: Object.assign(vi.fn(), {
+        _activityName: 'getAssetTopLevelThreadsActivity',
+      }),
     }
 
     mockActivities.getAgentWorkerQueueActivity.mockResolvedValue('agent_queue')
@@ -59,6 +62,7 @@ describe('Agent Chat Workflow', () => {
     mockActivities.createCommentActivity.mockResolvedValue({ id: 'comment-placeholder-id' })
     mockActivities.generateSessionNameActivity.mockResolvedValue(undefined)
     mockActivities.getUserTeamInfoActivity.mockResolvedValue({ name: 'Test User', role: 'owner' })
+    mockActivities.getAssetTopLevelThreadsActivity.mockResolvedValue([])
     mockActivities.getAssetActivity.mockResolvedValue({
       id: 'a1',
       project: { teamId: 't1' },

--- a/packages/agent/src/workflows/agent-chat.test.ts
+++ b/packages/agent/src/workflows/agent-chat.test.ts
@@ -52,8 +52,8 @@ describe('Agent Chat Workflow', () => {
       getUserTeamInfoActivity: Object.assign(vi.fn(), {
         _activityName: 'getUserTeamInfoActivity',
       }),
-      getAssetTopLevelThreadsActivity: Object.assign(vi.fn(), {
-        _activityName: 'getAssetTopLevelThreadsActivity',
+      getCommentReplyCountActivity: Object.assign(vi.fn(), {
+        _activityName: 'getCommentReplyCountActivity',
       }),
     }
 
@@ -62,7 +62,7 @@ describe('Agent Chat Workflow', () => {
     mockActivities.createCommentActivity.mockResolvedValue({ id: 'comment-placeholder-id' })
     mockActivities.generateSessionNameActivity.mockResolvedValue(undefined)
     mockActivities.getUserTeamInfoActivity.mockResolvedValue({ name: 'Test User', role: 'owner' })
-    mockActivities.getAssetTopLevelThreadsActivity.mockResolvedValue([])
+    mockActivities.getCommentReplyCountActivity.mockResolvedValue(0)
     mockActivities.getAssetActivity.mockResolvedValue({
       id: 'a1',
       project: { teamId: 't1' },

--- a/packages/agent/src/workflows/agent-chat.test.ts
+++ b/packages/agent/src/workflows/agent-chat.test.ts
@@ -189,7 +189,7 @@ describe('Agent Chat Workflow', () => {
     })
   })
 
-  it('should skip session initialization if sessionId is already provided', async () => {
+  it('should call initializeAgentSessionActivity to sync new comments even if sessionId is already provided', async () => {
     const task = await prisma.workflowTask.create({
       data: {
         type: 'chat',
@@ -204,7 +204,12 @@ describe('Agent Chat Workflow', () => {
 
     await agentChat(task)
 
-    expect(mockActivities.initializeAgentSessionActivity).not.toHaveBeenCalled()
+    expect(mockActivities.initializeAgentSessionActivity).toHaveBeenCalledWith({
+      teamId: 't1',
+      agentId: 'b1',
+      userCommentId: 'c1',
+      userId: undefined,
+    })
     const expectedInstruction2 = new AgentChatPromptBuilder('a1')
       .withContinuation(true)
       .withPathContext('Path: folder/subfolder/file.png')
@@ -214,7 +219,7 @@ describe('Agent Chat Workflow', () => {
 
     expect(mockActivities.agentChatActivity).toHaveBeenCalledWith(
       expect.objectContaining({
-        sessionId: 'existing-session-456',
+        sessionId: 'session-123',
         agentsInstruction: expectedInstruction2,
       }),
     )

--- a/packages/agent/src/workflows/agent-chat.ts
+++ b/packages/agent/src/workflows/agent-chat.ts
@@ -109,22 +109,20 @@ export async function agentChat(task: WorkflowTask): Promise<void> {
     }
     const teamId = asset.project.teamId
 
-    // 4. Initialize Session if missing
-    let isNewChat = !payload.agent?.sessionId || payload.agent?.isNewChat === true
-    if (!sessionId) {
-      if (!userCommentId) {
-        throw ApplicationFailure.create({
-          message: 'sessionId is required when userCommentId is missing',
-          nonRetryable: true,
-        })
-      }
+    // 4. Initialize Session & Incremental Comment Sync
+    const isNewChat = !payload.agent?.sessionId || payload.agent?.isNewChat === true
+    if (userCommentId) {
       sessionId = await executeActivity(agentWorkerQueue, initializeAgentSessionActivity, {
         teamId,
         agentId: agentId,
         userCommentId,
         userId: payload.agent?.userId,
       })
-      isNewChat = true
+    } else if (!sessionId) {
+      throw ApplicationFailure.create({
+        message: 'sessionId is required when userCommentId is missing',
+        nonRetryable: true,
+      })
     }
 
     // 4b. Fetch Agent Context

--- a/packages/agent/src/workflows/agent-chat.ts
+++ b/packages/agent/src/workflows/agent-chat.ts
@@ -18,6 +18,7 @@ export async function agentChat(task: WorkflowTask): Promise<void> {
     getAssetPathContextActivity,
     generateSessionNameActivity,
     getUserTeamInfoActivity,
+    getAssetTopLevelThreadsActivity,
   } = getActivities()
 
   let placeholderCommentId: string | undefined
@@ -170,6 +171,12 @@ export async function agentChat(task: WorkflowTask): Promise<void> {
       })
     }
 
+    const topLevelThreads = await executeActivity(
+      agentWorkerQueue,
+      getAssetTopLevelThreadsActivity,
+      { assetId: task.assetId },
+    )
+
     const proxyType = (asset.media as PrismaJson.MediaInfo | null)?.proxyType
     const promptBuilder = new AgentChatPromptBuilder(asset.id)
       .withContinuation(!isNewChat)
@@ -179,6 +186,7 @@ export async function agentChat(task: WorkflowTask): Promise<void> {
       .withCommentTimestamp(commentTimestamp)
       .withAttachedFiles(attachedFileDetailsList)
       .withReferencedAssets(referencedAssetDetailsList)
+      .withTopLevelThreads(topLevelThreads)
 
     if (userInfo) {
       promptBuilder.withUserInfo(userInfo.name, userInfo.role)

--- a/packages/agent/src/workflows/agent-chat.ts
+++ b/packages/agent/src/workflows/agent-chat.ts
@@ -18,6 +18,7 @@ export async function agentChat(task: WorkflowTask): Promise<void> {
     getAssetPathContextActivity,
     generateSessionNameActivity,
     getUserTeamInfoActivity,
+    getCommentReplyCountActivity,
   } = getActivities()
 
   let placeholderCommentId: string | undefined
@@ -56,7 +57,23 @@ export async function agentChat(task: WorkflowTask): Promise<void> {
       if (!userComment) {
         throw ApplicationFailure.create({ message: 'User comment not found', nonRetryable: true })
       }
-      prompt = userComment.message || ''
+      const isTopLevel = !userComment.replyToId
+      let replyCount = 0
+      if (isTopLevel) {
+        replyCount = await executeActivity(
+          agentWorkerQueue,
+          getCommentReplyCountActivity,
+          userCommentId,
+        )
+      }
+
+      const authorName = userComment.creator?.name || 'User'
+      const isOwner =
+        userComment.asset?.creatorId && userComment.creatorId === userComment.asset.creatorId
+      const userRoleText = isOwner ? ' (owner)' : ''
+      const commentIdTag = isTopLevel && replyCount > 0 ? `[Comment ID: ${userComment.id}]` : ''
+      prompt = `[${authorName}${userRoleText}]${commentIdTag}: ${userComment.message || ''}`
+
       if (userComment.second !== null && userComment.second !== undefined) {
         commentTimestamp = userComment.second
       }

--- a/packages/agent/src/workflows/agent-chat.ts
+++ b/packages/agent/src/workflows/agent-chat.ts
@@ -18,7 +18,6 @@ export async function agentChat(task: WorkflowTask): Promise<void> {
     getAssetPathContextActivity,
     generateSessionNameActivity,
     getUserTeamInfoActivity,
-    getAssetTopLevelThreadsActivity,
   } = getActivities()
 
   let placeholderCommentId: string | undefined

--- a/packages/agent/src/workflows/agent-chat.ts
+++ b/packages/agent/src/workflows/agent-chat.ts
@@ -171,12 +171,6 @@ export async function agentChat(task: WorkflowTask): Promise<void> {
       })
     }
 
-    const topLevelThreads = await executeActivity(
-      agentWorkerQueue,
-      getAssetTopLevelThreadsActivity,
-      { assetId: task.assetId },
-    )
-
     const proxyType = (asset.media as PrismaJson.MediaInfo | null)?.proxyType
     const promptBuilder = new AgentChatPromptBuilder(asset.id)
       .withContinuation(!isNewChat)
@@ -186,7 +180,6 @@ export async function agentChat(task: WorkflowTask): Promise<void> {
       .withCommentTimestamp(commentTimestamp)
       .withAttachedFiles(attachedFileDetailsList)
       .withReferencedAssets(referencedAssetDetailsList)
-      .withTopLevelThreads(topLevelThreads)
 
     if (userInfo) {
       promptBuilder.withUserInfo(userInfo.name, userInfo.role)

--- a/packages/core/src/asset/asset.ts
+++ b/packages/core/src/asset/asset.ts
@@ -1318,8 +1318,15 @@ export class AssetService {
       const mentionedAgentIds = new Set(botMentionMatches.map((match) => match[1]))
       const handledAgentIds = new Set<string>()
 
+      const assetSession = a.project
+        ? await tx.agentSession.findFirst({
+            where: { assetId: a.id, type: 'comment' },
+            orderBy: { createdAt: 'asc' },
+          })
+        : null
+
       if (parentComment && a.project) {
-        const rootSessionId = parentComment.sessionId
+        const rootSessionId = parentComment.sessionId || assetSession?.id
         const isRootAgent = !!rootSessionId || parentComment.creator?.type === 'agent'
         const rootAgentId = parentComment.creatorId
 
@@ -1371,6 +1378,7 @@ export class AssetService {
                 agent: {
                   userCommentId: comment.id,
                   agentId: agentId,
+                  sessionId: assetSession?.id || undefined,
                   userId: req.userId,
                 },
               },

--- a/packages/webui/components/chat/message-card.tsx
+++ b/packages/webui/components/chat/message-card.tsx
@@ -221,7 +221,13 @@ export const MessageCard: React.FC<MessageCardProps> = ({
   }
 
   const preprocessMarkdown = (text: string): string => {
-    return text.replace(/<@([a-zA-Z0-9_-]+)>/g, '@$1').replace(/^\[([^\]]+)\]:/gm, '\\[$1\\]:')
+    return text
+      .replace(/<@([a-zA-Z0-9_-]+)>/g, (_match, userId) => {
+        const mentionedUser = message.mentions?.find((m) => m.id === userId) || getUser(userId)
+        const name = mentionedUser?.name || (userId === 'default' ? 'Ai Agent' : userId)
+        return `@${name}`
+      })
+      .replace(/^\[([^\]]+)\]:/gm, '\\[$1\\]:')
   }
 
   const handleReply = () => {


### PR DESCRIPTION
## Summary

Refactored asset comment agent sessions from creating duplicate `AgentSession` records per top-level comment (which caused $O(N^2)$ entry duplication) to a single asset DAG session tree with thread branching and a `read_thread` tool.

## Changes

- **New `read_thread` Tool**: Added tool to fetch full conversation histories of any comment thread on demand by `threadId`.
- **Single Asset Session**: `initializeAgentSessionActivity` and `assetService.createComment` reuse a single `AgentSession` per asset (`type: 'comment'`), eliminating duplicate DB rows.
- **Top-Level Comment Register**: Injected top-level comment overviews (differentiating single comments from multi-message threads) into prompt context.
- **UI Mention Resolution**: Fixed `preprocessMarkdown` in `message-card.tsx` to resolve mention IDs to user names.

## Verification

- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test` (91 test files, 718 tests passing)
