### PR TITLE
refactor(agent): load models directly from database without pi fallback

### DIFF
--- a/packages/agent/src/database-session-storage.test.ts
+++ b/packages/agent/src/database-session-storage.test.ts
@@ -25,6 +25,20 @@ describe('DatabaseSessionStorage', () => {
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
   }
 
+  const mockProviders = [
+    {
+      name: 'test-provider',
+      config: { apiKey: 'TEST_KEY' },
+      models: [
+        {
+          modelId: 'test-model',
+          name: 'Test Model',
+          config: mockModelConfig,
+        },
+      ],
+    },
+  ]
+
   const setupTestData = async () => {
     const team = await prisma.team.create({ data: { name: 'Test Team' } })
     const provider = await prisma.provider.create({
@@ -340,7 +354,7 @@ describe('DatabaseSessionStorage', () => {
       allowedDomains: [],
       sessionId: sessionId,
       userId: user.id,
-      providers: [],
+      providers: mockProviders,
     })
 
     // 7. Verify skill environment variables are restored.
@@ -453,7 +467,7 @@ describe('DatabaseSessionStorage', () => {
       sessionId: sessionId,
       userId: user.id,
       userCommentId: 'new-comment-456',
-      providers: [],
+      providers: mockProviders,
     })
 
     // 4. Assert that the tools were instantiated using the new comment ID and user ID
@@ -507,7 +521,7 @@ describe('DatabaseSessionStorage', () => {
       sessionId: sessionId,
       userId: user.id,
       userCommentId: 'new-comment-456',
-      providers: [],
+      providers: mockProviders,
     })
 
     // 4. Assert that the tools were instantiated using the new comment ID and user ID

--- a/packages/agent/src/database-session-storage.test.ts
+++ b/packages/agent/src/database-session-storage.test.ts
@@ -5,7 +5,7 @@ import { type SessionTreeEntry } from '@earendil-works/pi-agent-core'
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import { DatabaseSessionStorage } from './database-session-storage'
 import { agentService } from '@shumai/core/src/agent/agent'
-import { createAgentSession } from './index'
+import { createAgentSession, type DbProviderInfo } from './index'
 import * as sandboxedBashModule from './tools/sandboxed-bash'
 import * as analyzeImageModule from './tools/analyze-image'
 import * as screenshotModule from './tools/screenshot'
@@ -25,10 +25,10 @@ describe('DatabaseSessionStorage', () => {
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
   }
 
-  const mockProviders = [
+  const mockProviders: DbProviderInfo[] = [
     {
       name: 'test-provider',
-      config: { apiKey: 'TEST_KEY' },
+      config: { api: 'openai-responses', apiKey: 'TEST_KEY' },
       models: [
         {
           modelId: 'test-model',

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -28,6 +28,27 @@ vi.mock('node:child_process', async () => {
   }
 })
 
+const mockProviders: DbProviderInfo[] = [
+  {
+    name: 'google',
+    config: { api: 'google-generative-ai', apiKey: 'GOOGLE_API_KEY' },
+    models: [
+      {
+        modelId: 'gemini',
+        name: 'Gemini',
+        config: {
+          api: 'google-generative-ai',
+          reasoning: false,
+          input: ['text'],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 8192,
+          maxTokens: 4096,
+        },
+      },
+    ],
+  },
+]
+
 describe('formatSkillsForPrompt', () => {
   it('should return empty string if skills array is empty', () => {
     expect(formatSkillsForPrompt([])).toBe('')
@@ -104,7 +125,7 @@ describe('Sandbox Network isolation integration', () => {
       systemPrompt: 'prompt',
       teamSkills: [],
       allowedDomains: [],
-      providers: [],
+      providers: mockProviders,
     })
 
     // 4. Verify SandboxManager.initialize was called and extract the callback
@@ -232,7 +253,7 @@ describe('Sandbox Network isolation integration', () => {
         systemPrompt: 'prompt',
         teamSkills: [],
         allowedDomains: [],
-        providers: [],
+        providers: mockProviders,
       })
 
       // 3. Call createAgentSession for Session 2
@@ -244,7 +265,7 @@ describe('Sandbox Network isolation integration', () => {
         systemPrompt: 'prompt',
         teamSkills: [],
         allowedDomains: [],
-        providers: [],
+        providers: mockProviders,
       })
 
       expect(registeredCallback).toBeDefined()
@@ -314,7 +335,7 @@ describe('Sandbox Network isolation integration', () => {
         systemPrompt: 'prompt',
         teamSkills: [],
         allowedDomains: [],
-        providers: [],
+        providers: mockProviders,
         thinkingLevel: 'high',
       })
       expect(harnessHigh.getThinkingLevel()).toBe('high')
@@ -328,7 +349,7 @@ describe('Sandbox Network isolation integration', () => {
         systemPrompt: 'prompt',
         teamSkills: [],
         allowedDomains: [],
-        providers: [],
+        providers: mockProviders,
       })
       expect(harnessDefault.getThinkingLevel()).toBe('off')
     } finally {
@@ -367,7 +388,7 @@ describe('Sandbox Network isolation integration', () => {
         systemPrompt: 'prompt',
         teamSkills: [],
         allowedDomains: [],
-        providers: [],
+        providers: mockProviders,
         maxRetries: 5,
         baseDelayMs: 1500,
       })
@@ -410,7 +431,7 @@ describe('Sandbox Network isolation integration', () => {
         systemPrompt: 'prompt',
         teamSkills: [],
         allowedDomains: [],
-        providers: [],
+        providers: mockProviders,
       })
       const tools = harness.getTools()
       const bashTool = tools.find((t) => t.name === 'bash')
@@ -452,6 +473,12 @@ describe('getModelFromDb', () => {
     expect(model?.id).toBe('non-existent-or-future-model')
     expect(model?.provider).toBe('google')
     expect(model?.api).toBe('google-generative-ai')
+  })
+
+  it('should throw an error when provider or model is not found in database configuration', () => {
+    expect(() => getModelFromDb([], 'google', 'non-existent')).toThrow(
+      'Provider "google" or model "non-existent" not found in database configuration',
+    )
   })
 })
 
@@ -497,7 +524,7 @@ describe('createAgentSession sandbox options', () => {
       systemPrompt: 'prompt',
       teamSkills: [],
       allowedDomains: [],
-      providers: [],
+      providers: mockProviders,
     })
     expect(initializeSpy).toHaveBeenCalledWith(
       expect.objectContaining({ enableWeakerNestedSandbox: false }),
@@ -514,7 +541,7 @@ describe('createAgentSession sandbox options', () => {
       systemPrompt: 'prompt',
       teamSkills: [],
       allowedDomains: [],
-      providers: [],
+      providers: mockProviders,
     })
     expect(initializeSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({ enableWeakerNestedSandbox: true }),

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6,7 +6,7 @@ import {
   type ThinkingLevel,
 } from '@earendil-works/pi-agent-core'
 import { NodeExecutionEnv } from '@earendil-works/pi-agent-core/node'
-import { getModel } from '@earendil-works/pi-ai/compat'
+import type { Api, Model } from '@earendil-works/pi-ai'
 import { agentService } from '@shumai/core/src/agent/agent'
 import { prisma } from '@shumai/db'
 import { Type, type TSchema } from '@sinclair/typebox'
@@ -42,33 +42,23 @@ export function getModelFromDb(providers: DbProviderInfo[], providerName: string
   const dbProvider = providers.find((p) => p.name === providerName)
   const dbModel = dbProvider?.models.find((m) => m.modelId === modelId)
 
-  if (!dbProvider || !dbModel) return undefined
+  if (!dbProvider || !dbModel) {
+    throw new Error(
+      `Provider "${providerName}" or model "${modelId}" not found in database configuration`,
+    )
+  }
 
-  // Model contains complex internal types from pi-ai
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let m: any
-  try {
-    // Try to get built-in model as template
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const builtIn = (getModel as any)(providerName, modelId)
-    if (!builtIn) {
-      throw new Error(`Model ${modelId} is not a built-in model`)
-    }
-    m = { ...builtIn }
-  } catch {
-    // Not a built-in model
-    m = {
-      id: modelId,
-      name: dbModel.name || modelId,
-      provider: providerName,
-      api: 'openai-responses',
-      baseUrl: '',
-      reasoning: false,
-      input: ['text'],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 4096,
-      maxTokens: 4096,
-    }
+  const m = {
+    id: modelId,
+    name: dbModel.name || modelId,
+    provider: providerName,
+    api: 'openai-responses',
+    baseUrl: '',
+    reasoning: false,
+    input: ['text'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 4096,
+    maxTokens: 4096,
   }
 
   // Override with database config
@@ -82,7 +72,7 @@ export function getModelFromDb(providers: DbProviderInfo[], providerName: string
   if (dbModel.name) {
     m.name = dbModel.name
   }
-  return m
+  return m as Model<Api>
 }
 
 export function getApiKeyAndHeadersFromDb(providers: DbProviderInfo[], providerName: string) {
@@ -151,9 +141,7 @@ export async function createAgentSession(params: CreateAgentSessionParams) {
   const agentDir = path.join(process.cwd(), '.pi', 'agents', agentId)
   if (!fs.existsSync(agentDir)) fs.mkdirSync(agentDir, { recursive: true })
 
-  const model =
-    getModelFromDb(params.providers, providerName, modelId) ||
-    (getModel as unknown as (p: string, m: string) => unknown)(providerName, modelId)
+  const model = getModelFromDb(params.providers, providerName, modelId)
 
   const piDir = path.join(process.cwd(), '.pi')
   if (!fs.existsSync(piDir)) fs.mkdirSync(piDir, { recursive: true })


### PR DESCRIPTION
## Summary

Refactors `getModelFromDb` in `@shumai/agent` to load model configurations directly from database provider data without relying on or falling back to `@earendil-works/pi-ai/compat`'s `getModel`.

## Changes

- Removed `getModel` import and fallback logic from `packages/agent/src/index.ts`.
- Updated `getModelFromDb` to throw an error if the requested provider or model is not found in the database.
- Updated unit test cases in `packages/agent/src/index.test.ts` and `packages/agent/src/database-session-storage.test.ts` to pass mock DB provider configurations.
- Added a unit test asserting that `getModelFromDb` throws an error when a model is not found in the database configuration.

## Verification

- `bun run lint`: Passed
- `bun run format`: Passed
- `bun run typecheck`: Passed
- `bun run test`: Passed (95 test files, 777 tests)
- `bun run test:e2e:workflow`: Passed (11 test files, 42 tests)

## Notes

Database provider configurations serve as the single source of truth for all built-in and custom models.