### PR TITLE
test(core): add missing tests for methods introduced in 97069042

### DIFF
--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -399,4 +399,26 @@ describe('AgentService', () => {
       expect(found?.creator?.name).toBe('Regular User')
     })
   })
+
+  describe('getAgent', () => {
+    test('returns agent when it exists', async () => {
+      const db = prisma
+      const svc = new AgentService()
+      const { agent } = await setupTestData(db)
+
+      const result = await svc.getAgent({ agentId: agent.id })
+
+      expect(result).not.toBeNull()
+      expect(result?.id).toBe(agent.id)
+      expect(result?.type).toBe('chat')
+    })
+
+    test('returns null for non-existent ID', async () => {
+      const svc = new AgentService()
+
+      const result = await svc.getAgent({ agentId: 'nonexistent-id' })
+
+      expect(result).toBeNull()
+    })
+  })
 })

--- a/packages/core/src/project/project.test.ts
+++ b/packages/core/src/project/project.test.ts
@@ -379,4 +379,98 @@ describe('ProjectService', () => {
       expect(s3Service.deleteObject).toHaveBeenCalledWith(expect.any(String), 'file-c-key')
     })
   })
+
+  describe('getUserProjects', () => {
+    it('team-scoped member sees all projects in team', async () => {
+      const team = await prisma.team.create({ data: { name: 'GUP Team A' } })
+      await prisma.project.create({ data: { name: 'P1', teamId: team.id } })
+      await prisma.project.create({ data: { name: 'P2', teamId: team.id } })
+      await prisma.project.create({ data: { name: 'P3', teamId: team.id } })
+
+      const user = await prisma.user.create({
+        data: { name: 'gup-u1', email: 'gup-u1@example.com' },
+      })
+      await prisma.teamMember.create({
+        data: { teamId: team.id, userId: user.id, role: 'editor', scope: 'team' },
+      })
+
+      const result = await projectService.getUserProjects(user.id)
+      expect(result).toHaveLength(3)
+      const names = result.map((p) => p.name).sort()
+      expect(names).toEqual(['P1', 'P2', 'P3'])
+    })
+
+    it('project-scoped member sees only assigned projects', async () => {
+      const team = await prisma.team.create({ data: { name: 'GUP Team B' } })
+      const p1 = await prisma.project.create({ data: { name: 'P1', teamId: team.id } })
+      const p2 = await prisma.project.create({ data: { name: 'P2', teamId: team.id } })
+      await prisma.project.create({ data: { name: 'P3', teamId: team.id } })
+
+      const user = await prisma.user.create({
+        data: { name: 'gup-u2', email: 'gup-u2@example.com' },
+      })
+      const tm = await prisma.teamMember.create({
+        data: { teamId: team.id, userId: user.id, role: 'reviewer', scope: 'project' },
+      })
+      await prisma.projectMember.create({
+        data: { projectId: p1.id, teamMemberId: tm.id, role: 'reviewer' },
+      })
+      await prisma.projectMember.create({
+        data: { projectId: p2.id, teamMemberId: tm.id, role: 'reviewer' },
+      })
+
+      const result = await projectService.getUserProjects(user.id)
+      expect(result).toHaveLength(2)
+      const names = result.map((p) => p.name).sort()
+      expect(names).toEqual(['P1', 'P2'])
+    })
+
+    it('aggregates across multiple teams', async () => {
+      const teamA = await prisma.team.create({ data: { name: 'GUP Multi A' } })
+      const teamB = await prisma.team.create({ data: { name: 'GUP Multi B' } })
+      await prisma.project.create({ data: { name: 'PA1', teamId: teamA.id } })
+      await prisma.project.create({ data: { name: 'PB1', teamId: teamB.id } })
+
+      const user = await prisma.user.create({
+        data: { name: 'gup-u3', email: 'gup-u3@example.com' },
+      })
+      await prisma.teamMember.create({
+        data: { teamId: teamA.id, userId: user.id, role: 'editor', scope: 'team' },
+      })
+      await prisma.teamMember.create({
+        data: { teamId: teamB.id, userId: user.id, role: 'editor', scope: 'team' },
+      })
+
+      const result = await projectService.getUserProjects(user.id)
+      expect(result).toHaveLength(2)
+      const names = result.map((p) => p.name).sort()
+      expect(names).toEqual(['PA1', 'PB1'])
+    })
+
+    it('respects limit parameter', async () => {
+      const team = await prisma.team.create({ data: { name: 'GUP Limit' } })
+      for (let i = 0; i < 5; i++) {
+        await prisma.project.create({ data: { name: `PLim${i}`, teamId: team.id } })
+      }
+
+      const user = await prisma.user.create({
+        data: { name: 'gup-u4', email: 'gup-u4@example.com' },
+      })
+      await prisma.teamMember.create({
+        data: { teamId: team.id, userId: user.id, role: 'editor', scope: 'team' },
+      })
+
+      const result = await projectService.getUserProjects(user.id, 2)
+      expect(result).toHaveLength(2)
+    })
+
+    it('returns empty array for user with no teams', async () => {
+      const user = await prisma.user.create({
+        data: { name: 'gup-u5', email: 'gup-u5@example.com' },
+      })
+
+      const result = await projectService.getUserProjects(user.id)
+      expect(result).toEqual([])
+    })
+  })
 })

--- a/packages/core/src/skill/skill.test.ts
+++ b/packages/core/src/skill/skill.test.ts
@@ -223,4 +223,36 @@ describe('SkillService', () => {
     })
     expect(dbSkill?.config).toEqual(newConfig)
   })
+
+  describe('getSkill', () => {
+    it('returns skill info with teamId when it exists', async () => {
+      const team = await prisma.team.create({ data: { name: 'Test Team' } })
+      const skill = await prisma.skill.create({
+        data: {
+          name: 'My Skill',
+          description: 'A description',
+          assetId: 'asset-1',
+          hash: 'hash-1',
+          teamId: team.id,
+        },
+      })
+
+      const result = await skillService.getSkill(skill.id)
+      expect(result).not.toBeNull()
+      expect(result?.id).toBe(skill.id)
+      expect(result?.name).toBe('My Skill')
+      expect(result?.description).toBe('A description')
+      expect(result?.teamId).toBe(team.id)
+      expect(result?.assetId).toBe('asset-1')
+      expect(result?.hash).toBe('hash-1')
+      expect(result?.permission).toBe('reviewer')
+      expect(typeof result?.createdAt).toBe('string')
+      expect(typeof result?.updatedAt).toBe('string')
+    })
+
+    it('returns null for non-existent ID', async () => {
+      const result = await skillService.getSkill('nonexistent-id')
+      expect(result).toBeNull()
+    })
+  })
 })

--- a/packages/core/src/team/team.test.ts
+++ b/packages/core/src/team/team.test.ts
@@ -324,4 +324,60 @@ describe('TeamService', () => {
     expect(settings.allowedDomains).toEqual([])
     expect(settings.pendingDomains).toEqual([])
   })
+
+  describe('hasWritableRoleInAnyTeam', () => {
+    it('should return true for user with owner role', async () => {
+      const user = await prisma.user.create({
+        data: { name: 'Owner User', email: 'hwt-owner@example.com', password: 'pw' },
+      })
+      const team = await prisma.team.create({
+        data: { name: 'Owner Team' },
+      })
+      await prisma.teamMember.create({
+        data: { teamId: team.id, userId: user.id, role: 'owner' },
+      })
+
+      const result = await teamService.hasWritableRoleInAnyTeam(user.id)
+      expect(result).toBe(true)
+    })
+
+    it('should return true for user with editor role', async () => {
+      const user = await prisma.user.create({
+        data: { name: 'Editor User', email: 'hwt-editor@example.com', password: 'pw' },
+      })
+      const team = await prisma.team.create({
+        data: { name: 'Editor Team' },
+      })
+      await prisma.teamMember.create({
+        data: { teamId: team.id, userId: user.id, role: 'editor' },
+      })
+
+      const result = await teamService.hasWritableRoleInAnyTeam(user.id)
+      expect(result).toBe(true)
+    })
+
+    it('should return false for user with only reviewer role', async () => {
+      const user = await prisma.user.create({
+        data: { name: 'Reviewer User', email: 'hwt-reviewer@example.com', password: 'pw' },
+      })
+      const team = await prisma.team.create({
+        data: { name: 'Reviewer Team' },
+      })
+      await prisma.teamMember.create({
+        data: { teamId: team.id, userId: user.id, role: 'reviewer' },
+      })
+
+      const result = await teamService.hasWritableRoleInAnyTeam(user.id)
+      expect(result).toBe(false)
+    })
+
+    it('should return false for user with no team membership', async () => {
+      const user = await prisma.user.create({
+        data: { name: 'No Team User', email: 'hwt-noteam@example.com', password: 'pw' },
+      })
+
+      const result = await teamService.hasWritableRoleInAnyTeam(user.id)
+      expect(result).toBe(false)
+    })
+  })
 })

--- a/packages/core/src/user/user.test.ts
+++ b/packages/core/src/user/user.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { prisma } from '@shumai/db'
+import { setupTestDbHooks } from '@shumai/db/test'
+import { userService } from '@shumai/core/src/user/user'
+
+describe('UserService', () => {
+  setupTestDbHooks()
+
+  describe('getUserById', () => {
+    it('returns user when exists', async () => {
+      const user = await prisma.user.create({
+        data: {
+          name: 'Test User',
+          email: 'gu-test@example.com',
+        },
+      })
+
+      const result = await userService.getUserById(user.id)
+
+      expect(result).not.toBeNull()
+      expect(result?.id).toBe(user.id)
+      expect(result?.name).toBe('Test User')
+      expect(result?.email).toBe('gu-test@example.com')
+    })
+
+    it('returns null for non-existent ID', async () => {
+      const result = await userService.getUserById('nonexistent-id')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('createGuestUser', () => {
+    it('creates user with correct fields', async () => {
+      const result = await userService.createGuestUser({
+        name: 'Guest',
+        email: 'guest@example.com',
+        guestEmail: 'original@example.com',
+      })
+
+      expect(result.name).toBe('Guest')
+      expect(result.email).toBe('guest@example.com')
+      expect(result.guestEmail).toBe('original@example.com')
+      expect(result.type).toBe('human')
+    })
+
+    it('persists to database', async () => {
+      const result = await userService.createGuestUser({
+        name: 'Guest',
+        email: 'guest@example.com',
+        guestEmail: 'original@example.com',
+      })
+
+      const dbUser = await prisma.user.findUnique({
+        where: { id: result.id },
+      })
+
+      expect(dbUser).not.toBeNull()
+      expect(dbUser?.name).toBe('Guest')
+      expect(dbUser?.email).toBe('guest@example.com')
+      expect(dbUser?.guestEmail).toBe('original@example.com')
+      expect(dbUser?.type).toBe('human')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Add comprehensive test coverage for 5 core service methods that were added in commit `97069042` ("refactor(api): enforce layered architecture by moving db queries to core services") but lacked corresponding tests.

## Changes

- **`AgentService.getAgent`** — 2 tests added to `agent.test.ts` (found vs not-found)
- **`ProjectService.getUserProjects`** — 5 tests added to `project.test.ts` (team scope, project scope, multi-team aggregation, limit parameter, empty result)
- **`SkillService.getSkill`** — 2 tests added to `skill.test.ts` (full field mapping with teamId, not-found)
- **`TeamService.hasWritableRoleInAnyTeam`** — 4 tests added to `team.test.ts` (owner ✓, editor ✓, reviewer ✗, no membership ✗)
- **`UserService`** — New test file `user.test.ts` created with 4 tests for `getUserById` and `createGuestUser`

Total: **15 new test cases** across 5 files (1 new, 4 modified).

## Verification

- `bun run lint` ✅
- `bun run format` ✅
- `bun run typecheck` ✅
- `bun run test` ✅ (95 test files, 776 tests passed)

## Notes

All tests follow the established `setupTestDbHooks()` pattern with real database (Testcontainers + transaction rollback). No mocking of Prisma — these are service-level integration tests.