### PR TITLE
fix(webui): update file size formatting to SI decimal standard

### DIFF
--- a/packages/webui/components/file-browser/file-list-item.tsx
+++ b/packages/webui/components/file-browser/file-list-item.tsx
@@ -6,6 +6,7 @@ import { useDraggable } from '@dnd-kit/react'
 import { File, Folder, MoreVertical, AudioLines } from 'lucide-react'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { cn } from '@/ui/lib/utils'
+import { formatSize } from '@/ui/lib/format'
 import type { DragState } from '../dnd-types'
 import FieldRenderer from '../field-renderer'
 import { Badge } from '@/ui/components/ui/badge'
@@ -135,13 +136,6 @@ export function FileListItem({
     setName(displayItem.name)
   }, [displayItem.name])
 
-  const formatSize = (size?: number) => {
-    if (!size) return '-'
-    if (size < 1024) return `${size} B`
-    if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`
-    return `${(size / (1024 * 1024)).toFixed(1)} MB`
-  }
-
   const formatDate = (date?: string) => {
     if (!date) return '-'
     return new Date(date).toLocaleDateString('en-US', {
@@ -253,7 +247,11 @@ export function FileListItem({
           minWidth: columnSizing?.['size'] || 100,
         }}
       >
-        {displayItem.type === 'folder' ? '-' : formatSize(displayItem.sizeByte)}
+        {displayItem.type === 'folder'
+          ? '-'
+          : displayItem.sizeByte
+            ? formatSize(displayItem.sizeByte)
+            : '-'}
       </div>
       <div
         className="px-4 py-2 border-r shrink-0 flex items-center"

--- a/packages/webui/lib/format.test.ts
+++ b/packages/webui/lib/format.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { formatSize } from './format'
+
+describe('formatSize', () => {
+  it('formats zero bytes', () => {
+    expect(formatSize(0)).toBe('0 B')
+  })
+
+  it('formats bytes below 1 KB', () => {
+    expect(formatSize(500)).toBe('500 B')
+  })
+
+  it('formats KB', () => {
+    expect(formatSize(1000)).toBe('1 KB')
+    expect(formatSize(1500)).toBe('1.5 KB')
+  })
+
+  it('formats MB', () => {
+    expect(formatSize(1000000)).toBe('1 MB')
+    expect(formatSize(2500000)).toBe('2.5 MB')
+  })
+
+  it('formats GB correctly using decimal standard', () => {
+    expect(formatSize(4109222091)).toBe('4.11 GB')
+  })
+})

--- a/packages/webui/lib/format.ts
+++ b/packages/webui/lib/format.ts
@@ -1,7 +1,20 @@
 export function formatSize(bytes: number): string {
-  if (bytes === 0) return '0 B'
-  const k = 1024
+  if (!bytes || bytes <= 0) return '0 B'
+  const k = 1000
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
-  const i = Math.floor(Math.log(bytes) / Math.log(k))
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i]
+  let i = Math.floor(Math.log(bytes) / Math.log(k))
+  if (i < 0) i = 0
+  if (i >= sizes.length) i = sizes.length - 1
+
+  const val = bytes / Math.pow(k, i)
+  if (i === 0) {
+    return `${Math.round(val)} B`
+  }
+
+  const formatted = parseFloat(val.toFixed(2))
+  if (formatted >= 1000 && i < sizes.length - 1) {
+    return parseFloat((bytes / Math.pow(k, i + 1)).toFixed(2)) + ' ' + sizes[i + 1]
+  }
+
+  return `${formatted} ${sizes[i]}`
 }


### PR DESCRIPTION
## Summary

Fixes a file size formatting bug where file sizes formatted with `formatSize` used a binary base (1024) while using decimal SI unit labels (`GB`), causing a 4,109,222,091 bytes file to show up as "3.8 GB" instead of "4.11 GB".

## Changes

- Updated `formatSize` in `packages/webui/lib/format.ts` to use SI decimal base 1000 and support up to 2 decimal places with automatic unit roll-up.
- Updated `FileListItem` (`packages/webui/components/file-browser/file-list-item.tsx`) to use the centralized `formatSize` utility instead of a local inline helper.
- Added unit tests for `formatSize` in `packages/webui/lib/format.test.ts`.

## Verification

- `bun run lint` (passed)
- `bun run format` (passed)
- `bun run typecheck` (passed)
- `bun run test` (passed 93 test files, 746 tests including unit test in `format.test.ts`)
- `bun run test:e2e` (passed 30 tests)
- `bun run test:e2e:workflow` (passed 4 tests)

## Notes

None.