### PR TITLE
fix(agent): update session user_id when initializing thread sessions

### DIFF
--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -659,6 +659,67 @@ describe('Agent Database Activities Integration', () => {
       expect(text).toContain(`[Thread ID: ${msg3.id}]`)
     })
 
+    it('reproduces bug: should assign correct user_id to thread session when user2 asks in the thread', async () => {
+      const user2 = await prisma.user.create({
+        data: {
+          name: 'Test Human 2',
+          email: 'human2@shumai.ai',
+          type: 'human',
+        },
+      })
+
+      // msg1 (top-level comment by user1)
+      const msg1 = await prisma.assetComment.create({
+        data: { assetId: asset.id, message: 'msg1', creatorId: user.id },
+      })
+
+      // msg3 (user1 asks agent in thread)
+      const msg3 = await prisma.assetComment.create({
+        data: {
+          assetId: asset.id,
+          message: 'msg3 ask agent',
+          creatorId: user.id,
+          replyToId: msg1.id,
+        },
+      })
+
+      const session1Id = await initializeAgentSessionActivity({
+        teamId: team.id,
+        agentId: 'test-agent-id',
+        userCommentId: msg3.id,
+        userId: user.id,
+      })
+
+      const session1 = await prisma.agentSession.findUnique({
+        where: { id: session1Id },
+      })
+      expect(session1?.userId).toBe(user.id)
+
+      // msg5 (user2 asks agent in the SAME thread)
+      const msg5 = await prisma.assetComment.create({
+        data: {
+          assetId: asset.id,
+          message: 'msg5 ask agent',
+          creatorId: user2.id,
+          replyToId: msg1.id,
+        },
+      })
+
+      const session2Id = await initializeAgentSessionActivity({
+        teamId: team.id,
+        agentId: 'test-agent-id',
+        userCommentId: msg5.id,
+        userId: user2.id,
+      })
+
+      const session2 = await prisma.agentSession.findUnique({
+        where: { id: session2Id },
+      })
+
+      // The thread session returned for msg5 asked by user2 should have userId set to user2
+      expect(session2?.userId).toBe(user2.id)
+    })
+
     it('should return user name and role for team member', async () => {
       const info = await getUserTeamInfoActivity({
         userId: user.id,

--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -1,7 +1,7 @@
 import {
-    type AgentMessage,
-    type AgentTool,
-    type SessionTreeEntry,
+  type AgentMessage,
+  type AgentTool,
+  type SessionTreeEntry,
 } from '@earendil-works/pi-agent-core'
 import { type ImageContent } from '@earendil-works/pi-ai'
 import { assetService } from '@shumai/core/src/asset/asset'
@@ -19,10 +19,10 @@ import { generateKeyBetween } from 'jittered-fractional-indexing'
 import { ulid } from 'ulid'
 import { DatabaseSessionStorage } from '../database-session-storage'
 import {
-    createAgentSession,
-    fieldsToTypeBoxSchema,
-    type AutofillField,
-    type DbProviderInfo,
+  createAgentSession,
+  fieldsToTypeBoxSchema,
+  type AutofillField,
+  type DbProviderInfo,
 } from '../index'
 
 import { aiUsageService } from '@shumai/core/src/ai-usage/ai-usage'
@@ -498,6 +498,8 @@ export async function initializeAgentSessionActivity(params: {
   const rootCommentId = userComment.replyToId || userComment.id
   const targetUserCommentId = isThread ? rootCommentId : null
 
+  const targetUserId = params.userId || userComment.creatorId || null
+
   let session = await prisma.agentSession.findFirst({
     where: {
       assetId: userComment.assetId,
@@ -510,12 +512,17 @@ export async function initializeAgentSessionActivity(params: {
     session = await prisma.agentSession.create({
       data: {
         agentId,
-        userId: params.userId || null,
+        userId: targetUserId,
         cwd: process.cwd(),
         assetId: userComment.assetId,
         userCommentId: targetUserCommentId,
         type: 'comment',
       },
+    })
+  } else if (targetUserId && session.userId !== targetUserId) {
+    session = await prisma.agentSession.update({
+      where: { id: session.id },
+      data: { userId: targetUserId },
     })
   }
   const sessionId = session.id

--- a/packages/agent/src/database-session-storage.ts
+++ b/packages/agent/src/database-session-storage.ts
@@ -354,6 +354,12 @@ export class DatabaseSessionStorage implements SessionStorage<DatabaseSessionMet
     userCommentId?: string
   }): Promise<DatabaseSessionStorage> {
     if (params.sessionId) {
+      if (params.userId) {
+        await prisma.agentSession.updateMany({
+          where: { id: params.sessionId, NOT: { userId: params.userId } },
+          data: { userId: params.userId },
+        })
+      }
       return new DatabaseSessionStorage(params.sessionId)
     } else {
       const session = await prisma.agentSession.create({


### PR DESCRIPTION
## Summary

Fixes a bug where agent comment thread sessions retained the `userId` of the initial user who created the session, causing subsequent agent interactions by other users in the thread to reuse the original user's ID on the session database record.

## Changes

- Updated `initializeAgentSessionActivity` in `packages/agent/src/activities/agent.ts` to update `userId` on an existing `AgentSession` if the current prompt requester differs from the session's recorded `userId`.
- Updated `DatabaseSessionStorage.create` in `packages/agent/src/database-session-storage.ts` to update `userId` on existing sessions when instantiated with explicit `sessionId` and `userId`.
- Added reproduction test in `packages/agent/src/activities/agent.test.ts` verifying that thread sessions reflect the user who triggered the turn.

## Verification

- Ran `bun run test packages/agent/src/activities/agent.test.ts` (25 passed).
- Ran `bun run lint` (0 errors).
- Ran `bun run format` (all files formatted).
- Ran `bun run typecheck` (0 errors).
- Ran `bun run test` (91 test files, 728 tests passed).
- Ran `bun run test:e2e:workflow` (11 test files, 42 tests passed).

## Notes

No breaking changes.