### PR TITLE
ci(workflow): add docker compose deployment verification job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,3 +161,45 @@ jobs:
 
       - name: Run Workflow E2E Tests
         run: bun run test:e2e:workflow
+
+  docker_compose_deploy:
+    name: Docker Compose Deployment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker Image
+        run: |
+          docker build -t shumaione/shumai:latest .
+
+      - name: Start Docker Compose
+        run: |
+          docker compose -f docker-compose/local/docker-compose.yaml up -d
+
+      - name: Verify Home Page HTTP 200
+        run: |
+          echo "Waiting for shumai_app container to start..."
+          for i in {1..30}; do
+            STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000 || true)
+            echo "Attempt $i: HTTP status code $STATUS_CODE"
+            if [ "$STATUS_CODE" -eq 200 ]; then
+              echo "✅ Docker compose app is running cleanly (HTTP 200 OK)"
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "❌ Container failed to respond with HTTP 200 OK within 60s"
+          echo "--- Container Logs ---"
+          docker compose -f docker-compose/local/docker-compose.yaml logs
+          exit 1
+
+      - name: Cleanup Docker Compose
+        if: always()
+        run: |
+          docker compose -f docker-compose/local/docker-compose.yaml down -v
+


### PR DESCRIPTION
## Summary

Adds a Docker Compose deployment verification job to GitHub Actions CI to ensure containerized builds start cleanly and serve the home page without runtime startup errors or 5xx crashes.

## Changes

- Added `docker_compose_deploy` job to [.github/workflows/ci.yaml](file:///.github/workflows/ci.yaml).
- Job builds the production Docker image via `docker buildx` and starts the local Postgres & Shumai stack via `docker compose`.
- Includes a retry loop (up to 60s) curling `http://localhost:3000` to verify HTTP 200 OK.
- Dumps container logs on failure for immediate diagnostic visibility in CI.

## Verification

- Tested locally against fixed codebase: Docker image built cleanly, `shumai_postgres` and `shumai_app` started, and `curl` verified `HTTP 200 OK`.
- Verified against `v0.2.3` codebase: confirmed that the CI check correctly detected container crash (`TypeError: undefined is not an object`) and reported failure (`HTTP 000`).
- Ran `bun run lint` and `bun run typecheck`.

## Notes

This prevents regressions where backend module refactoring breaks top-level synchronous imports or C++ native addon path resolutions in containerized environments.