### PR TITLE
fix(agent): resolve S3 MIME type detection and prompt parameter in image analysis

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -202,4 +202,3 @@ jobs:
         if: always()
         run: |
           docker compose -f docker-compose/local/docker-compose.yaml down -v
-

--- a/packages/agent/src/tools/analyze-image.ts
+++ b/packages/agent/src/tools/analyze-image.ts
@@ -106,11 +106,14 @@ export function createAnalyzeImageTool(
       const bucket = process.env.S3_BUCKET || 'shumai'
       const { buffer, contentType } = await s3Service.getObject(bucket, keyToUse)
 
+      const mimeType =
+        contentType && contentType !== 'application/octet-stream' ? contentType : 'image/webp'
+
       const content: ImageContent[] = [
         {
           type: 'image',
           data: buffer.toString('base64'),
-          mimeType: contentType || 'image/webp',
+          mimeType,
         },
       ]
 

--- a/packages/agent/src/tools/read-pdf-pages.ts
+++ b/packages/agent/src/tools/read-pdf-pages.ts
@@ -121,10 +121,12 @@ export function createReadPdfPagesTool(
 
       for (const pageItem of pages) {
         const { buffer, contentType } = await s3Service.getObject(bucket, pageItem.key)
+        const mimeType =
+          contentType && contentType !== 'application/octet-stream' ? contentType : 'image/webp'
         content.push({
           type: 'image',
           data: buffer.toString('base64'),
-          mimeType: contentType || 'image/webp',
+          mimeType,
         })
         sourceKeys.push(pageItem.key)
       }

--- a/packages/agent/src/tools/screenshot.ts
+++ b/packages/agent/src/tools/screenshot.ts
@@ -102,10 +102,12 @@ export function createScreenshotTool(
 
       for (const shot of screenshots) {
         const { buffer, contentType } = await s3Service.getObject(bucket, shot.key)
+        const mimeType =
+          contentType && contentType !== 'application/octet-stream' ? contentType : 'image/webp'
         content.push({
           type: 'image',
           data: buffer.toString('base64'),
-          mimeType: contentType || 'image/webp',
+          mimeType,
         })
         sourceKeys.push(shot.key)
       }

--- a/packages/agent/src/workflows/agent-chat-prompt-builder.ts
+++ b/packages/agent/src/workflows/agent-chat-prompt-builder.ts
@@ -166,7 +166,7 @@ export class AgentChatPromptBuilder {
     if (effectiveType) {
       const type = getSimpleMediaType(effectiveType)
       if (type === 'image') {
-        instruction += `\n\nIf you need to view the image data, call the 'analyze_image' tool. It does not require any parameters.`
+        instruction += `\n\nIf you need to view the image data, call the 'analyze_image' tool with assetId "${this.assetId}".`
       } else if (type === 'video') {
         instruction += `\n\nIf you need to view visual frames or take screenshots of the video, call the 'screenshot' tool. You must specify the 'start' (seconds), 'end' (seconds), and 'count' (number of screenshots) parameters.`
       } else if (type === 'pdf') {

--- a/packages/core/src/chat/chat.test.ts
+++ b/packages/core/src/chat/chat.test.ts
@@ -351,49 +351,49 @@ describe('ChatService', () => {
       },
     })
 
-      // 2. Manually insert a test entry representing a custom context message
-      await prisma.agentSessionEntry.create({
+    // 2. Manually insert a test entry representing a custom context message
+    await prisma.agentSessionEntry.create({
+      data: {
+        id: 'test-entry-2-context',
+        sessionId,
+        type: 'custom_message',
+        parentId: 'test-entry-1-user',
         data: {
-          id: 'test-entry-2-context',
-          sessionId,
-          type: 'custom_message',
-          parentId: 'test-entry-1-user',
-          data: {
-            customType: 'context',
-            content: 'some context',
-            display: 'chat',
-          } as PrismaJson.PiSessionEntryData,
-        },
-      })
+          customType: 'context',
+          content: 'some context',
+          display: 'chat',
+        } as PrismaJson.PiSessionEntryData,
+      },
+    })
 
-      // 3. Manually insert a test entry representing a custom thinking level change
-      await prisma.agentSessionEntry.create({
+    // 3. Manually insert a test entry representing a custom thinking level change
+    await prisma.agentSessionEntry.create({
+      data: {
+        id: 'test-entry-3-thinking',
+        sessionId,
+        type: 'thinking_level_change',
+        parentId: 'test-entry-2-context',
         data: {
-          id: 'test-entry-3-thinking',
-          sessionId,
-          type: 'thinking_level_change',
-          parentId: 'test-entry-2-context',
-          data: {
-            thinkingLevel: 'deep',
-          } as PrismaJson.PiSessionEntryData,
-        },
-      })
+          thinkingLevel: 'deep',
+        } as PrismaJson.PiSessionEntryData,
+      },
+    })
 
-      // 4. Manually insert a test entry representing custom context_display_info entry
-      await prisma.agentSessionEntry.create({
+    // 4. Manually insert a test entry representing custom context_display_info entry
+    await prisma.agentSessionEntry.create({
+      data: {
+        id: 'test-entry-4-display',
+        sessionId,
+        type: 'custom',
+        parentId: 'test-entry-3-thinking',
         data: {
-          id: 'test-entry-4-display',
-          sessionId,
-          type: 'custom',
-          parentId: 'test-entry-3-thinking',
+          customType: 'context_display_info',
           data: {
-            customType: 'context_display_info',
-            data: {
-              assets: [{ id: 'a1', name: 'File A', type: 'file' }],
-            },
-          } as PrismaJson.PiSessionEntryData,
-        },
-      })
+            assets: [{ id: 'a1', name: 'File A', type: 'file' }],
+          },
+        } as PrismaJson.PiSessionEntryData,
+      },
+    })
 
     await prisma.agentSession.update({
       where: { id: sessionId },

--- a/packages/core/src/s3/s3.ts
+++ b/packages/core/src/s3/s3.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { ulid } from 'ulid'
 import { LruTtlCache } from '../cache/lru-ttl-cache'
+import { detectSupportedMimeType } from '../utils/mime'
 
 export function signLocalUrl(bucket: string, key: string): string {
   const secret = process.env.BETTER_AUTH_SECRET || 'shumai-local-storage-secret'
@@ -99,9 +100,22 @@ export class S3StorageService implements S3Service {
   async getObject(bucket: string, key: string): Promise<S3Object> {
     const file = this.client.file(key, { bucket })
     const arrayBuffer = await file.arrayBuffer()
+    const buffer = Buffer.from(arrayBuffer)
+    let contentType = file.type
+    if (!contentType || contentType === 'application/octet-stream') {
+      const detected = detectSupportedMimeType(buffer)
+      if (detected) {
+        contentType = detected
+      } else {
+        const fileType = Bun.file(key).type
+        if (fileType && fileType !== 'application/octet-stream') {
+          contentType = fileType
+        }
+      }
+    }
     return {
-      buffer: Buffer.from(arrayBuffer),
-      contentType: file.type || 'application/octet-stream',
+      buffer,
+      contentType: contentType || 'application/octet-stream',
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes an issue where image analysis (`analyze_image` tool) returns incorrect or generic answers when using S3 storage (`STORAGE_BACKEND='s3'`). S3 storage objects were returning `contentType: 'application/octet-stream'`, causing AI vision models to fail decoding image payloads.

## Changes

- **S3 MIME Type Resolution (`packages/core/src/s3/s3.ts`)**: Updated `S3StorageService.getObject` to inspect file magic bytes via `detectSupportedMimeType` and fallback to `Bun.file(key).type` when `file.type` is missing or `'application/octet-stream'`.
- **Tool MIME Type Handling (`packages/agent/src/tools/`)**: Ensured `analyze-image.ts`, `read-pdf-pages.ts`, and `screenshot.ts` fallback from `'application/octet-stream'` to `'image/webp'`.
- **Prompt Builder Instruction (`packages/agent/src/workflows/agent-chat-prompt-builder.ts`)**: Updated system prompt instruction for `analyze_image` to include the required `assetId` parameter.

## Verification

- `bun run lint` (Passed with 0 warnings/errors)
- `bun run format` (Passed cleanly)
- `bun run typecheck` (Passed cleanly)
- `bun run test` (Passed 722 tests across 91 test files)
- `bun run test:e2e` (Passed 30 Playwright E2E tests)
- `bun run test:e2e:workflow` (Passed 42 workflow tests)

## Notes

No breaking changes introduced.