### PR TITLE
fix(s3): enforce property syntax in S3Service interface and fix ReadableStream handling in S3StorageService

### DIFF
--- a/packages/core/src/s3/s3.test.ts
+++ b/packages/core/src/s3/s3.test.ts
@@ -154,6 +154,41 @@ describe('S3Service implementations', () => {
       expect(url2).toBe('http://download-url-2')
       expect(s3PresignSpy).toHaveBeenCalledTimes(2)
     })
+
+    it('should handle ReadableStream in putObject by wrapping in Response', async () => {
+      const s3 = new S3StorageService('http://localhost:9000', 'key', 'secret', 'test-bucket')
+      s3WriteSpy.mockClear()
+
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('stream content'))
+          controller.close()
+        },
+      })
+
+      await s3.putObject('test-bucket', 'file.txt', stream, 14, 'text/plain')
+
+      expect(s3WriteSpy).toHaveBeenCalledWith(
+        'file.txt',
+        expect.any(Response),
+        expect.objectContaining({ bucket: 'test-bucket', type: 'text/plain' }),
+      )
+    })
+
+    it('should handle ArrayBuffer in putObject', async () => {
+      const s3 = new S3StorageService('http://localhost:9000', 'key', 'secret', 'test-bucket')
+      s3WriteSpy.mockClear()
+
+      const arrayBuffer = new TextEncoder().encode('array buffer content').buffer
+
+      await s3.putObject('test-bucket', 'file.txt', arrayBuffer, 20, 'text/plain')
+
+      expect(s3WriteSpy).toHaveBeenCalledWith(
+        'file.txt',
+        arrayBuffer,
+        expect.objectContaining({ bucket: 'test-bucket', type: 'text/plain' }),
+      )
+    })
   })
 
   describe('LocalStorageService', () => {

--- a/packages/core/src/s3/s3.ts
+++ b/packages/core/src/s3/s3.ts
@@ -33,29 +33,29 @@ export interface S3Object {
 }
 
 export interface S3Service {
-  getObjectSize(bucket: string, key: string): Promise<number>
-  putObject(
+  getObjectSize: (bucket: string, key: string) => Promise<number>
+  putObject: (
     bucket: string,
     key: string,
     body: Buffer | Uint8Array | ArrayBuffer | string | ReadableStream,
     size: number,
     contentType?: string,
-  ): Promise<void>
-  getObject(bucket: string, key: string): Promise<S3Object>
-  copyObject(
+  ) => Promise<void>
+  getObject: (bucket: string, key: string) => Promise<S3Object>
+  copyObject: (
     sourceBucket: string,
     sourceKey: string,
     destBucket: string,
     destKey: string,
-  ): Promise<void>
-  downloadToFile(bucket: string, key: string, filePath: string): Promise<void>
-  deleteObject(bucket: string, key: string): Promise<number>
-  deletePrefix(bucket: string, prefix: string): Promise<number>
-  headObject(bucket: string, key: string): Promise<ObjectInfo>
-  listObjects(bucket: string, prefix: string): Promise<string[]>
-  uploadFile(filePath: string, contentType: string): Promise<string>
-  uploadFileToKey(filePath: string, key: string, contentType: string): Promise<void>
-  presign(bucket: string, key: string, method: string, download?: boolean): Promise<string>
+  ) => Promise<void>
+  downloadToFile: (bucket: string, key: string, filePath: string) => Promise<void>
+  deleteObject: (bucket: string, key: string) => Promise<number>
+  deletePrefix: (bucket: string, prefix: string) => Promise<number>
+  headObject: (bucket: string, key: string) => Promise<ObjectInfo>
+  listObjects: (bucket: string, prefix: string) => Promise<string[]>
+  uploadFile: (filePath: string, contentType: string) => Promise<string>
+  uploadFileToKey: (filePath: string, key: string, contentType: string) => Promise<void>
+  presign: (bucket: string, key: string, method: string, download?: boolean) => Promise<string>
 }
 
 export class S3StorageService implements S3Service {
@@ -87,11 +87,15 @@ export class S3StorageService implements S3Service {
   async putObject(
     bucket: string,
     key: string,
-    body: Buffer | Uint8Array | string,
+    body: Buffer | Uint8Array | ArrayBuffer | string | ReadableStream,
     _size: number,
     contentType?: string,
   ): Promise<void> {
-    await this.client.write(key, body, {
+    const payload =
+      body && typeof body === 'object' && 'getReader' in body
+        ? new Response(body as ReadableStream)
+        : body
+    await this.client.write(key, payload as string | Buffer | ArrayBuffer | Uint8Array | Response, {
       bucket,
       type: contentType,
     })

--- a/packages/core/src/s3/s3.ts
+++ b/packages/core/src/s3/s3.ts
@@ -95,7 +95,7 @@ export class S3StorageService implements S3Service {
       body && typeof body === 'object' && 'getReader' in body
         ? new Response(body as ReadableStream)
         : body
-    await this.client.write(key, payload as string | Buffer | ArrayBuffer | Uint8Array | Response, {
+    await this.client.write(key, payload, {
       bucket,
       type: contentType,
     })


### PR DESCRIPTION
## Summary

This PR converts all method declarations in `S3Service` to property syntax to trigger strict contravariant parameter checking (`strictFunctionTypes`), and fixes `S3StorageService.putObject` to properly handle `ReadableStream` and `ArrayBuffer` payloads without data corruption.

## Changes

- Converted method declarations in `S3Service` to property syntax (e.g. `putObject: (...) => Promise<void>`), preventing TypeScript bivariant parameter checking from silently ignoring implementation signature mismatches.
- Updated `S3StorageService.putObject` parameter type to `Buffer | Uint8Array | ArrayBuffer | string | ReadableStream`.
- Wrapped `ReadableStream` payloads in `new Response(stream)` before passing to Bun's `S3Client.write`, allowing Bun to stream data natively to S3 rather than stringifying into `"[object ReadableStream]"`.
- Added unit tests in `packages/core/src/s3/s3.test.ts` for `S3StorageService.putObject` handling `ReadableStream` and `ArrayBuffer`.

## Verification

All workspace checks passed simultaneously:
- `bun run lint` (0 warnings/errors)
- `bun run format` (0 changes needed)
- `bun run typecheck` (PASSED cleanly; reproduced `TS2416` when signature mismatched)
- `bun run test` (92 passed, 743 tests)
- `bun run test:e2e` (30 passed)
- `bun run test:e2e:workflow` (11 passed, 42 tests)

## Notes

None.