### PR TITLE
fix(agent): download original document asset instead of pdf proxy

### DIFF
--- a/packages/agent/src/tools/download-asset.test.ts
+++ b/packages/agent/src/tools/download-asset.test.ts
@@ -137,32 +137,33 @@ describe('downloadAssetTool', () => {
     expect(result.details.size).toBe(Buffer.from('fake-video-bytes').length)
   })
 
-  it('should download proxy pdf to .pi directory when pdfTranscode is present', async () => {
+  it('should download original file to .pi directory even when pdfTranscode is present', async () => {
     vi.mocked(authzService.hasPermission).mockResolvedValue()
     vi.mocked(prisma.asset.findUnique).mockResolvedValue({
-      id: 'asset-pdf-1',
-      name: 'doc.pdf',
-      storageKey: { key: 'raw/doc.pdf' },
+      id: 'asset-md-1',
+      name: 'doc.md',
+      storageKey: { key: 'raw/doc.md' },
       media: {
         proxyType: 'pdf',
         pdfTranscode: { key: 'proxy/doc.pdf' },
+        original: { key: 'raw/doc.md' },
       },
     } as unknown as Asset)
 
     vi.mocked(s3Service.getObject).mockResolvedValue({
-      buffer: Buffer.from('fake-pdf-bytes'),
-      contentType: 'application/pdf',
+      buffer: Buffer.from('# fake markdown bytes'),
+      contentType: 'text/markdown',
     } as unknown as { buffer: Buffer; contentType: string })
 
     const tool = createDownloadAssetTool('user-1')
-    const result = await tool.execute('call-1', { assetId: 'asset-pdf-1' })
+    const result = await tool.execute('call-1', { assetId: 'asset-md-1' })
 
-    expect(s3Service.getObject).toHaveBeenCalledWith('shumai', 'proxy/doc.pdf')
+    expect(s3Service.getObject).toHaveBeenCalledWith('shumai', 'raw/doc.md')
 
-    const expectedPath = path.join(piDir, 'asset-pdf-1_doc.pdf')
+    const expectedPath = path.join(piDir, 'asset-md-1_doc.md')
     createdFiles.push(expectedPath)
 
     expect(fs.existsSync(expectedPath)).toBe(true)
-    expect(result.details.contentType).toBe('application/pdf')
+    expect(result.details.contentType).toBe('text/markdown')
   })
 })

--- a/packages/agent/src/tools/download-asset.ts
+++ b/packages/agent/src/tools/download-asset.ts
@@ -65,10 +65,6 @@ export function createDownloadAssetTool(userId: string): AgentTool<typeof downlo
           } else if (mediaInfo.videoPreview?.key) {
             mediaKey = mediaInfo.videoPreview.key
           }
-        } else if (mediaInfo.proxyType === 'pdf' || mediaInfo.pdfTranscode?.key) {
-          if (mediaInfo.pdfTranscode?.key) {
-            mediaKey = mediaInfo.pdfTranscode.key
-          }
         } else if (mediaInfo.original?.key) {
           mediaKey = mediaInfo.original.key || mediaKey
         }


### PR DESCRIPTION
## Summary

Removes the `pdfTranscode` proxy resolution branch in `download_asset` tool so agents download original document files (e.g. `.md`, `.txt`) directly.

## Changes

- Removed `mediaInfo.proxyType === 'pdf'` / `pdfTranscode` proxy branch from `packages/agent/src/tools/download-asset.ts`.
- Updated unit test in `packages/agent/src/tools/download-asset.test.ts` to verify that original file is downloaded even if `pdfTranscode` metadata is present.

## Verification

- `bun run lint` passed
- `bun run format` passed
- `bun run typecheck` passed
- `bun run test packages/agent/src/tools/download-asset.test.ts` passed