### PR TITLE
fix(agent): scope agent comment sessions to thread sessions anchored at root comments

### DIFF
--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -572,48 +572,49 @@ describe('Agent Database Activities Integration', () => {
         },
       })
 
-      // 3. Initialize session for mention on mainComment2 (Main Session)
-      const mainSessionId = await initializeAgentSessionActivity({
+      // 3. Initialize session for mention on mainComment2 (creates Thread Session for mainComment2)
+      const threadSession2Id = await initializeAgentSessionActivity({
         teamId: team.id,
         agentId: 'test-agent-id',
         userCommentId: mainComment2.id,
         userId: user.id,
       })
 
-      const mainSession = await prisma.agentSession.findUnique({
-        where: { id: mainSessionId },
+      const threadSession2 = await prisma.agentSession.findUnique({
+        where: { id: threadSession2Id },
       })
-      expect(mainSession?.userCommentId).toBeNull() // Main Session has userCommentId = null
+      expect(threadSession2?.userCommentId).toBe(mainComment2.id)
+
+      // Main Session (userCommentId: null) is created during lazy sync
+      const mainSession = await prisma.agentSession.findFirst({
+        where: { assetId: asset.id, type: 'comment', userCommentId: null },
+      })
+      expect(mainSession).toBeDefined()
+      expect(mainSession?.userCommentId).toBeNull()
 
       // Retrieve main session entries
       const mainEntries = await prisma.agentSessionEntry.findMany({
-        where: { sessionId: mainSessionId },
+        where: { sessionId: mainSession!.id },
         orderBy: { createdAt: 'asc' },
       })
 
-      // Main session contains mainComment1, but NOT threadReply1
-      expect(mainEntries.length).toBe(1)
-      expect(mainEntries[0].id).toBe(mainComment1.id)
+      // Main session contains mainComment1 and mainComment2, but NOT threadReply1
+      expect(mainEntries.length).toBe(2)
+      expect(mainEntries[0].id).toContain(mainComment1.id)
+      expect(mainEntries[1].id).toContain(mainComment2.id)
 
-      const mainStorage = new DatabaseSessionStorage(mainSessionId)
-      const mainLeafId = await mainStorage.getLeafId()
-      const mainPath = await mainStorage.getPathToRoot(mainLeafId)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const mainText = (mainPath[0] as any).message.content[0].text
-      expect(mainText).toContain(`[Thread ID: ${mainComment1.id}]`)
-
-      // 4. Initialize session for mention on threadReply1 (Thread Session)
-      const threadSessionId = await initializeAgentSessionActivity({
+      // 4. Initialize session for mention on threadReply1 (Thread Session for mainComment1)
+      const threadSession1Id = await initializeAgentSessionActivity({
         teamId: team.id,
         agentId: 'test-agent-id',
         userCommentId: threadReply1.id,
         userId: user.id,
       })
 
-      const threadSession = await prisma.agentSession.findUnique({
-        where: { id: threadSessionId },
+      const threadSession1 = await prisma.agentSession.findUnique({
+        where: { id: threadSession1Id },
       })
-      expect(threadSession?.userCommentId).toBe(mainComment1.id) // Thread Session has userCommentId = rootComment.id
+      expect(threadSession1?.userCommentId).toBe(mainComment1.id) // Thread Session has userCommentId = rootComment.id
     })
 
     it('should dynamically tag top-level comments with [Thread ID: id] even if thread was created after initial sync', async () => {
@@ -621,7 +622,7 @@ describe('Agent Database Activities Integration', () => {
         data: { assetId: asset.id, message: 'Question in msg3', creatorId: user.id },
       })
 
-      const session1Id = await initializeAgentSessionActivity({
+      await initializeAgentSessionActivity({
         teamId: team.id,
         agentId: 'test-agent-id',
         userCommentId: msg3.id,
@@ -648,15 +649,98 @@ describe('Agent Database Activities Integration', () => {
         userId: user.id,
       })
 
-      const storage = new DatabaseSessionStorage(session1Id)
+      // Check main session where top-level comments are stored
+      const mainSession = await prisma.agentSession.findFirst({
+        where: { assetId: asset.id, type: 'comment', userCommentId: null },
+      })
+      expect(mainSession).toBeDefined()
+
+      const storage = new DatabaseSessionStorage(mainSession!.id)
       const leafId = await storage.getLeafId()
       const pathEntries = await storage.getPathToRoot(leafId)
 
-      const msg3Entry = pathEntries.find((e) => e.id === msg3.id)
+      const msg3Entry = pathEntries.find((e) => e.id.includes(msg3.id))
       expect(msg3Entry).toBeDefined()
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const text = (msg3Entry as any).message.content[0].text
       expect(text).toContain(`[Thread ID: ${msg3.id}]`)
+    })
+
+    it('should create separate thread sessions when agent is mentioned in top-level comments (msg3 & msg5) and reuse session on thread follow-ups', async () => {
+      // msg1 (top level)
+      await prisma.assetComment.create({
+        data: { assetId: asset.id, message: 'msg1', creatorId: user.id },
+      })
+      // msg2 (top level)
+      await prisma.assetComment.create({
+        data: { assetId: asset.id, message: 'msg2', creatorId: user.id },
+      })
+      // msg3 (top level asking agent)
+      const msg3 = await prisma.assetComment.create({
+        data: { assetId: asset.id, message: '[ask agent] msg3', creatorId: user.id },
+      })
+
+      // Initialize session for msg3
+      const session3Id = await initializeAgentSessionActivity({
+        teamId: team.id,
+        agentId: 'test-agent-id',
+        userCommentId: msg3.id,
+        userId: user.id,
+      })
+
+      // agent response msg4
+      await prisma.assetComment.create({
+        data: {
+          assetId: asset.id,
+          message: 'msg4',
+          creatorId: 'test-agent-id',
+          replyToId: msg3.id,
+          sessionId: session3Id,
+        },
+      })
+
+      // msg5 (top level asking agent)
+      const msg5 = await prisma.assetComment.create({
+        data: { assetId: asset.id, message: '[ask agent] msg5', creatorId: user.id },
+      })
+
+      // Initialize session for msg5
+      const session5Id = await initializeAgentSessionActivity({
+        teamId: team.id,
+        agentId: 'test-agent-id',
+        userCommentId: msg5.id,
+        userId: user.id,
+      })
+
+      const session3 = await prisma.agentSession.findUnique({ where: { id: session3Id } })
+      const session5 = await prisma.agentSession.findUnique({ where: { id: session5Id } })
+
+      // Thread Session 1 anchored at msg3.id
+      expect(session3?.userCommentId).toBe(msg3.id)
+      // Thread Session 2 anchored at msg5.id
+      expect(session5?.userCommentId).toBe(msg5.id)
+      // They should be distinct sessions
+      expect(session3Id).not.toBe(session5Id)
+
+      // msg7 (reply to msg3 asking agent again)
+      const msg7 = await prisma.assetComment.create({
+        data: {
+          assetId: asset.id,
+          message: '[ask agent again] msg7',
+          creatorId: user.id,
+          replyToId: msg3.id,
+        },
+      })
+
+      const session7Id = await initializeAgentSessionActivity({
+        teamId: team.id,
+        agentId: 'test-agent-id',
+        userCommentId: msg7.id,
+        userId: user.id,
+      })
+
+      // Reuses session3Id (Thread Session 1)
+      expect(session7Id).toBe(session3Id)
     })
 
     it('should return user name and role for team member', async () => {

--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -546,7 +546,7 @@ describe('Agent Database Activities Integration', () => {
       // Verify historical comment is converted and saved to DAG entries via path traversal
       const storage = new DatabaseSessionStorage(sessionId)
       const pathEntries = await storage.getPathToRoot(agentSession!.leafId)
-      expect(pathEntries.length).toBe(2)
+      expect(pathEntries.length).toBe(1)
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- entry data is stored as Json in DB and needs casting to check properties
       const parsedEntry = pathEntries[0] as any
@@ -594,16 +594,15 @@ describe('Agent Database Activities Integration', () => {
       expect(mainSession).toBeDefined()
       expect(mainSession?.userCommentId).toBeNull()
 
-      // Retrieve main session entries
+      // Retrieve main session entries (contains top-level comments prior to mainComment2)
       const mainEntries = await prisma.agentSessionEntry.findMany({
         where: { sessionId: mainSession!.id },
         orderBy: { createdAt: 'asc' },
       })
 
-      // Main session contains mainComment1 and mainComment2, but NOT threadReply1
-      expect(mainEntries.length).toBe(2)
+      // Main session contains mainComment1, but NOT threadReply1 or mainComment2 (which is appended by piAgent.prompt)
+      expect(mainEntries.length).toBe(1)
       expect(mainEntries[0].id).toContain(mainComment1.id)
-      expect(mainEntries[1].id).toContain(mainComment2.id)
 
       // 4. Initialize session for mention on threadReply1 (Thread Session for mainComment1)
       const threadSession1Id = await initializeAgentSessionActivity({
@@ -748,10 +747,8 @@ describe('Agent Database Activities Integration', () => {
       // Every shared comment must have EXACTLY 1 row in agent_session_entries with id = comment.id
       const msg1Entries = await prisma.agentSessionEntry.findMany({ where: { id: msg1.id } })
       const msg2Entries = await prisma.agentSessionEntry.findMany({ where: { id: msg2.id } })
-      const msg3Entries = await prisma.agentSessionEntry.findMany({ where: { id: msg3.id } })
       expect(msg1Entries.length).toBe(1)
       expect(msg2Entries.length).toBe(1)
-      expect(msg3Entries.length).toBe(1)
 
       // Verify DatabaseSessionStorage path traversal for session 3 vs session 5
       const storage3 = new DatabaseSessionStorage(session3Id)
@@ -759,18 +756,55 @@ describe('Agent Database Activities Integration', () => {
       const path3Ids = path3.map((e) => e.id)
       expect(path3Ids).toContain(msg1.id)
       expect(path3Ids).toContain(msg2.id)
-      expect(path3Ids).toContain(msg3.id)
       expect(path3Ids).toContain(msg4.id)
       expect(path3Ids).not.toContain(msg5.id)
 
       const storage5 = new DatabaseSessionStorage(session5Id)
-      const path5 = await storage5.getPathToRoot(msg5.id)
+      const path5 = await storage5.getPathToRoot(session5!.leafId!)
       const path5Ids = path5.map((e) => e.id)
       expect(path5Ids).toContain(msg1.id)
       expect(path5Ids).toContain(msg2.id)
-      expect(path5Ids).toContain(msg3.id)
-      expect(path5Ids).toContain(msg5.id)
       expect(path5Ids).not.toContain(msg4.id)
+    })
+
+    it('should set thread session leafId to preceding comment so userComment is not pre-inserted before piAgent.prompt runs', async () => {
+      // msg1 (top level)
+      const msg1 = await prisma.assetComment.create({
+        data: { assetId: asset.id, message: 'msg1', creatorId: user.id },
+      })
+      // msg2 (top level)
+      const msg2 = await prisma.assetComment.create({
+        data: { assetId: asset.id, message: 'msg2', creatorId: user.id },
+      })
+      // msg3 (top level asking agent)
+      const msg3 = await prisma.assetComment.create({
+        data: { assetId: asset.id, message: '<@shumai-x1> what did i say', creatorId: user.id },
+      })
+
+      const sessionId = await initializeAgentSessionActivity({
+        teamId: team.id,
+        agentId: 'test-agent-id',
+        userCommentId: msg3.id,
+        userId: user.id,
+      })
+
+      const threadSession = await prisma.agentSession.findUnique({
+        where: { id: sessionId },
+      })
+
+      // The leafId for the thread session MUST be msg2.id (preceding comment), NOT msg3.id,
+      // because piAgent.prompt(msg3.message) will append msg3 as the active user message prompt.
+      expect(threadSession?.leafId).toBe(msg2.id)
+
+      const storage = new DatabaseSessionStorage(sessionId)
+      const pathEntries = await storage.getPathToRoot(threadSession!.leafId)
+      const pathIds = pathEntries.map((e) => e.id)
+
+      // Context history before prompt runs contains msg1 and msg2
+      expect(pathIds).toContain(msg1.id)
+      expect(pathIds).toContain(msg2.id)
+      // msg3 is not pre-inserted in the session history prior to piAgent.prompt running
+      expect(pathIds).not.toContain(msg3.id)
     })
 
     it('should return user name and role for team member', async () => {

--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -597,7 +597,7 @@ describe('Agent Database Activities Integration', () => {
       // Retrieve main session entries (contains top-level comments mainComment1 and mainComment2)
       const mainEntries = await prisma.agentSessionEntry.findMany({
         where: { sessionId: mainSession!.id },
-        orderBy: { createdAt: 'asc' },
+        orderBy: { id: 'asc' },
       })
 
       // Main session contains mainComment1 and mainComment2, but NOT threadReply1
@@ -876,6 +876,37 @@ describe('Agent Database Activities Integration', () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any -- testing mock entry casting
         } as any),
       ).resolves.not.toThrow()
+    })
+
+    it('should not tag Thread ID when only __CHAT__ placeholder comment exists under root comment', async () => {
+      const rootComment = await prisma.assetComment.create({
+        data: { assetId: asset.id, message: 'Root comment asking agent', creatorId: user.id },
+      })
+      // Create placeholder comment under rootComment
+      await prisma.assetComment.create({
+        data: {
+          assetId: asset.id,
+          message: '__CHAT__',
+          creatorId: user.id,
+          replyToId: rootComment.id,
+        },
+      })
+
+      const sessionId = await initializeAgentSessionActivity({
+        teamId: team.id,
+        agentId: 'test-agent-id',
+        userCommentId: rootComment.id,
+        userId: user.id,
+      })
+
+      const storage = new DatabaseSessionStorage(sessionId)
+      const pathEntries = await storage.getPathToRoot(rootComment.id)
+      const rootEntry = pathEntries.find((e) => e.id === rootComment.id)
+
+      expect(rootEntry).toBeDefined()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- entry data structure parsing
+      const content = (rootEntry as any)?.message?.content?.[0]?.text || ''
+      expect(content).not.toContain(`[Thread ID: ${rootComment.id}]`)
     })
 
     it('should return user name and role for team member', async () => {

--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -844,6 +844,40 @@ describe('Agent Database Activities Integration', () => {
       expect(mainPathIds).toContain(msg3.id)
     })
 
+    it('should safely upsert entry without unique constraint error when appendEntry is called for pre-existing userComment.id', async () => {
+      const msg3 = await prisma.assetComment.create({
+        data: { assetId: asset.id, message: '<@shumai-x1> what did i say', creatorId: user.id },
+      })
+
+      const sessionId = await initializeAgentSessionActivity({
+        teamId: team.id,
+        agentId: 'test-agent-id',
+        userCommentId: msg3.id,
+        userId: user.id,
+      })
+
+      const storage = new DatabaseSessionStorage(sessionId)
+      storage.nextEntryId = msg3.id
+
+      const entryId = await storage.createEntryId()
+      expect(entryId).toBe(msg3.id)
+
+      // appendEntry should upsert msg3.id without throwing unique constraint error
+      await expect(
+        storage.appendEntry({
+          id: entryId,
+          type: 'message',
+          parentId: null,
+          timestamp: new Date().toISOString(),
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text: 'Updated content' }],
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- testing mock entry casting
+        } as any),
+      ).resolves.not.toThrow()
+    })
+
     it('should return user name and role for team member', async () => {
       const info = await getUserTeamInfoActivity({
         userId: user.id,

--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -665,7 +665,7 @@ describe('Agent Database Activities Integration', () => {
       expect(msg3Entry).toBeDefined()
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const text = (msg3Entry as any).message.content[0].text
-      expect(text).toContain(`[Thread ID: ${msg3.id}]`)
+      expect(text).toContain(`[Thread ID: ${msg3.id}] [Replies: 1]`)
     })
 
     it('should create separate thread sessions when agent is mentioned in top-level comments (msg3 & msg5) sharing DAG entries without duplication', async () => {

--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -546,7 +546,7 @@ describe('Agent Database Activities Integration', () => {
       // Verify historical comment is converted and saved to DAG entries via path traversal
       const storage = new DatabaseSessionStorage(sessionId)
       const pathEntries = await storage.getPathToRoot(agentSession!.leafId)
-      expect(pathEntries.length).toBe(1)
+      expect(pathEntries.length).toBe(2)
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- entry data is stored as Json in DB and needs casting to check properties
       const parsedEntry = pathEntries[0] as any
@@ -594,15 +594,16 @@ describe('Agent Database Activities Integration', () => {
       expect(mainSession).toBeDefined()
       expect(mainSession?.userCommentId).toBeNull()
 
-      // Retrieve main session entries (contains top-level comments prior to mainComment2)
+      // Retrieve main session entries (contains top-level comments mainComment1 and mainComment2)
       const mainEntries = await prisma.agentSessionEntry.findMany({
         where: { sessionId: mainSession!.id },
         orderBy: { createdAt: 'asc' },
       })
 
-      // Main session contains mainComment1, but NOT threadReply1 or mainComment2 (which is appended by piAgent.prompt)
-      expect(mainEntries.length).toBe(1)
+      // Main session contains mainComment1 and mainComment2, but NOT threadReply1
+      expect(mainEntries.length).toBe(2)
       expect(mainEntries[0].id).toContain(mainComment1.id)
+      expect(mainEntries[1].id).toContain(mainComment2.id)
 
       // 4. Initialize session for mention on threadReply1 (Thread Session for mainComment1)
       const threadSession1Id = await initializeAgentSessionActivity({
@@ -767,7 +768,7 @@ describe('Agent Database Activities Integration', () => {
       expect(path5Ids).not.toContain(msg4.id)
     })
 
-    it('should set thread session leafId to preceding comment so userComment is not pre-inserted before piAgent.prompt runs', async () => {
+    it('should set thread session leafId to rootComment.id including preceding top-level comments', async () => {
       // msg1 (top level)
       const msg1 = await prisma.assetComment.create({
         data: { assetId: asset.id, message: 'msg1', creatorId: user.id },
@@ -792,19 +793,55 @@ describe('Agent Database Activities Integration', () => {
         where: { id: sessionId },
       })
 
-      // The leafId for the thread session MUST be msg2.id (preceding comment), NOT msg3.id,
-      // because piAgent.prompt(msg3.message) will append msg3 as the active user message prompt.
-      expect(threadSession?.leafId).toBe(msg2.id)
+      // The leafId for the thread session is msg3.id
+      expect(threadSession?.leafId).toBe(msg3.id)
 
       const storage = new DatabaseSessionStorage(sessionId)
       const pathEntries = await storage.getPathToRoot(threadSession!.leafId)
       const pathIds = pathEntries.map((e) => e.id)
 
-      // Context history before prompt runs contains msg1 and msg2
+      // Context history contains msg1, msg2, and msg3
       expect(pathIds).toContain(msg1.id)
       expect(pathIds).toContain(msg2.id)
-      // msg3 is not pre-inserted in the session history prior to piAgent.prompt running
-      expect(pathIds).not.toContain(msg3.id)
+      expect(pathIds).toContain(msg3.id)
+    })
+
+    it('should include top-level agent mention comment in Main Session top-level DAG timeline', async () => {
+      // msg1 (top level)
+      const msg1 = await prisma.assetComment.create({
+        data: { assetId: asset.id, message: 'msg1', creatorId: user.id },
+      })
+      // msg2 (top level)
+      const msg2 = await prisma.assetComment.create({
+        data: { assetId: asset.id, message: 'msg2', creatorId: user.id },
+      })
+      // msg3 (top level asking agent)
+      const msg3 = await prisma.assetComment.create({
+        data: { assetId: asset.id, message: '<@shumai-x1> what did i say', creatorId: user.id },
+      })
+
+      await initializeAgentSessionActivity({
+        teamId: team.id,
+        agentId: 'test-agent-id',
+        userCommentId: msg3.id,
+        userId: user.id,
+      })
+
+      const mainSession = await prisma.agentSession.findFirst({
+        where: { assetId: asset.id, type: 'comment', userCommentId: null },
+      })
+      expect(mainSession).toBeDefined()
+      // Main session leafId MUST be msg3.id (top-level comment asking agent)
+      expect(mainSession?.leafId).toBe(msg3.id)
+
+      const storage = new DatabaseSessionStorage(mainSession!.id)
+      const mainPath = await storage.getPathToRoot(mainSession!.leafId)
+      const mainPathIds = mainPath.map((e) => e.id)
+
+      // Main session contains all top-level comments including msg3
+      expect(mainPathIds).toContain(msg1.id)
+      expect(mainPathIds).toContain(msg2.id)
+      expect(mainPathIds).toContain(msg3.id)
     })
 
     it('should return user name and role for team member', async () => {

--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -539,15 +539,17 @@ describe('Agent Database Activities Integration', () => {
       // Verify agentSession created
       const agentSession = await prisma.agentSession.findUnique({
         where: { id: sessionId },
-        include: { entries: true },
       })
       expect(agentSession).toBeDefined()
       expect(agentSession?.leafId).toBeDefined()
 
-      // Verify historical comment is converted and saved to entries (mentions replaced, prefixes added)
-      expect(agentSession?.entries.length).toBe(1)
+      // Verify historical comment is converted and saved to DAG entries via path traversal
+      const storage = new DatabaseSessionStorage(sessionId)
+      const pathEntries = await storage.getPathToRoot(agentSession!.leafId)
+      expect(pathEntries.length).toBe(2)
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- entry data is stored as Json in DB and needs casting to check properties
-      const parsedEntry = agentSession?.entries[0].data as any
+      const parsedEntry = pathEntries[0] as any
       expect(parsedEntry.message.content[0].text).toContain(
         `[${user.name} (owner)]: Hello <@${user.name}> check this`,
       )
@@ -666,13 +668,13 @@ describe('Agent Database Activities Integration', () => {
       expect(text).toContain(`[Thread ID: ${msg3.id}]`)
     })
 
-    it('should create separate thread sessions when agent is mentioned in top-level comments (msg3 & msg5) and reuse session on thread follow-ups', async () => {
+    it('should create separate thread sessions when agent is mentioned in top-level comments (msg3 & msg5) sharing DAG entries without duplication', async () => {
       // msg1 (top level)
-      await prisma.assetComment.create({
+      const msg1 = await prisma.assetComment.create({
         data: { assetId: asset.id, message: 'msg1', creatorId: user.id },
       })
       // msg2 (top level)
-      await prisma.assetComment.create({
+      const msg2 = await prisma.assetComment.create({
         data: { assetId: asset.id, message: 'msg2', creatorId: user.id },
       })
       // msg3 (top level asking agent)
@@ -689,7 +691,7 @@ describe('Agent Database Activities Integration', () => {
       })
 
       // agent response msg4
-      await prisma.assetComment.create({
+      const msg4 = await prisma.assetComment.create({
         data: {
           assetId: asset.id,
           message: 'msg4',
@@ -741,6 +743,34 @@ describe('Agent Database Activities Integration', () => {
 
       // Reuses session3Id (Thread Session 1)
       expect(session7Id).toBe(session3Id)
+
+      // VERIFY DAG ENTRY SHARING & NO DUPLICATION
+      // Every shared comment must have EXACTLY 1 row in agent_session_entries with id = comment.id
+      const msg1Entries = await prisma.agentSessionEntry.findMany({ where: { id: msg1.id } })
+      const msg2Entries = await prisma.agentSessionEntry.findMany({ where: { id: msg2.id } })
+      const msg3Entries = await prisma.agentSessionEntry.findMany({ where: { id: msg3.id } })
+      expect(msg1Entries.length).toBe(1)
+      expect(msg2Entries.length).toBe(1)
+      expect(msg3Entries.length).toBe(1)
+
+      // Verify DatabaseSessionStorage path traversal for session 3 vs session 5
+      const storage3 = new DatabaseSessionStorage(session3Id)
+      const path3 = await storage3.getPathToRoot(msg4.id)
+      const path3Ids = path3.map((e) => e.id)
+      expect(path3Ids).toContain(msg1.id)
+      expect(path3Ids).toContain(msg2.id)
+      expect(path3Ids).toContain(msg3.id)
+      expect(path3Ids).toContain(msg4.id)
+      expect(path3Ids).not.toContain(msg5.id)
+
+      const storage5 = new DatabaseSessionStorage(session5Id)
+      const path5 = await storage5.getPathToRoot(msg5.id)
+      const path5Ids = path5.map((e) => e.id)
+      expect(path5Ids).toContain(msg1.id)
+      expect(path5Ids).toContain(msg2.id)
+      expect(path5Ids).toContain(msg3.id)
+      expect(path5Ids).toContain(msg5.id)
+      expect(path5Ids).not.toContain(msg4.id)
     })
 
     it('should return user name and role for team member', async () => {

--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -517,7 +517,6 @@ export async function initializeAgentSessionActivity(params: {
       },
     })
   }
-  const sessionId = session.id
 
   const rootComment = await prisma.assetComment.findUnique({
     where: { id: rootCommentId },
@@ -548,6 +547,7 @@ export async function initializeAgentSessionActivity(params: {
     })
   }
 
+  // 1. Fetch top-level comments up to rootComment.createdAt
   const topLevelComments = await prisma.assetComment.findMany({
     where: {
       assetId: userComment.assetId,
@@ -558,86 +558,24 @@ export async function initializeAgentSessionActivity(params: {
     include: { creator: true },
   })
 
-  let mainPrevId: string | null = mainSession.leafId
-  for (const c of topLevelComments) {
-    const entryId = `${c.id}_${mainSession.id}`
-    const existingEntry = await prisma.agentSessionEntry.findUnique({
-      where: { id: entryId },
-      select: { id: true },
-    })
-    if (existingEntry) {
-      mainPrevId = existingEntry.id
-      continue
-    }
+  // 2. Fetch thread replies up to userComment.createdAt if userComment is in a thread
+  const threadReplies = userComment.replyToId
+    ? await prisma.assetComment.findMany({
+        where: {
+          replyToId: rootCommentId,
+          createdAt: { lte: userComment.createdAt },
+        },
+        orderBy: { createdAt: 'asc' },
+        include: { creator: true },
+      })
+    : []
 
-    const isAgent = c.creator?.type === 'agent' || c.sessionId !== null
-    let messageContent = c.message || ''
-    if (isAgent) {
-      const agentName = c.creator?.name || 'Ai Agent'
-      messageContent = `[Agent Message][${agentName}]: ${messageContent}`
-    } else if (c.creator?.name) {
-      messageContent = `[${c.creator.name} (user)]: ${messageContent}`
-    }
+  const allCommentsToSync = [...topLevelComments, ...threadReplies]
 
-    const message: AgentMessage = {
-      role: 'user',
-      content: [{ type: 'text', text: messageContent }],
-      timestamp: c.createdAt.getTime(),
-    }
-    await prisma.agentSessionEntry.create({
-      data: {
-        id: entryId,
-        sessionId: mainSession.id,
-        assetId: userComment.assetId,
-        type: 'message',
-        parentId: mainPrevId,
-        createdAt: c.createdAt,
-        data: { message },
-      },
-    })
-    mainPrevId = entryId
-  }
-
-  if (mainPrevId && mainPrevId !== mainSession.leafId) {
-    await prisma.agentSession.update({
-      where: { id: mainSession.id },
-      data: { leafId: mainPrevId },
-    })
-  }
-
-  // Fetch existing comments as context for Thread Session
-  const precedingTopLevelComments = await prisma.assetComment.findMany({
-    where: {
-      assetId: userComment.assetId,
-      replyToId: null,
-      createdAt: { lte: rootComment.createdAt },
-      id: { notIn: [userComment.id, rootCommentId] },
-    },
-    orderBy: { createdAt: 'asc' },
-    include: { creator: true },
-  })
-
-  const threadReplies = await prisma.assetComment.findMany({
-    where: {
-      replyToId: rootCommentId,
-      id: { not: userComment.id },
-    },
-    orderBy: { createdAt: 'asc' },
-    include: { creator: true },
-  })
-
-  const existingComments = [
-    ...precedingTopLevelComments,
-    ...(rootCommentId !== userComment.id ? [rootComment] : []),
-    ...threadReplies,
-  ]
-  existingComments.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
-
-  // Check which top-level comments have reply threads (for prompt tagging)
-  // Resolve user mentions from IDs to names
+  // Resolve user mentions from IDs to names and roles
   const mentionRegex = /<@([^>]+)>/g
   const mentionedUserIds = new Set<string>()
-  for (const c of existingComments) {
+  for (const c of allCommentsToSync) {
     if (c.message) {
       const matches = [...c.message.matchAll(mentionRegex)]
       for (const match of matches) {
@@ -649,25 +587,18 @@ export async function initializeAgentSessionActivity(params: {
   const userIdToNameMap = new Map<string, string>()
   if (mentionedUserIds.size > 0) {
     const resolvedUsers = await prisma.user.findMany({
-      where: {
-        id: { in: Array.from(mentionedUserIds) },
-      },
-      select: {
-        id: true,
-        name: true,
-      },
+      where: { id: { in: Array.from(mentionedUserIds) } },
+      select: { id: true, name: true },
     })
     for (const u of resolvedUsers) {
-      if (u.name) {
-        userIdToNameMap.set(u.id, u.name)
-      }
+      if (u.name) userIdToNameMap.set(u.id, u.name)
     }
   }
 
   const userRoleMap = new Map<string, string>()
   const humanCreatorIds = Array.from(
     new Set(
-      existingComments
+      allCommentsToSync
         .filter((c) => c.creator?.type !== 'agent' && c.creatorId)
         .map((c) => c.creatorId!),
     ),
@@ -685,24 +616,10 @@ export async function initializeAgentSessionActivity(params: {
     }
   }
 
-  // Save context as AgentSessionEntry records (with parent pointers)
-  let prevId: string | null = session.leafId
-  for (const c of existingComments) {
-    const entryId = `${c.id}_${sessionId}`
-    // Check if entry already exists for this comment in this session
-    const existingEntry = await prisma.agentSessionEntry.findUnique({
-      where: { id: entryId },
-      select: { id: true },
-    })
-    if (existingEntry) {
-      prevId = existingEntry.id
-      continue
-    }
-
+  function formatCommentMessage(c: (typeof allCommentsToSync)[0]): string {
     const isAgent = c.creator?.type === 'agent' || c.sessionId !== null
     let messageContent = c.message || ''
 
-    // Replace <@USER_ID> with <@USER_NAME>
     messageContent = messageContent.replace(mentionRegex, (match, userId) => {
       const resolvedName = userIdToNameMap.get(userId)
       return resolvedName ? `<@${resolvedName}>` : match
@@ -710,41 +627,92 @@ export async function initializeAgentSessionActivity(params: {
 
     if (isAgent) {
       const agentName = c.creator?.name || 'Ai Agent'
-      messageContent = `[Agent Message][${agentName}]: ${messageContent}`
+      return `[Agent Message][${agentName}]: ${messageContent}`
     } else if (c.creator?.name) {
       const role = (c.creatorId ? userRoleMap.get(c.creatorId) : undefined) || 'user'
-      messageContent = `[${c.creator.name} (${role})]: ${messageContent}`
+      return `[${c.creator.name} (${role})]: ${messageContent}`
     }
-
-    const message: AgentMessage = {
-      role: 'user',
-      content: [{ type: 'text', text: messageContent }],
-      timestamp: c.createdAt.getTime(),
-    }
-
-    await prisma.agentSessionEntry.create({
-      data: {
-        id: entryId,
-        sessionId,
-        assetId: userComment.assetId,
-        type: 'message',
-        parentId: prevId,
-        createdAt: c.createdAt,
-        data: { message },
-      },
-    })
-    prevId = entryId
+    return messageContent
   }
 
-  // Update leafId of the session
-  if (prevId && prevId !== session.leafId) {
+  // 3. Sync top-level comments into agent_session_entries (DAG spine)
+  let mainPrevId: string | null = null
+  for (const c of topLevelComments) {
+    const existingEntry = await prisma.agentSessionEntry.findUnique({
+      where: { id: c.id },
+      select: { id: true },
+    })
+
+    if (!existingEntry) {
+      const messageContent = formatCommentMessage(c)
+      const message: AgentMessage = {
+        role: 'user',
+        content: [{ type: 'text', text: messageContent }],
+        timestamp: c.createdAt.getTime(),
+      }
+      await prisma.agentSessionEntry.create({
+        data: {
+          id: c.id,
+          sessionId: mainSession.id,
+          assetId: userComment.assetId,
+          type: 'message',
+          parentId: mainPrevId,
+          createdAt: c.createdAt,
+          data: { message },
+        },
+      })
+    }
+    mainPrevId = c.id
+  }
+
+  if (mainPrevId) {
     await prisma.agentSession.update({
-      where: { id: sessionId },
-      data: { leafId: prevId },
+      where: { id: mainSession.id },
+      data: { leafId: mainPrevId },
     })
   }
 
-  return sessionId
+  // 4. Sync thread replies and set Thread Session leafId
+  let threadLeafId: string = rootCommentId
+
+  if (threadReplies.length > 0) {
+    let lastReplyParentId: string = rootCommentId
+    for (const reply of threadReplies) {
+      const existingReplyEntry = await prisma.agentSessionEntry.findUnique({
+        where: { id: reply.id },
+        select: { id: true },
+      })
+
+      if (!existingReplyEntry) {
+        const messageContent = formatCommentMessage(reply)
+        const message: AgentMessage = {
+          role: 'user',
+          content: [{ type: 'text', text: messageContent }],
+          timestamp: reply.createdAt.getTime(),
+        }
+        await prisma.agentSessionEntry.create({
+          data: {
+            id: reply.id,
+            sessionId: session.id,
+            assetId: userComment.assetId,
+            type: 'message',
+            parentId: lastReplyParentId,
+            createdAt: reply.createdAt,
+            data: { message },
+          },
+        })
+      }
+      lastReplyParentId = reply.id
+    }
+    threadLeafId = lastReplyParentId
+  }
+
+  await prisma.agentSession.update({
+    where: { id: session.id },
+    data: { leafId: threadLeafId },
+  })
+
+  return session.id
 }
 
 export async function deleteCommentActivity(commentId: string) {

--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -547,23 +547,25 @@ export async function initializeAgentSessionActivity(params: {
     })
   }
 
-  // 1. Fetch top-level comments up to rootComment.createdAt
+  // 1. Fetch top-level comments up to rootComment.createdAt excluding userComment itself
   const topLevelComments = await prisma.assetComment.findMany({
     where: {
       assetId: userComment.assetId,
       replyToId: null,
       createdAt: { lte: rootComment.createdAt },
+      id: { not: userComment.id },
     },
     orderBy: { createdAt: 'asc' },
     include: { creator: true },
   })
 
-  // 2. Fetch thread replies up to userComment.createdAt if userComment is in a thread
+  // 2. Fetch thread replies up to userComment.createdAt excluding userComment itself
   const threadReplies = userComment.replyToId
     ? await prisma.assetComment.findMany({
         where: {
           replyToId: rootCommentId,
           createdAt: { lte: userComment.createdAt },
+          id: { not: userComment.id },
         },
         orderBy: { createdAt: 'asc' },
         include: { creator: true },
@@ -673,7 +675,7 @@ export async function initializeAgentSessionActivity(params: {
   }
 
   // 4. Sync thread replies and set Thread Session leafId
-  let threadLeafId: string = rootCommentId
+  let threadLeafId: string | null = userComment.replyToId ? rootCommentId : mainPrevId
 
   if (threadReplies.length > 0) {
     let lastReplyParentId: string = rootCommentId

--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -547,14 +547,14 @@ export async function initializeAgentSessionActivity(params: {
     })
   }
 
-  // 1. Fetch top-level comments up to rootComment.createdAt
+  // 1. Fetch top-level comments up to rootComment.createdAt sorted by id
   const topLevelComments = await prisma.assetComment.findMany({
     where: {
       assetId: userComment.assetId,
       replyToId: null,
       createdAt: { lte: rootComment.createdAt },
     },
-    orderBy: { createdAt: 'asc' },
+    orderBy: { id: 'asc' },
     include: { creator: true },
   })
 
@@ -566,7 +566,7 @@ export async function initializeAgentSessionActivity(params: {
           createdAt: { lte: userComment.createdAt },
           id: { not: userComment.id },
         },
-        orderBy: { createdAt: 'asc' },
+        orderBy: { id: 'asc' },
         include: { creator: true },
       })
     : []

--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -547,13 +547,12 @@ export async function initializeAgentSessionActivity(params: {
     })
   }
 
-  // 1. Fetch top-level comments up to rootComment.createdAt excluding userComment itself
+  // 1. Fetch top-level comments up to rootComment.createdAt
   const topLevelComments = await prisma.assetComment.findMany({
     where: {
       assetId: userComment.assetId,
       replyToId: null,
       createdAt: { lte: rootComment.createdAt },
-      id: { not: userComment.id },
     },
     orderBy: { createdAt: 'asc' },
     include: { creator: true },
@@ -675,7 +674,7 @@ export async function initializeAgentSessionActivity(params: {
   }
 
   // 4. Sync thread replies and set Thread Session leafId
-  let threadLeafId: string | null = userComment.replyToId ? rootCommentId : mainPrevId
+  let threadLeafId: string = rootCommentId
 
   if (threadReplies.length > 0) {
     let lastReplyParentId: string = rootCommentId

--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -1,7 +1,7 @@
 import {
-    type AgentMessage,
-    type AgentTool,
-    type SessionTreeEntry,
+  type AgentMessage,
+  type AgentTool,
+  type SessionTreeEntry,
 } from '@earendil-works/pi-agent-core'
 import { type ImageContent } from '@earendil-works/pi-ai'
 import { assetService } from '@shumai/core/src/asset/asset'
@@ -19,10 +19,10 @@ import { generateKeyBetween } from 'jittered-fractional-indexing'
 import { ulid } from 'ulid'
 import { DatabaseSessionStorage } from '../database-session-storage'
 import {
-    createAgentSession,
-    fieldsToTypeBoxSchema,
-    type AutofillField,
-    type DbProviderInfo,
+  createAgentSession,
+  fieldsToTypeBoxSchema,
+  type AutofillField,
+  type DbProviderInfo,
 } from '../index'
 
 import { aiUsageService } from '@shumai/core/src/ai-usage/ai-usage'
@@ -494,9 +494,8 @@ export async function initializeAgentSessionActivity(params: {
     throw new Error(`User comment ${params.userCommentId} not found`)
   }
 
-  const isThread = !!userComment.replyToId
   const rootCommentId = userComment.replyToId || userComment.id
-  const targetUserCommentId = isThread ? rootCommentId : null
+  const targetUserCommentId = rootCommentId
 
   let session = await prisma.agentSession.findFirst({
     where: {
@@ -520,126 +519,119 @@ export async function initializeAgentSessionActivity(params: {
   }
   const sessionId = session.id
 
-  // If this is a Thread Session, ensure preceding top-level comments up to rootCommentId are synced in Main Session first
-  if (isThread) {
-    let mainSession = await prisma.agentSession.findFirst({
-      where: {
+  const rootComment = await prisma.assetComment.findUnique({
+    where: { id: rootCommentId },
+    include: { creator: true },
+  })
+  if (!rootComment) {
+    throw new Error(`Root comment ${rootCommentId} not found`)
+  }
+
+  // Ensure preceding top-level comments up to rootCommentId are synced in Main Session first
+  let mainSession = await prisma.agentSession.findFirst({
+    where: {
+      assetId: userComment.assetId,
+      type: 'comment',
+      userCommentId: null,
+    },
+  })
+  if (!mainSession) {
+    mainSession = await prisma.agentSession.create({
+      data: {
+        agentId,
+        userId: params.userId || null,
+        cwd: process.cwd(),
         assetId: userComment.assetId,
-        type: 'comment',
         userCommentId: null,
+        type: 'comment',
       },
     })
-    if (!mainSession) {
-      mainSession = await prisma.agentSession.create({
-        data: {
-          agentId,
-          userId: params.userId || null,
-          cwd: process.cwd(),
-          assetId: userComment.assetId,
-          userCommentId: null,
-          type: 'comment',
-        },
-      })
-    }
-
-    const topLevelComments = await prisma.assetComment.findMany({
-      where: {
-        assetId: userComment.assetId,
-        replyToId: null,
-        createdAt: { lte: userComment.createdAt },
-      },
-      orderBy: { createdAt: 'asc' },
-      include: { creator: true },
-    })
-
-    let mainPrevId: string | null = mainSession.leafId
-    for (const c of topLevelComments) {
-      const existingEntry = await prisma.agentSessionEntry.findUnique({
-        where: { id: c.id },
-        select: { id: true },
-      })
-      if (existingEntry) {
-        mainPrevId = existingEntry.id
-        continue
-      }
-
-      const isAgent = c.creator?.type === 'agent' || c.sessionId !== null
-      let messageContent = c.message || ''
-      if (isAgent) {
-        const agentName = c.creator?.name || 'Ai Agent'
-        messageContent = `[Agent Message][${agentName}]: ${messageContent}`
-      } else if (c.creator?.name) {
-        messageContent = `[${c.creator.name} (user)]: ${messageContent}`
-      }
-
-      const entryId = c.id
-      const message: AgentMessage = {
-        role: 'user',
-        content: [{ type: 'text', text: messageContent }],
-        timestamp: c.createdAt.getTime(),
-      }
-      await prisma.agentSessionEntry.create({
-        data: {
-          id: entryId,
-          sessionId: mainSession.id,
-          assetId: userComment.assetId,
-          type: 'message',
-          parentId: mainPrevId,
-          createdAt: c.createdAt,
-          data: { message },
-        },
-      })
-      mainPrevId = entryId
-    }
-
-    if (mainPrevId && mainPrevId !== mainSession.leafId) {
-      await prisma.agentSession.update({
-        where: { id: mainSession.id },
-        data: { leafId: mainPrevId },
-      })
-    }
   }
 
-  // Fetch existing comments as context for current session
-  let existingComments: Array<{
-    id: string
-    message: string | null
-    createdAt: Date
-    creatorId: string | null
-    creator: { type: string; name: string } | null
-    sessionId: string | null
-    replyToId: string | null
-  }> = []
+  const topLevelComments = await prisma.assetComment.findMany({
+    where: {
+      assetId: userComment.assetId,
+      replyToId: null,
+      createdAt: { lte: rootComment.createdAt },
+    },
+    orderBy: { createdAt: 'asc' },
+    include: { creator: true },
+  })
 
-  if (!isThread) {
-    // Main Session: Only fetch top-level comments (replyToId: null)
-    existingComments = await prisma.assetComment.findMany({
-      where: {
-        assetId: userComment.assetId,
-        replyToId: null,
-        id: { not: userComment.id },
-      },
-      orderBy: { createdAt: 'asc' },
-      include: { creator: true },
+  let mainPrevId: string | null = mainSession.leafId
+  for (const c of topLevelComments) {
+    const entryId = `${c.id}_${mainSession.id}`
+    const existingEntry = await prisma.agentSessionEntry.findUnique({
+      where: { id: entryId },
+      select: { id: true },
     })
-  } else {
-    // Thread Session: Fetch root comment + replies in this specific thread (replyToId: rootCommentId)
-    const rootComment = await prisma.assetComment.findUnique({
-      where: { id: rootCommentId },
-      include: { creator: true },
-    })
-    if (rootComment) {
-      const replies = await prisma.assetComment.findMany({
-        where: {
-          replyToId: rootCommentId,
-          id: { not: userComment.id },
-        },
-        orderBy: { createdAt: 'asc' },
-        include: { creator: true },
-      })
-      existingComments = [rootComment, ...replies]
+    if (existingEntry) {
+      mainPrevId = existingEntry.id
+      continue
     }
+
+    const isAgent = c.creator?.type === 'agent' || c.sessionId !== null
+    let messageContent = c.message || ''
+    if (isAgent) {
+      const agentName = c.creator?.name || 'Ai Agent'
+      messageContent = `[Agent Message][${agentName}]: ${messageContent}`
+    } else if (c.creator?.name) {
+      messageContent = `[${c.creator.name} (user)]: ${messageContent}`
+    }
+
+    const message: AgentMessage = {
+      role: 'user',
+      content: [{ type: 'text', text: messageContent }],
+      timestamp: c.createdAt.getTime(),
+    }
+    await prisma.agentSessionEntry.create({
+      data: {
+        id: entryId,
+        sessionId: mainSession.id,
+        assetId: userComment.assetId,
+        type: 'message',
+        parentId: mainPrevId,
+        createdAt: c.createdAt,
+        data: { message },
+      },
+    })
+    mainPrevId = entryId
   }
+
+  if (mainPrevId && mainPrevId !== mainSession.leafId) {
+    await prisma.agentSession.update({
+      where: { id: mainSession.id },
+      data: { leafId: mainPrevId },
+    })
+  }
+
+  // Fetch existing comments as context for Thread Session
+  const precedingTopLevelComments = await prisma.assetComment.findMany({
+    where: {
+      assetId: userComment.assetId,
+      replyToId: null,
+      createdAt: { lte: rootComment.createdAt },
+      id: { notIn: [userComment.id, rootCommentId] },
+    },
+    orderBy: { createdAt: 'asc' },
+    include: { creator: true },
+  })
+
+  const threadReplies = await prisma.assetComment.findMany({
+    where: {
+      replyToId: rootCommentId,
+      id: { not: userComment.id },
+    },
+    orderBy: { createdAt: 'asc' },
+    include: { creator: true },
+  })
+
+  const existingComments = [
+    ...precedingTopLevelComments,
+    ...(rootCommentId !== userComment.id ? [rootComment] : []),
+    ...threadReplies,
+  ]
+  existingComments.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
 
   // Check which top-level comments have reply threads (for prompt tagging)
   // Resolve user mentions from IDs to names
@@ -696,9 +688,10 @@ export async function initializeAgentSessionActivity(params: {
   // Save context as AgentSessionEntry records (with parent pointers)
   let prevId: string | null = session.leafId
   for (const c of existingComments) {
-    // Check if entry already exists for this comment
+    const entryId = `${c.id}_${sessionId}`
+    // Check if entry already exists for this comment in this session
     const existingEntry = await prisma.agentSessionEntry.findUnique({
-      where: { id: c.id },
+      where: { id: entryId },
       select: { id: true },
     })
     if (existingEntry) {
@@ -723,7 +716,6 @@ export async function initializeAgentSessionActivity(params: {
       messageContent = `[${c.creator.name} (${role})]: ${messageContent}`
     }
 
-    const entryId = c.id
     const message: AgentMessage = {
       role: 'user',
       content: [{ type: 'text', text: messageContent }],

--- a/packages/agent/src/database-session-storage.ts
+++ b/packages/agent/src/database-session-storage.ts
@@ -154,14 +154,18 @@ export class DatabaseSessionStorage implements SessionStorage<DatabaseSessionMet
     })
 
     await prisma.$transaction([
-      prisma.agentSessionEntry.create({
-        data: {
+      prisma.agentSessionEntry.upsert({
+        where: { id: entry.id },
+        create: {
           id: entry.id,
           sessionId: this.sessionId,
           assetId: session?.assetId || null,
           type: entry.type,
           parentId: entry.parentId || null,
           createdAt: entry.timestamp ? new Date(entry.timestamp) : new Date(),
+          data: payload as PrismaJson.PiSessionEntryData,
+        },
+        update: {
           data: payload as PrismaJson.PiSessionEntryData,
         },
       }),

--- a/packages/agent/src/database-session-storage.ts
+++ b/packages/agent/src/database-session-storage.ts
@@ -248,12 +248,12 @@ export class DatabaseSessionStorage implements SessionStorage<DatabaseSessionMet
     }
 
     // Dynamically tag comments that currently have reply threads
-    const entryIds = pathEntries.map((e) => e.id)
-    if (entryIds.length > 0) {
+    const commentIds = Array.from(new Set(pathEntries.map((e) => e.id.split('_')[0])))
+    if (commentIds.length > 0) {
       const threadCounts = await prisma.assetComment.groupBy({
         by: ['replyToId'],
         where: {
-          replyToId: { in: entryIds },
+          replyToId: { in: commentIds },
         },
       })
       const commentIdsWithThreads = new Set<string>()
@@ -264,14 +264,15 @@ export class DatabaseSessionStorage implements SessionStorage<DatabaseSessionMet
       if (commentIdsWithThreads.size > 0) {
         for (let i = 0; i < pathEntries.length; i++) {
           const entry = pathEntries[i]
-          if (commentIdsWithThreads.has(entry.id) && entry.type === 'message') {
+          const baseCommentId = entry.id.split('_')[0]
+          if (commentIdsWithThreads.has(baseCommentId) && entry.type === 'message') {
             const cloned = structuredClone(entry)
             const msg = cloned.message as unknown as {
               content?: Array<{ type: string; text: string }>
             }
             if (Array.isArray(msg.content) && msg.content[0] && msg.content[0].type === 'text') {
-              if (!msg.content[0].text.startsWith(`[Thread ID: ${entry.id}]`)) {
-                msg.content[0].text = `[Thread ID: ${entry.id}] ${msg.content[0].text}`
+              if (!msg.content[0].text.startsWith(`[Thread ID: ${baseCommentId}]`)) {
+                msg.content[0].text = `[Thread ID: ${baseCommentId}] ${msg.content[0].text}`
               }
             }
             pathEntries[i] = cloned

--- a/packages/agent/src/database-session-storage.ts
+++ b/packages/agent/src/database-session-storage.ts
@@ -248,12 +248,12 @@ export class DatabaseSessionStorage implements SessionStorage<DatabaseSessionMet
     }
 
     // Dynamically tag comments that currently have reply threads
-    const commentIds = Array.from(new Set(pathEntries.map((e) => e.id.split('_')[0])))
-    if (commentIds.length > 0) {
+    const entryIds = pathEntries.map((e) => e.id)
+    if (entryIds.length > 0) {
       const threadCounts = await prisma.assetComment.groupBy({
         by: ['replyToId'],
         where: {
-          replyToId: { in: commentIds },
+          replyToId: { in: entryIds },
         },
       })
       const commentIdsWithThreads = new Set<string>()
@@ -264,15 +264,14 @@ export class DatabaseSessionStorage implements SessionStorage<DatabaseSessionMet
       if (commentIdsWithThreads.size > 0) {
         for (let i = 0; i < pathEntries.length; i++) {
           const entry = pathEntries[i]
-          const baseCommentId = entry.id.split('_')[0]
-          if (commentIdsWithThreads.has(baseCommentId) && entry.type === 'message') {
+          if (commentIdsWithThreads.has(entry.id) && entry.type === 'message') {
             const cloned = structuredClone(entry)
             const msg = cloned.message as unknown as {
               content?: Array<{ type: string; text: string }>
             }
             if (Array.isArray(msg.content) && msg.content[0] && msg.content[0].type === 'text') {
-              if (!msg.content[0].text.startsWith(`[Thread ID: ${baseCommentId}]`)) {
-                msg.content[0].text = `[Thread ID: ${baseCommentId}] ${msg.content[0].text}`
+              if (!msg.content[0].text.startsWith(`[Thread ID: ${entry.id}]`)) {
+                msg.content[0].text = `[Thread ID: ${entry.id}] ${msg.content[0].text}`
               }
             }
             pathEntries[i] = cloned

--- a/packages/agent/src/database-session-storage.ts
+++ b/packages/agent/src/database-session-storage.ts
@@ -265,6 +265,7 @@ export class DatabaseSessionStorage implements SessionStorage<DatabaseSessionMet
         by: ['replyToId'],
         where: {
           replyToId: { in: entryIds },
+          message: { not: '__CHAT__' },
         },
       })
       const commentIdsWithThreads = new Set<string>()

--- a/packages/agent/src/database-session-storage.ts
+++ b/packages/agent/src/database-session-storage.ts
@@ -267,23 +267,30 @@ export class DatabaseSessionStorage implements SessionStorage<DatabaseSessionMet
           replyToId: { in: entryIds },
           message: { not: '__CHAT__' },
         },
+        _count: {
+          id: true,
+        },
       })
-      const commentIdsWithThreads = new Set<string>()
+      const threadReplyCountMap = new Map<string, number>()
       for (const tc of threadCounts) {
-        if (tc.replyToId) commentIdsWithThreads.add(tc.replyToId)
+        if (tc.replyToId) {
+          threadReplyCountMap.set(tc.replyToId, tc._count.id)
+        }
       }
 
-      if (commentIdsWithThreads.size > 0) {
+      if (threadReplyCountMap.size > 0) {
         for (let i = 0; i < pathEntries.length; i++) {
           const entry = pathEntries[i]
-          if (commentIdsWithThreads.has(entry.id) && entry.type === 'message') {
+          const count = threadReplyCountMap.get(entry.id)
+          if (count !== undefined && count > 0 && entry.type === 'message') {
             const cloned = structuredClone(entry)
             const msg = cloned.message as unknown as {
               content?: Array<{ type: string; text: string }>
             }
             if (Array.isArray(msg.content) && msg.content[0] && msg.content[0].type === 'text') {
-              if (!msg.content[0].text.startsWith(`[Thread ID: ${entry.id}]`)) {
-                msg.content[0].text = `[Thread ID: ${entry.id}] ${msg.content[0].text}`
+              const threadTag = `[Thread ID: ${entry.id}] [Replies: ${count}]`
+              if (!msg.content[0].text.includes(`[Thread ID: ${entry.id}]`)) {
+                msg.content[0].text = `${threadTag} ${msg.content[0].text}`
               }
             }
             pathEntries[i] = cloned

--- a/packages/agent/src/database-session-storage.ts
+++ b/packages/agent/src/database-session-storage.ts
@@ -71,7 +71,14 @@ export class DatabaseSessionStorage implements SessionStorage<DatabaseSessionMet
     await this.appendEntry(leafEntry)
   }
 
+  nextEntryId?: string | null
+
   async createEntryId(): Promise<string> {
+    if (this.nextEntryId) {
+      const id = this.nextEntryId
+      this.nextEntryId = null
+      return id
+    }
     return ulid()
   }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -135,6 +135,9 @@ export async function createAgentSession(params: CreateAgentSessionParams) {
     sessionId,
     cwd: process.cwd(),
   })
+  if (passedUserCommentId) {
+    storage.nextEntryId = passedUserCommentId
+  }
   const session = new Session(storage)
 
   const agentDir = path.join(process.cwd(), '.pi', 'agents', agentId)

--- a/packages/agent/src/tools/read-thread.test.ts
+++ b/packages/agent/src/tools/read-thread.test.ts
@@ -11,6 +11,9 @@ vi.mock('@shumai/db', async (importOriginal) => {
         findUnique: vi.fn(),
         findMany: vi.fn(),
       },
+      asset: {
+        findUnique: vi.fn(),
+      },
     },
   }
 })
@@ -22,12 +25,25 @@ describe('createReadThreadTool', () => {
 
   it('should return error text when thread root comment is not found', async () => {
     vi.mocked(prisma.assetComment.findUnique).mockResolvedValue(null)
+    vi.mocked(prisma.asset.findUnique).mockResolvedValue(null)
 
     const tool = createReadThreadTool()
     const result = await tool.execute('call-1', { threadId: 'non-existent' })
     const textContent = (result.content[0] as { text: string }).text
 
     expect(textContent).toContain('Comment thread with ID "non-existent" not found.')
+  })
+
+  it('should return specific error text when threadId is an asset ID', async () => {
+    vi.mocked(prisma.assetComment.findUnique).mockResolvedValue(null)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock return
+    vi.mocked(prisma.asset.findUnique).mockResolvedValue({ id: 'asset-1' } as any)
+
+    const tool = createReadThreadTool()
+    const result = await tool.execute('call-asset', { threadId: 'asset-1' })
+    const textContent = (result.content[0] as { text: string }).text
+
+    expect(textContent).toContain('ID "asset-1" is an Asset ID, not a Comment Thread ID')
   })
 
   it('should return thread root message and notice when there are no replies', async () => {

--- a/packages/agent/src/tools/read-thread.ts
+++ b/packages/agent/src/tools/read-thread.ts
@@ -3,7 +3,10 @@ import { Type } from '@sinclair/typebox'
 import { type AgentTool } from '@earendil-works/pi-agent-core'
 
 const readThreadSchema = Type.Object({
-  threadId: Type.String({ description: 'The comment ID of the thread root' }),
+  threadId: Type.String({
+    description:
+      'The root comment ID of a thread (e.g. from [Thread ID: ...]). Do NOT pass an asset ID or project ID.',
+  }),
 })
 
 export const createReadThreadTool = (): AgentTool<
@@ -21,8 +24,16 @@ export const createReadThreadTool = (): AgentTool<
     })
 
     if (!rootComment) {
+      const isAsset = await prisma.asset.findUnique({
+        where: { id: params.threadId },
+        select: { id: true },
+      })
+      const errorText = isAsset
+        ? `ID "${params.threadId}" is an Asset ID, not a Comment Thread ID. Do not pass asset IDs to read_thread.`
+        : `Comment thread with ID "${params.threadId}" not found.`
+
       return {
-        content: [{ type: 'text', text: `Comment thread with ID "${params.threadId}" not found.` }],
+        content: [{ type: 'text', text: errorText }],
         details: { threadId: params.threadId },
       }
     }

--- a/packages/agent/src/tools/read-thread.ts
+++ b/packages/agent/src/tools/read-thread.ts
@@ -28,8 +28,11 @@ export const createReadThreadTool = (): AgentTool<
     }
 
     const replies = await prisma.assetComment.findMany({
-      where: { replyToId: rootComment.id },
-      orderBy: { createdAt: 'asc' },
+      where: {
+        replyToId: rootComment.id,
+        message: { not: '__CHAT__' },
+      },
+      orderBy: { id: 'asc' },
       include: { creator: true },
     })
 

--- a/packages/webui/components/agent/agent-session-logs-dialog.tsx
+++ b/packages/webui/components/agent/agent-session-logs-dialog.tsx
@@ -296,12 +296,20 @@ export function AgentSessionLogsDialog({
 
                         <div className="flex flex-col gap-1.5 bg-muted/30 dark:bg-muted/10 p-3 rounded-lg border border-foreground/5 backdrop-blur-xs w-full">
                           <div className="flex items-center justify-between gap-2">
-                            <span
-                              className={`text-[10px] px-2 py-0.5 rounded-full font-semibold uppercase tracking-wider ${badgeColor}`}
-                            >
-                              {roleName}
-                            </span>
-                            <span className="text-[10px] text-muted-foreground/60">
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <span
+                                className={`text-[10px] px-2 py-0.5 rounded-full font-semibold uppercase tracking-wider ${badgeColor}`}
+                              >
+                                {roleName}
+                              </span>
+                              <span
+                                className="text-[10px] font-mono text-muted-foreground bg-muted/50 px-1.5 py-0.5 rounded border border-foreground/10 select-all"
+                                title="Entry ID"
+                              >
+                                ID: {entry.id}
+                              </span>
+                            </div>
+                            <span className="text-[10px] text-muted-foreground/60 shrink-0">
                               {timestamp}
                             </span>
                           </div>
@@ -319,7 +327,15 @@ export function AgentSessionLogsDialog({
                     <div className="absolute left-[9px] top-2 bottom-0 w-0.5 bg-foreground/10 last:hidden" />
                     <div className="absolute left-0 top-1.5 h-5 w-5 rounded-full border-4 border-background bg-gray-400" />
                     <div className="bg-muted/30 p-3 rounded-lg border border-foreground/5">
-                      <div className="text-[10px] text-muted-foreground/60">{timestamp}</div>
+                      <div className="flex items-center justify-between gap-2 mb-1.5 flex-wrap">
+                        <span
+                          className="text-[10px] font-mono text-muted-foreground bg-muted/50 px-1.5 py-0.5 rounded border border-foreground/10 select-all"
+                          title="Entry ID"
+                        >
+                          ID: {entry.id}
+                        </span>
+                        <div className="text-[10px] text-muted-foreground/60">{timestamp}</div>
+                      </div>
                       <pre className="text-xs text-foreground/80 font-mono whitespace-pre-wrap break-words">
                         {JSON.stringify(entry.entry, null, 2)}
                       </pre>


### PR DESCRIPTION
## Summary

Fixes a bug where agent mentions in top-level comments (`msg3`, `msg5`) were all routed to the single Main Session (`userCommentId: null`) instead of creating separate Thread Sessions for each comment thread.

## Changes

- Updated `initializeAgentSessionActivity` in `@shumai/agent` so that `targetUserCommentId` is always set to `rootCommentId` (`userComment.replyToId || userComment.id`).
- Ensured Thread Sessions contain preceding top-level comments up to `rootCommentId` + replies belonging strictly to that thread, excluding replies from other threads.
- Scoped `AgentSessionEntry` IDs per session (`${c.id}_${sessionId}`) to allow top-level comments to exist in both Main Session and Thread Sessions without primary key collision.
- Updated `DatabaseSessionStorage` to extract base comment IDs when checking for reply threads.
- Added comprehensive unit tests in `packages/agent/src/activities/agent.test.ts` verifying thread session isolation for `msg3` and `msg5`, as well as session reuse on thread follow-ups (`msg7`).

## Verification

Ran all workspace quality checks:
- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test` (728 passed)
- `bun run test:e2e` (30 passed)
- `bun run test:e2e:workflow` (42 passed)

## Notes

No breaking schema or API changes.