### PR TITLE
fix(webui): mention popup avatars, keyboard auto-scroll, and non-sticky section headers

### DIFF
--- a/packages/webui/components/chat/message-input.tsx
+++ b/packages/webui/components/chat/message-input.tsx
@@ -552,7 +552,7 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
                             e.stopPropagation()
                             setCollapsedSections((prev) => ({ ...prev, bots: !prev.bots }))
                           }}
-                          className="w-full text-xs font-semibold text-muted-foreground px-3 py-2 bg-muted/50 border-b border-border sticky top-0 flex items-center justify-between hover:bg-muted transition-colors"
+                          className="w-full text-xs font-semibold text-muted-foreground px-3 py-2 bg-muted/50 border-b border-border flex items-center justify-between hover:bg-muted transition-colors"
                         >
                           <span>Agents</span>
                           <ChevronDown
@@ -601,7 +601,7 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
                             e.stopPropagation()
                             setCollapsedSections((prev) => ({ ...prev, users: !prev.users }))
                           }}
-                          className="w-full text-xs font-semibold text-muted-foreground px-3 py-2 bg-muted/50 border-b border-border sticky top-0 flex items-center justify-between hover:bg-muted transition-colors"
+                          className="w-full text-xs font-semibold text-muted-foreground px-3 py-2 bg-muted/50 border-b border-border flex items-center justify-between hover:bg-muted transition-colors"
                         >
                           <span>Members</span>
                           <ChevronDown

--- a/packages/webui/components/chat/message-input.tsx
+++ b/packages/webui/components/chat/message-input.tsx
@@ -6,6 +6,7 @@ import { client } from '@/ui/api/client'
 import { useAnnotationStore } from '@/ui/stores/annotation-store'
 import type { Annotation } from '@/ui/types'
 import { useMutation } from '@tanstack/react-query'
+import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar'
 import { Skeleton } from '../ui/skeleton'
 import { useMemberStore } from '@/ui/stores/members'
 import { useTeamContextStore } from '@/ui/stores/team-context'
@@ -158,6 +159,7 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
     const editorRef = useRef<HTMLDivElement>(null)
     const fileInputRef = useRef<HTMLInputElement>(null)
     const mentionRangeRef = useRef<Range | null>(null)
+    const mentionListRef = useRef<HTMLDivElement>(null)
 
     const { mutateAsync: uploadAttachment } = useMutation({
       mutationFn: async ({
@@ -237,6 +239,22 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
     useEffect(() => {
       setHighlightedIndex(0)
     }, [mentionQuery, showMentionList, collapsedSections])
+
+    // Keep the highlighted mention item visible when navigating with arrow keys
+    useEffect(() => {
+      mentionListRef.current
+        ?.querySelector<HTMLElement>(`[data-index="${highlightedIndex}"]`)
+        ?.scrollIntoView({ block: 'nearest' })
+    }, [highlightedIndex])
+
+    const getInitials = (name: string) => {
+      return name
+        .split(' ')
+        .map((n) => n[0])
+        .slice(0, 2)
+        .join('')
+        .toUpperCase()
+    }
 
     const handleInput = () => {
       if (!editorRef.current) return
@@ -492,7 +510,7 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
         {showMentionList &&
           (membersLoading || filteredAgents.length > 0 || filteredHumans.length > 0) && (
             <div className="absolute bottom-full left-4 mb-2 w-64 rounded-xl shadow-lg border border-border overflow-hidden z-20 bg-popover text-popover-foreground animate-in fade-in slide-in-from-bottom-2 duration-200">
-              <div className="h-64 overflow-y-auto">
+              <div ref={mentionListRef} className="h-64 overflow-y-auto">
                 {membersLoading ? (
                   <div className="p-2 space-y-4 animate-pulse">
                     {/* Agents Skeleton */}
@@ -547,6 +565,7 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
                             return (
                               <button
                                 key={item.data.id}
+                                data-index={actualIndex}
                                 onClick={() => handleSelectEntity(item)}
                                 onMouseEnter={() => setHighlightedIndex(actualIndex)}
                                 className={`w-full flex items-center gap-2 px-3 py-2 transition-colors text-left ${
@@ -555,9 +574,18 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
                                     : 'hover:bg-accent/50'
                                 }`}
                               >
-                                <div className="w-6 h-6 rounded-full bg-purple-100 dark:bg-purple-900/40 flex items-center justify-center text-xs font-bold text-purple-600 dark:text-purple-300">
-                                  {item.data.name?.[0]}
-                                </div>
+                                <Avatar className="w-6 h-6">
+                                  {item.type === 'user' && item.data.image && (
+                                    <AvatarImage
+                                      src={item.data.image}
+                                      alt={item.data.name}
+                                      className="object-cover"
+                                    />
+                                  )}
+                                  <AvatarFallback className="text-[10px] bg-purple-400 text-black font-semibold">
+                                    {getInitials(item.data.name)}
+                                  </AvatarFallback>
+                                </Avatar>
                                 <span className="text-sm">{item.data.name}</span>
                               </button>
                             )
@@ -587,6 +615,7 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
                             return (
                               <button
                                 key={item.data.id}
+                                data-index={actualIndex}
                                 onClick={() => handleSelectEntity(item)}
                                 onMouseEnter={() => setHighlightedIndex(actualIndex)}
                                 className={`w-full flex items-center gap-2 px-3 py-2 transition-colors text-left ${
@@ -595,9 +624,18 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
                                     : 'hover:bg-accent/50'
                                 }`}
                               >
-                                <div className="w-6 h-6 rounded-full bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center text-xs font-bold text-blue-600 dark:text-blue-300">
-                                  {item.data.name?.[0]}
-                                </div>
+                                <Avatar className="w-6 h-6">
+                                  {item.type === 'user' && item.data.image && (
+                                    <AvatarImage
+                                      src={item.data.image}
+                                      alt={item.data.name}
+                                      className="object-cover"
+                                    />
+                                  )}
+                                  <AvatarFallback className="text-[10px] bg-blue-400 text-black font-semibold">
+                                    {getInitials(item.data.name)}
+                                  </AvatarFallback>
+                                </Avatar>
                                 <span className="text-sm">{item.data.name}</span>
                               </button>
                             )


### PR DESCRIPTION
## Summary

Fixes three issues in the comment input box @-mention user select popup:
1. User avatars were not shown (only a colored letter circle was rendered).
2. Pressing ArrowDown/ArrowUp did not auto-scroll the list, so the highlighted row could move out of view.
3. The Agents/Members section headers used `sticky top-0`, causing the Agents header to stay pinned while scrolling and the Members header to snap onto the same top position and overlap/cover it.

## Changes

- **Avatars**: Replaced the letter-in-circle `<div>` in both the Agents and Members rows with the shadcn `Avatar`/`AvatarImage`/`AvatarFallback` components (matching the pattern already used in `message-card.tsx` and `user-field.tsx`). Users now render their real avatar image via `UserInfo.image` with an initials fallback; bots keep a colored fallback chip since `BotInfo` has no image field. The agents/humans fallback colors (purple/blue) are preserved.
- **Auto-scroll**: Added a ref to the popup's scroll container (`h-64 overflow-y-auto`), tagged each row with `data-index`, and added an effect that calls `scrollIntoView({ block: 'nearest' })` when `highlightedIndex` changes, keeping the highlighted row visible during keyboard navigation.
- **Sticky headers**: Removed `sticky top-0` from both the Agents and Members header buttons so they scroll away naturally with their sections (previously two sticky elements with the same top offset overlapped when scrolled — verified by measuring both headers landing at the identical 0–31px band at full scroll, with the Members header painting on top).

## Verification

- `bun run lint` ✅
- `bun run format` ✅
- `bun run typecheck` ✅
- `bun run test` — 779 passed ✅
- `bun run test:e2e` — 30 passed (harness + app, all browsers) ✅
- `bun run test:e2e:workflow` — 42 passed ✅

## Notes

- Scroll is instant (`block: 'nearest'`, no smooth behavior) per request.
- No existing mention-related e2e tests were affected.