### PR TITLE
test(e2e): add search in file list and save-search-as-collection cases

### DIFF
--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -76,6 +76,10 @@ apps/web/e2e/
 | Owner drags a file into a folder and a folder into another folder | `tests/project/move-folder-file.spec.ts` |
 | Owner drags a file onto a file to create a version stack | `tests/project/version-stack-create.spec.ts` |
 | Owner drags a file onto a version stack to add a new version | `tests/project/version-stack-add-version.spec.ts` |
+| Owner searches the file list by an English name keyword | `tests/project/search-file-list.spec.ts` |
+| Owner searches the file list by Chinese, Japanese, and Korean name keywords | `tests/project/search-file-list.spec.ts` |
+| Owner searches the file list with a keyword and a filter condition | `tests/project/search-file-list.spec.ts` |
+| Owner saves a search result as a collection | `tests/project/save-search-collection.spec.ts` |
 
 ### file
 | Test | File |

--- a/apps/web/e2e/tests/project/save-search-collection.spec.ts
+++ b/apps/web/e2e/tests/project/save-search-collection.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '../../fixtures'
+import { apiUploadFile, fileCard } from '../../helpers/files'
+
+test('owner saves a search result as a collection', async ({ project, prisma }) => {
+  const { page, context, teamId, rootFolderId, projectId } = project
+
+  const matching = 'quarterly-report-2024'
+  const other = 'annual-budget-2024'
+
+  for (const name of [matching, other]) {
+    await apiUploadFile(
+      context.request,
+      teamId,
+      rootFolderId,
+      name,
+      'application/octet-stream',
+      Buffer.alloc(0),
+    )
+  }
+
+  await page.goto(`/projects/${projectId}`)
+  await expect(fileCard(page, matching)).toBeVisible()
+  await expect(fileCard(page, other)).toBeVisible()
+
+  // Run a keyword search
+  await page.getByRole('button', { name: 'Search' }).click()
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toBeVisible()
+
+  await dialog.getByPlaceholder('Search records by name...').fill('report')
+  await dialog.getByRole('button', { name: 'Search' }).click()
+  await expect(dialog.getByText(matching, { exact: true })).toBeVisible()
+  await expect(dialog.getByText(other, { exact: true })).not.toBeVisible()
+
+  // Save the search result as a collection; the dialog closes and navigates
+  // to the new collection page
+  await dialog.getByRole('button', { name: 'Save as collection' }).click()
+
+  await expect(page).toHaveURL(new RegExp(`/projects/${projectId}/collections/[^/]+`))
+  await expect(page.getByText('Collection saved')).toBeVisible()
+
+  // The collection page is a files-only view of the saved search
+  await expect(fileCard(page, matching)).toBeVisible()
+  await expect(fileCard(page, other)).not.toBeVisible()
+
+  // DB: the collection stores the keyword search as its filter
+  const collection = await prisma.collection.findFirst({ where: { projectId } })
+  expect(collection).not.toBeNull()
+  expect(collection?.name).toBe('report')
+  expect(collection?.filter).toMatchObject({
+    sourceFolderId: rootFolderId,
+    searchFilter: {
+      conditions: [{ field: 'name', operator: 'contains', value: 'report' }],
+      recursively: true,
+      query: 'report',
+      isSemantic: false,
+    },
+  })
+})

--- a/apps/web/e2e/tests/project/search-file-list.spec.ts
+++ b/apps/web/e2e/tests/project/search-file-list.spec.ts
@@ -1,0 +1,162 @@
+import type { APIRequestContext } from '@playwright/test'
+import { expect, test } from '../../fixtures'
+import { apiUploadFile, fileCard } from '../../helpers/files'
+
+const BINARY_MIME = 'application/octet-stream'
+
+/** Uploads an empty binary file into the project root through the API. */
+async function uploadBinaryFile(
+  request: APIRequestContext,
+  teamId: string,
+  rootFolderId: string,
+  name: string,
+  size = 0,
+): Promise<void> {
+  await apiUploadFile(request, teamId, rootFolderId, name, BINARY_MIME, Buffer.alloc(size))
+}
+
+test('owner searches the file list by an English name keyword', async ({ project }) => {
+  const { page, projectId } = project
+
+  const report2024 = 'quarterly-report-2024'
+  const report2025 = 'quarterly-report-2025'
+  const budget2024 = 'annual-budget-2024'
+
+  for (const name of [report2024, report2025, budget2024]) {
+    await uploadBinaryFile(project.context.request, project.teamId, project.rootFolderId, name)
+  }
+
+  await page.goto(`/projects/${projectId}`)
+  await expect(fileCard(page, report2024)).toBeVisible()
+  await expect(fileCard(page, report2025)).toBeVisible()
+  await expect(fileCard(page, budget2024)).toBeVisible()
+
+  // Open the search dialog from the toolbar
+  await page.getByRole('button', { name: 'Search' }).click()
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toBeVisible()
+
+  // Keyword-only search (no filter conditions)
+  await dialog.getByPlaceholder('Search records by name...').fill('report')
+  await dialog.getByRole('button', { name: 'Search' }).click()
+
+  await expect(dialog.getByText(report2024, { exact: true })).toBeVisible()
+  await expect(dialog.getByText(report2025, { exact: true })).toBeVisible()
+  await expect(dialog.getByText(budget2024, { exact: true })).not.toBeVisible()
+
+  // Apply the search to the file list
+  await dialog.getByRole('button', { name: 'Apply and Close' }).click()
+  await expect(dialog).not.toBeVisible()
+
+  await expect(fileCard(page, report2024)).toBeVisible()
+  await expect(fileCard(page, report2025)).toBeVisible()
+  await expect(fileCard(page, budget2024)).not.toBeVisible()
+})
+
+test('owner searches the file list by Chinese, Japanese, and Korean name keywords', async ({
+  project,
+}) => {
+  const { page, projectId } = project
+
+  const zhDoc = '产品需求文档-2024'
+  const zhDesign = '产品设计文档-2025'
+  const jaDoc = '日本語ドキュメント'
+  const koDoc = '한국어문서'
+
+  for (const name of [zhDoc, zhDesign, jaDoc, koDoc]) {
+    await uploadBinaryFile(project.context.request, project.teamId, project.rootFolderId, name)
+  }
+
+  await page.goto(`/projects/${projectId}`)
+  await expect(fileCard(page, zhDoc)).toBeVisible()
+
+  const searchByName = async (keyword: string, visible: string[], hidden: string[]) => {
+    await page.getByRole('button', { name: 'Search' }).click()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByPlaceholder('Search records by name...').fill(keyword)
+    await dialog.getByRole('button', { name: 'Search' }).click()
+    for (const name of visible) {
+      await expect(dialog.getByText(name, { exact: true })).toBeVisible()
+    }
+    for (const name of hidden) {
+      await expect(dialog.getByText(name, { exact: true })).not.toBeVisible()
+    }
+    await dialog.getByRole('button', { name: 'Apply and Close' }).click()
+    await expect(dialog).not.toBeVisible()
+  }
+
+  // Chinese keyword
+  await searchByName('需求', [zhDoc], [zhDesign, jaDoc, koDoc])
+  await expect(fileCard(page, zhDoc)).toBeVisible()
+  await expect(fileCard(page, zhDesign)).not.toBeVisible()
+
+  // Japanese keyword
+  await searchByName('ドキュメント', [jaDoc], [zhDoc, zhDesign, koDoc])
+  await expect(fileCard(page, jaDoc)).toBeVisible()
+  await expect(fileCard(page, zhDoc)).not.toBeVisible()
+
+  // Korean keyword
+  await searchByName('한국어', [koDoc], [zhDoc, zhDesign, jaDoc])
+  await expect(fileCard(page, koDoc)).toBeVisible()
+  await expect(fileCard(page, jaDoc)).not.toBeVisible()
+})
+
+test('owner searches the file list with a keyword and a filter condition', async ({ project }) => {
+  const { page, projectId } = project
+
+  const bigReport = 'quarterly-report-2024'
+  const smallReport = 'quarterly-report-2025'
+
+  await uploadBinaryFile(
+    project.context.request,
+    project.teamId,
+    project.rootFolderId,
+    bigReport,
+    1000,
+  )
+  await uploadBinaryFile(
+    project.context.request,
+    project.teamId,
+    project.rootFolderId,
+    smallReport,
+    10,
+  )
+
+  await page.goto(`/projects/${projectId}`)
+  await expect(fileCard(page, bigReport)).toBeVisible()
+  await expect(fileCard(page, smallReport)).toBeVisible()
+
+  // Open the search dialog from the toolbar
+  await page.getByRole('button', { name: 'Search' }).click()
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toBeVisible()
+
+  await dialog.getByPlaceholder('Search records by name...').fill('report')
+
+  // Add a "Size > 100" filter condition on top of the keyword
+  await dialog.getByRole('button', { name: '+ Add condition' }).click()
+
+  const comboboxes = dialog.getByRole('combobox')
+  await comboboxes.first().click()
+  await page.getByRole('option', { name: 'Size', exact: true }).click()
+
+  await comboboxes.nth(1).click()
+  await page.getByRole('option', { name: '>', exact: true }).click()
+
+  await dialog.locator('input[type="number"]').fill('100')
+  // The condition value is applied after the debounced input; the badge
+  // confirms the filter became active before we run the search.
+  await expect(dialog.getByText('1 active')).toBeVisible()
+
+  await dialog.getByRole('button', { name: 'Search' }).click()
+  await expect(dialog.getByText(bigReport, { exact: true })).toBeVisible()
+  await expect(dialog.getByText(smallReport, { exact: true })).not.toBeVisible()
+
+  // Apply the keyword + filter to the file list
+  await dialog.getByRole('button', { name: 'Apply and Close' }).click()
+  await expect(dialog).not.toBeVisible()
+
+  await expect(fileCard(page, bigReport)).toBeVisible()
+  await expect(fileCard(page, smallReport)).not.toBeVisible()
+})


### PR DESCRIPTION
## Summary

Adds web app E2E coverage for the file-list search feature (project domain):
- Search by English name keyword (no filter)
- Search by Chinese / Japanese / Korean name keywords (no filter)
- Search with a keyword + filter condition (Size > 100)
- Save a search result as a collection

## Changes

- `apps/web/e2e/tests/project/search-file-list.spec.ts` — 3 new tests covering keyword-only search, CJK keyword search, and keyword + filter-condition search. Files are uploaded as empty binary assets through the API (`apiUploadFile`) because name `contains` search relies on `name_ngram`, which is only populated by the server-side Prisma client extension (DB-seeded assets are invisible to name search).
- `apps/web/e2e/tests/project/save-search-collection.spec.ts` — verifies the `Save as collection` flow in the search dialog: navigates to the new collection page, shows the `Collection saved` toast, lists only matching files, and stores the search filter in the DB.
- `apps/web/e2e/README.md` — documents the 4 new test cases.

## Verification

- `bun run lint` ✅
- `bun run format` ✅
- `bun run typecheck` ✅
- `bun run test` — 779 passed ✅
- `bun run test:e2e` — 96 passed (all 3 browsers, single run) ✅
- `bun run test:e2e:workflow` — 42 passed ✅

## Notes

- The pre-existing `audio-playback` harness test failed once during an earlier run but passes consistently in isolation and in the final full-suite run; it is unrelated to these changes.
- Verification artifacts (test-results/, .env.e2e) were removed before submit.