### PR TITLE
feat(webui): persist agent preference in localStorage

### DIFF
--- a/packages/webui/stores/chatbot.test.ts
+++ b/packages/webui/stores/chatbot.test.ts
@@ -1,7 +1,34 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useChatbotStore } from './chatbot'
+import { useChatbotStore, AGENT_PREFERENCE_STORAGE_KEY } from './chatbot'
 import { client } from '@/ui/api/client'
 import type { ChatMessage } from '@shumai/dtos'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value.toString()
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+
+if (typeof globalThis.localStorage === 'undefined') {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: localStorageMock,
+  })
+}
+if (typeof globalThis.window === 'undefined') {
+  Object.defineProperty(globalThis, 'window', {
+    value: globalThis,
+  })
+}
 
 vi.mock('@/ui/api/client', () => {
   const chatMock = {
@@ -30,6 +57,7 @@ vi.mock('@/ui/api/client', () => {
 describe('useChatbotStore', () => {
   beforeEach(() => {
     vi.resetAllMocks()
+    localStorage.clear()
     useChatbotStore.setState({
       isHistoryMode: false,
       isChatbotOpen: false,
@@ -41,6 +69,30 @@ describe('useChatbotStore', () => {
       selectedAgentId: 'agent-1',
       inputText: '',
     })
+  })
+
+  it('should persist selectedAgentId to localStorage when setSelectedAgentId is called', () => {
+    useChatbotStore.getState().setSelectedAgentId('agent-pref-123')
+    expect(useChatbotStore.getState().selectedAgentId).toBe('agent-pref-123')
+    expect(localStorage.getItem(AGENT_PREFERENCE_STORAGE_KEY)).toBe('agent-pref-123')
+
+    useChatbotStore.getState().setSelectedAgentId(null)
+    expect(useChatbotStore.getState().selectedAgentId).toBeNull()
+    expect(localStorage.getItem(AGENT_PREFERENCE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('should restore preferred agent from localStorage on startNewSession', () => {
+    localStorage.setItem(AGENT_PREFERENCE_STORAGE_KEY, 'agent-pref-saved')
+    useChatbotStore.setState({
+      selectedAgentId: 'agent-temporary-historical',
+      currentSessionId: 'sess-historical',
+      messages: [{ id: 'msg-1', role: 'user', content: 'test' } as unknown as ChatMessage],
+    })
+
+    useChatbotStore.getState().startNewSession()
+    const state = useChatbotStore.getState()
+    expect(state.currentSessionId).toBeNull()
+    expect(state.selectedAgentId).toBe('agent-pref-saved')
   })
 
   it('should persist and reset inputText', () => {

--- a/packages/webui/stores/chatbot.ts
+++ b/packages/webui/stores/chatbot.ts
@@ -3,6 +3,15 @@ import { client } from '@/ui/api/client'
 import type { ChatMessage, ChatSessionInfo } from '@shumai/dtos'
 import { toast } from 'sonner'
 
+export const AGENT_PREFERENCE_STORAGE_KEY = 'shumai_selected_agent_id'
+
+const getInitialAgentId = (): string | null => {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    return localStorage.getItem(AGENT_PREFERENCE_STORAGE_KEY)
+  }
+  return null
+}
+
 export interface ChatAsset {
   id: string
   name: string
@@ -74,8 +83,17 @@ export const useChatbotStore = create<ChatbotState>((set) => ({
   setHistorySessions: (sessions) => set({ historySessions: sessions }),
   isStreaming: false,
   setIsStreaming: (streaming) => set({ isStreaming: streaming }),
-  selectedAgentId: null,
-  setSelectedAgentId: (id) => set({ selectedAgentId: id }),
+  selectedAgentId: getInitialAgentId(),
+  setSelectedAgentId: (id) => {
+    if (typeof window !== 'undefined' && window.localStorage) {
+      if (id) {
+        localStorage.setItem(AGENT_PREFERENCE_STORAGE_KEY, id)
+      } else {
+        localStorage.removeItem(AGENT_PREFERENCE_STORAGE_KEY)
+      }
+    }
+    set({ selectedAgentId: id })
+  },
   inputText: '',
   setInputText: (text) => set({ inputText: text }),
   scrollTop: 0,
@@ -147,6 +165,7 @@ export const useChatbotStore = create<ChatbotState>((set) => ({
   },
 
   startNewSession: () => {
+    const savedAgentId = getInitialAgentId()
     set({
       currentSessionId: null,
       messages: [],
@@ -154,6 +173,7 @@ export const useChatbotStore = create<ChatbotState>((set) => ({
       inputText: '',
       scrollTop: 0,
       isAtBottom: true,
+      ...(savedAgentId ? { selectedAgentId: savedAgentId } : {}),
     })
   },
 


### PR DESCRIPTION
## Summary

Persist selected agent preference in `localStorage` so that user preference is remembered across page reloads and when starting new chat sessions, while allowing historical chat sessions to preserve their session-specific agent.

## Changes

- Defined `AGENT_PREFERENCE_STORAGE_KEY` and initialized `selectedAgentId` in `useChatbotStore` from `localStorage`.
- Updated `setSelectedAgentId` to save/remove agent preference in `localStorage`.
- Updated `startNewSession` to restore the saved agent preference from `localStorage`.
- Added unit tests in `packages/webui/stores/chatbot.test.ts` covering `localStorage` persistence and preference restoration.

## Verification

- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test`
- `bun run test:e2e`
- `bun run test:e2e:workflow`

## Notes

None.