### PR TITLE
feat(agent): enable LLM API call retries in AgentHarness

### DIFF
--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -336,6 +336,49 @@ describe('Sandbox Network isolation integration', () => {
     }
   })
 
+  it('should pass retry configuration to AgentHarness', async () => {
+    const team = await prisma.team.create({
+      data: { name: 'Test Team Retry' },
+    })
+    await prisma.user.create({
+      data: {
+        id: 'test-agent-retry',
+        name: 'Agent Retry',
+        email: 'agent-retry@test.com',
+        type: 'agent',
+      },
+    })
+    await prisma.agent.create({
+      data: {
+        id: 'test-agent-retry',
+        teamId: team.id,
+        type: 'chat',
+        config: { provider: 'google', model: 'gemini' },
+      },
+    })
+
+    const initializeSpy = vi.spyOn(SandboxManager, 'initialize').mockResolvedValue()
+    try {
+      const { harness } = await createAgentSession({
+        teamId: team.id,
+        agentId: 'test-agent-retry',
+        providerName: 'google',
+        modelId: 'gemini',
+        systemPrompt: 'prompt',
+        teamSkills: [],
+        allowedDomains: [],
+        providers: [],
+        maxRetries: 5,
+        baseDelayMs: 1500,
+      })
+
+      // @ts-expect-error accessing private property for verification
+      expect(harness.streamOptions?.maxRetries).toBe(5)
+    } finally {
+      initializeSpy.mockRestore()
+    }
+  })
+
   it('should filter out denied tools from AgentHarness', async () => {
     const team = await prisma.team.create({
       data: { name: 'Test Team 3' },

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -114,6 +114,8 @@ export interface CreateAgentSessionParams {
   thinkingLevel?: string
   disableTools?: boolean
   providers: DbProviderInfo[]
+  maxRetries?: number
+  baseDelayMs?: number
 }
 
 export async function createAgentSession(params: CreateAgentSessionParams) {
@@ -131,6 +133,8 @@ export async function createAgentSession(params: CreateAgentSessionParams) {
     customTools = [],
     thinkingLevel,
     disableTools = false,
+    maxRetries = 3,
+    baseDelayMs = 2000,
   } = params
 
   const storage = await DatabaseSessionStorage.create({
@@ -292,6 +296,10 @@ export async function createAgentSession(params: CreateAgentSessionParams) {
     session,
     model,
     thinkingLevel: (thinkingLevel || 'off') as ThinkingLevel,
+    streamOptions: {
+      maxRetries,
+      maxRetryDelayMs: baseDelayMs,
+    },
     systemPrompt: async () => {
       let prompt = systemPrompt
 


### PR DESCRIPTION
## Summary

Enable LLM API auto-retries for `AgentHarness` when instantiated in `@shumai/agent`.

## Changes

- Added `maxRetries` and `baseDelayMs` optional parameters to `CreateAgentSessionParams` (defaulting to 3 retries and 2000ms delay).
- Passed `streamOptions: { maxRetries, maxRetryDelayMs: baseDelayMs }` to `AgentHarness` in `createAgentSession`.
- Added unit test in `packages/agent/src/index.test.ts` to verify `streamOptions` configuration.

## Verification

- `bun run lint` passed
- `bun run format` passed
- `bun run typecheck` passed
- `bun run test` passed (93 test files / 753 tests)
- `bun run test:e2e` passed (30 tests)
- `bun run test:e2e:workflow` passed (11 test files / 42 tests)

## Notes

None.