### PR TITLE
test(e2e): add project-level invite and file-move e2e tests

### DIFF
--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -71,6 +71,10 @@ apps/web/e2e/
 | Owner creates a share link from a file context menu and lands on the share page | `tests/project/create-share-link.spec.ts` |
 | Owner protects a share with a password; guests must enter it to view | `tests/project/share-password.spec.ts` |
 | Owner creates a collection from the sidebar; the collection shows project files | `tests/project/create-collection.spec.ts` |
+| Owner invites a member to a project; the member only sees the invited project | `tests/project/invite-member.spec.ts` |
+| Owner drags a file into a folder and a folder into another folder | `tests/project/move-folder-file.spec.ts` |
+| Owner drags a file onto a file to create a version stack | `tests/project/version-stack-create.spec.ts` |
+| Owner drags a file onto a version stack to add a new version | `tests/project/version-stack-add-version.spec.ts` |
 
 ## Conventions
 

--- a/apps/web/e2e/fixtures.ts
+++ b/apps/web/e2e/fixtures.ts
@@ -44,6 +44,8 @@ export interface OwnerFixture {
 export interface ProjectFixture extends OwnerFixture {
   projectId: string
   projectName: string
+  /** The project's root folder asset id. */
+  rootFolderId: string
 }
 
 /** The media kind of a seeded test file. */
@@ -132,10 +134,13 @@ export const test = base.extend<{
     }
   },
   /** Sets up an authenticated team owner plus a project created via the API. */
-  project: async ({ owner }, use) => {
+  project: async ({ owner, prisma }, use) => {
     const name = uniqueProjectName()
     const project = await apiCreateProject(owner.context.request, owner.teamId, name)
-    await use({ ...owner, projectId: project.id, projectName: name })
+    const projectRow = await prisma.project.findUnique({ where: { id: project.id } })
+    const rootFolderId = projectRow?.rootFolderId
+    if (!rootFolderId) throw new Error('Project has no root folder')
+    await use({ ...owner, projectId: project.id, projectName: name, rootFolderId })
   },
   /**
    * Sets up an owner + project with a seeded processed file asset under the

--- a/apps/web/e2e/helpers/assets.ts
+++ b/apps/web/e2e/helpers/assets.ts
@@ -1,0 +1,31 @@
+import type { PrismaClient } from '../../../../packages/db/src/generated/prisma/client'
+
+/**
+ * Seeds a folder asset directly through the database (fast, no UI). The folder
+ * is placed under `parentId` (usually a project's root folder).
+ */
+export async function seedFolder(
+  prisma: PrismaClient,
+  projectId: string,
+  parentId: string,
+  name: string,
+) {
+  return prisma.asset.create({
+    data: { name, type: 'folder', status: 'processed', projectId, parentId },
+  })
+}
+
+/**
+ * Seeds a processed file asset directly through the database (fast, no UI).
+ * The file is placed under `parentId` (a folder or a version stack).
+ */
+export async function seedFile(
+  prisma: PrismaClient,
+  projectId: string,
+  parentId: string,
+  name: string,
+) {
+  return prisma.asset.create({
+    data: { name, type: 'file', status: 'processed', sizeByte: 10, projectId, parentId },
+  })
+}

--- a/apps/web/e2e/helpers/dnd.ts
+++ b/apps/web/e2e/helpers/dnd.ts
@@ -1,0 +1,37 @@
+import type { Locator, Page } from '@playwright/test'
+
+/**
+ * Performs a pointer drag from one card to another. dnd-kit v6 uses a
+ * `PointerSensor` with a 10px distance activation constraint, and WebKit only
+ * reliably starts the drag when pointer moves are delivered in separate,
+ * awaited batches (a single fast `mouse.move(steps)` can be coalesced before
+ * the drag activates, losing the drop). Moves are therefore chunked with
+ * intermediate waits so the activation and drag move handlers run between
+ * batches on every browser.
+ */
+export async function dragCard(page: Page, source: Locator, target: Locator): Promise<void> {
+  const sourceBox = (await source.boundingBox())!
+  const targetBox = (await target.boundingBox())!
+  if (!sourceBox || !targetBox) {
+    throw new Error('Drag source or target has no bounding box')
+  }
+
+  const fromX = sourceBox.x + sourceBox.width / 2
+  const fromY = sourceBox.y + sourceBox.height / 2
+  const toX = targetBox.x + targetBox.width / 2
+  const toY = targetBox.y + targetBox.height / 2
+
+  await page.mouse.move(fromX, fromY)
+  await page.mouse.down()
+
+  // Move in several chunks so the dnd-kit sensor activates mid-drag
+  const chunks = 8
+  for (let i = 1; i <= chunks; i++) {
+    const x = fromX + ((toX - fromX) * i) / chunks
+    const y = fromY + ((toY - fromY) * i) / chunks
+    await page.mouse.move(x, y)
+    await page.waitForTimeout(15)
+  }
+
+  await page.mouse.up()
+}

--- a/apps/web/e2e/helpers/ui.ts
+++ b/apps/web/e2e/helpers/ui.ts
@@ -34,6 +34,14 @@ export async function openMembersDialog(page: Page): Promise<Locator> {
   return dialog
 }
 
+/** Opens the project members dialog from the project file-browser toolbar. */
+export async function openProjectMembersDialog(page: Page): Promise<Locator> {
+  await page.getByTestId('project-members-trigger').click()
+  const dialog = page.locator('[role="dialog"]')
+  await expect(dialog).toBeVisible()
+  return dialog
+}
+
 /** Clicks "Generate Link" in the members dialog and returns the invite link. */
 export async function generateInviteLink(dialog: Locator): Promise<string> {
   await dialog.getByRole('button', { name: 'Generate Link' }).click()

--- a/apps/web/e2e/tests/project/invite-member.spec.ts
+++ b/apps/web/e2e/tests/project/invite-member.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '../../fixtures'
+import { E2E_PASSWORD, uniqueEmail } from '../../helpers/auth'
+import { apiCreateProject, uniqueProjectName } from '../../helpers/project'
+import { generateInviteLink, openProjectMembersDialog } from '../../helpers/ui'
+
+test('owner invites a member to a project; the member only sees the invited project', async ({
+  project,
+  browser,
+  prisma,
+}) => {
+  const { page, context, teamId, projectId, projectName } = project
+
+  // A second project the invitee must NOT see
+  const secondProject = await apiCreateProject(context.request, teamId, uniqueProjectName())
+
+  // 1. Owner opens the project members dialog and generates an invite link
+  await page.goto(`/projects/${projectId}`)
+  await expect(page.getByTestId('project-members-trigger')).toBeVisible()
+  const dialog = await openProjectMembersDialog(page)
+  const inviteLink = await generateInviteLink(dialog)
+
+  const inviteCode = new URL(inviteLink).searchParams.get('inviteCode')
+  if (!inviteCode) {
+    throw new Error(`Invite link is missing the inviteCode param: ${inviteLink}`)
+  }
+  const origin = new URL(page.url()).origin
+  expect(inviteLink.startsWith(`${origin}/signup?inviteCode=`)).toBe(true)
+
+  // 2. The invitee signs up through the invite link in a brand-new session
+  const inviteeContext = await browser.newContext()
+  const inviteePage = await inviteeContext.newPage()
+  const inviteeEmail = uniqueEmail('project-invitee')
+  try {
+    await inviteePage.goto(inviteLink)
+
+    // The invite context banner is shown on the signup page
+    await expect(inviteePage.getByText(/invited you to join/)).toBeVisible()
+
+    await inviteePage.fill('#email', inviteeEmail)
+    await inviteePage.fill('#password', E2E_PASSWORD)
+    await inviteePage.click('button[type="submit"]')
+
+    // The invitee is redirected to the shared team page
+    await expect(inviteePage).toHaveURL(/\/teams\/[^/]+/)
+
+    // 3. The invitee only sees the invited project, not the second one
+    await expect(inviteePage.getByText(projectName, { exact: true })).toBeVisible()
+    await expect(inviteePage.getByText(secondProject.name, { exact: true })).not.toBeVisible()
+
+    // 4. Direct access to the other project is denied (API returns 403)
+    const res = await inviteeContext.request.get(`/api/projects/${secondProject.id}`)
+    expect(res.status()).toBe(403)
+
+    // 5. Opening the other project URL renders the router error boundary
+    await inviteePage.goto(`/projects/${secondProject.id}`)
+    await expect(inviteePage.getByText('Something went wrong!')).toBeVisible()
+  } finally {
+    await inviteeContext.close()
+  }
+
+  // 6. DB: the invitee is a project-scoped team member of exactly the invited project
+  const inviteeUser = await prisma.user.findUnique({ where: { email: inviteeEmail } })
+  expect(inviteeUser).not.toBeNull()
+
+  const tm = await prisma.teamMember.findUnique({
+    where: { teamIdUserId: { teamId, userId: inviteeUser!.id } },
+  })
+  expect(tm?.scope).toBe('project')
+
+  const projectMemberships = await prisma.projectMember.findMany({
+    where: { teamMemberId: tm!.id },
+  })
+  expect(projectMemberships).toHaveLength(1)
+  expect(projectMemberships[0].projectId).toBe(projectId)
+
+  const invite = await prisma.invite.findUnique({ where: { code: inviteCode } })
+  expect(invite?.used).toBe(true)
+  expect(invite?.projectId).toBe(projectId)
+})

--- a/apps/web/e2e/tests/project/move-folder-file.spec.ts
+++ b/apps/web/e2e/tests/project/move-folder-file.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '../../fixtures'
+import { seedFile, seedFolder } from '../../helpers/assets'
+import { dragCard } from '../../helpers/dnd'
+import { fileCard } from '../../helpers/files'
+
+test('owner moves a file into a folder and a folder into another folder', async ({
+  project,
+  prisma,
+}) => {
+  const { page, projectId, rootFolderId } = project
+
+  const folderA = await seedFolder(prisma, projectId, rootFolderId, `e2e-folder-a-${Date.now()}`)
+  const folderB = await seedFolder(prisma, projectId, rootFolderId, `e2e-folder-b-${Date.now()}`)
+  const file1 = await seedFile(prisma, projectId, rootFolderId, `e2e-move-file-${Date.now()}`)
+
+  await page.goto(`/projects/${projectId}`)
+  await expect(fileCard(page, file1.name)).toBeVisible()
+  await expect(fileCard(page, folderA.name)).toBeVisible()
+  await expect(fileCard(page, folderB.name)).toBeVisible()
+
+  // 1. Drag the file onto folder A -> the file moves into folder A
+  await dragCard(page, fileCard(page, file1.name), fileCard(page, folderA.name))
+
+  await expect
+    .poll(async () => {
+      const asset = await prisma.asset.findUnique({ where: { id: file1.id } })
+      return asset?.parentId
+    })
+    .toBe(folderA.id)
+
+  // The file is no longer in the project root
+  await expect(fileCard(page, file1.name)).not.toBeVisible()
+
+  // Opening folder A shows the moved file
+  await fileCard(page, folderA.name).dblclick()
+  await expect(page).toHaveURL(new RegExp(`/projects/${projectId}/folders/${folderA.id}`))
+  await expect(fileCard(page, file1.name)).toBeVisible()
+
+  // 2. Back at the root, drag folder A onto folder B -> folder A moves into folder B
+  await page.goto(`/projects/${projectId}`)
+  await expect(fileCard(page, folderA.name)).toBeVisible()
+  await expect(fileCard(page, folderB.name)).toBeVisible()
+
+  await dragCard(page, fileCard(page, folderA.name), fileCard(page, folderB.name))
+
+  await expect
+    .poll(async () => {
+      const asset = await prisma.asset.findUnique({ where: { id: folderA.id } })
+      return asset?.parentId
+    })
+    .toBe(folderB.id)
+
+  // Folder A is no longer in the project root
+  await expect(fileCard(page, folderA.name)).not.toBeVisible()
+
+  // Opening folder B shows folder A inside it
+  await fileCard(page, folderB.name).dblclick()
+  await expect(page).toHaveURL(new RegExp(`/projects/${projectId}/folders/${folderB.id}`))
+  await expect(fileCard(page, folderA.name)).toBeVisible()
+
+  // 3. DB: folder/file counters are kept in sync on the moved folders
+  const movedFolderA = await prisma.asset.findUnique({ where: { id: folderA.id } })
+  expect(movedFolderA?.fileCount).toBe(1) // file1 moved in
+  const movedFolderB = await prisma.asset.findUnique({ where: { id: folderB.id } })
+  expect(movedFolderB?.fileCount).toBe(1) // folderA moved in
+})

--- a/apps/web/e2e/tests/project/version-stack-add-version.spec.ts
+++ b/apps/web/e2e/tests/project/version-stack-add-version.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '../../fixtures'
+import { seedFile } from '../../helpers/assets'
+import { dragCard } from '../../helpers/dnd'
+import { fileCard } from '../../helpers/files'
+
+test('owner moves a file onto a version stack to create a new version', async ({
+  project,
+  prisma,
+}) => {
+  const { page, projectId, rootFolderId } = project
+
+  const fileA = await seedFile(prisma, projectId, rootFolderId, `e2e-ver-a-${Date.now()}`)
+  const fileB = await seedFile(prisma, projectId, rootFolderId, `e2e-ver-b-${Date.now()}`)
+  const fileC = await seedFile(prisma, projectId, rootFolderId, `e2e-ver-c-${Date.now()}`)
+
+  await page.goto(`/projects/${projectId}`)
+  await expect(fileCard(page, fileA.name)).toBeVisible()
+  await expect(fileCard(page, fileB.name)).toBeVisible()
+  await expect(fileCard(page, fileC.name)).toBeVisible()
+
+  // 1. First create a version stack by dropping file B onto file A
+  await dragCard(page, fileCard(page, fileB.name), fileCard(page, fileA.name))
+  await expect(page.getByText('v2', { exact: true })).toBeVisible()
+
+  await expect
+    .poll(async () => {
+      return prisma.asset.count({
+        where: { projectId, parentId: rootFolderId, type: 'version_stack' },
+      })
+    })
+    .toBe(1)
+  let stack = await prisma.asset.findFirstOrThrow({
+    where: { projectId, parentId: rootFolderId, type: 'version_stack' },
+  })
+  expect(stack.fileCount).toBe(2)
+
+  // 2. Drop file C onto the stack card -> a new version is added to the stack
+  // (the stack card currently displays the latest version's name, file B)
+  await dragCard(page, fileCard(page, fileC.name), fileCard(page, fileB.name))
+
+  // The newly added file becomes the latest version: the stack card shows file C
+  // with a v3 badge and file B's card disappears from the folder
+  await expect(page.getByText('v3', { exact: true })).toBeVisible()
+  await expect(fileCard(page, fileC.name)).toBeVisible()
+  await expect(fileCard(page, fileB.name)).not.toBeVisible()
+
+  // DB: the stack now has 3 versions, including file C
+  await expect
+    .poll(async () => {
+      const s = await prisma.asset.findFirst({
+        where: { projectId, parentId: rootFolderId, type: 'version_stack' },
+      })
+      return s?.fileCount
+    })
+    .toBe(3)
+
+  stack = await prisma.asset.findFirstOrThrow({
+    where: { projectId, parentId: rootFolderId, type: 'version_stack' },
+  })
+
+  const versions = await prisma.asset.findMany({
+    where: { parentId: stack.id, type: 'file' },
+    orderBy: { sortIndex: 'asc' },
+  })
+  expect(versions).toHaveLength(3)
+  expect(new Set(versions.map((v) => v.id))).toEqual(new Set([fileA.id, fileB.id, fileC.id]))
+
+  const movedFileC = await prisma.asset.findUnique({ where: { id: fileC.id } })
+  expect(movedFileC?.parentId).toBe(stack.id)
+})

--- a/apps/web/e2e/tests/project/version-stack-create.spec.ts
+++ b/apps/web/e2e/tests/project/version-stack-create.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '../../fixtures'
+import { seedFile } from '../../helpers/assets'
+import { dragCard } from '../../helpers/dnd'
+import { fileCard } from '../../helpers/files'
+
+test('owner moves a file onto another file to create a version stack', async ({
+  project,
+  prisma,
+}) => {
+  const { page, projectId, rootFolderId } = project
+
+  const fileA = await seedFile(prisma, projectId, rootFolderId, `e2e-stack-a-${Date.now()}`)
+  const fileB = await seedFile(prisma, projectId, rootFolderId, `e2e-stack-b-${Date.now()}`)
+
+  await page.goto(`/projects/${projectId}`)
+  await expect(fileCard(page, fileA.name)).toBeVisible()
+  await expect(fileCard(page, fileB.name)).toBeVisible()
+
+  // Drag file B onto file A -> a version stack is created with both files
+  await dragCard(page, fileCard(page, fileB.name), fileCard(page, fileA.name))
+
+  // The stack card shows the latest version's name (the dragged file) and a v2 badge;
+  // the original two file cards are gone from the folder
+  await expect(fileCard(page, fileB.name)).toBeVisible()
+  await expect(page.getByText('v2', { exact: true })).toBeVisible()
+  await expect(fileCard(page, fileA.name)).not.toBeVisible()
+
+  // DB: exactly one version stack in the project root with both files as versions
+  await expect
+    .poll(async () => {
+      return prisma.asset.count({
+        where: { projectId, parentId: rootFolderId, type: 'version_stack' },
+      })
+    })
+    .toBe(1)
+
+  const stack = await prisma.asset.findFirstOrThrow({
+    where: { projectId, parentId: rootFolderId, type: 'version_stack' },
+  })
+  expect(stack.fileCount).toBe(2)
+
+  const versions = await prisma.asset.findMany({
+    where: { parentId: stack.id, type: 'file' },
+    orderBy: { sortIndex: 'asc' },
+  })
+  expect(versions).toHaveLength(2)
+  expect(new Set(versions.map((v) => v.id))).toEqual(new Set([fileA.id, fileB.id]))
+})

--- a/packages/webui/components/file-browser/toolbar.tsx
+++ b/packages/webui/components/file-browser/toolbar.tsx
@@ -354,6 +354,7 @@ export function FileBrowserToolbar({
         {!isRecentlyDeleted && (
           <div
             className="flex items-center -space-x-2 cursor-pointer hover:opacity-90"
+            data-testid="project-members-trigger"
             onClick={() => handleOpenMembersDialog(true)}
           >
             {members?.slice(0, 3).map((member) => (


### PR DESCRIPTION
## Summary

Adds 4 project-level webapp E2E tests covering member invites and drag-and-drop file/folder/version-stack moves.

## Changes

- **tests/project/invite-member.spec.ts** — owner invites a member to a project via the project members dialog; the invitee only sees the invited project (not a second project), direct API access to the other project returns 403, and the project URL renders the router error boundary.
- **tests/project/move-folder-file.spec.ts** — drags a file onto a folder and a folder onto another folder (dnd-kit), asserting UI navigation and DB parent/count bookkeeping.
- **tests/project/version-stack-create.spec.ts** — drags a file onto a file to create a version stack (v2 badge, both files become versions).
- **tests/project/version-stack-add-version.spec.ts** — drags a file onto an existing version stack to add a new version (v3 badge, the new file becomes the latest version).

Supporting changes:
- apps/web/e2e/fixtures.ts: expose rootFolderId on the project fixture.
- apps/web/e2e/helpers/assets.ts: seedFolder / seedFile DB seeding helpers.
- apps/web/e2e/helpers/dnd.ts: cross-browser dragCard helper. WebKit only reliably activates dnd-kit's pointer sensor when moves are delivered in awaited batches (a single fast mouse.move(steps) gets coalesced before activation, losing the drop).
- apps/web/e2e/helpers/ui.ts: openProjectMembersDialog helper.
- packages/webui/components/file-browser/toolbar.tsx: add data-testid="project-members-trigger" (test support only).
- apps/web/e2e/README.md: document the 4 new test cases.

## Verification

- bun run lint ✅
- bun run format ✅
- bun run typecheck ✅
- bun run test (779 tests) ✅
- bun run test:e2e (69 tests, chromium + firefox + webkit) ✅
- bun run test:e2e:workflow (42 tests) ✅

## Notes

The new-version semantics: generateSortIndex in packages/core/src/asset/asset.ts inserts via generateKeyBetween(null, previous), so the dropped file becomes the latest version of the stack (confirmed against a real DB during debugging).
