### PR TITLE
fix(webui): persist field order on drag and drop

### DIFF
--- a/packages/webui/components/fields-manager.tsx
+++ b/packages/webui/components/fields-manager.tsx
@@ -8,7 +8,7 @@ import { ulid } from 'ulid'
 import { client } from '@/ui/api/client'
 import { useFieldStore } from '@/ui/stores/fields'
 import { DragDropProvider, KeyboardSensor, PointerSensor, type DragEndEvent } from '@dnd-kit/react'
-import { useSortable } from '@dnd-kit/react/sortable'
+import { isSortable, useSortable } from '@dnd-kit/react/sortable'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { InferRequestType, InferResponseType } from 'hono/client'
 import { m } from '@/ui/paraglide/messages.js'
@@ -24,7 +24,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/ui/components/ui/popo
 import { Input } from '@/ui/components/ui/input'
 import { Label } from '@/ui/components/ui/label'
 import { Switch } from '@/ui/components/ui/switch'
-import { arrayMove } from '@/ui/lib/dnd-utils'
+import { reorderFieldSubset } from '@/ui/lib/dnd-utils'
 import { PointerActivationConstraints } from '@dnd-kit/dom'
 
 export const PREDEFINED_COLORS = ['red', 'orange', 'yellow', 'green', 'blue', 'purple', 'gray']
@@ -220,20 +220,23 @@ export function FieldsManager({ projectId, onManageFields, onSave }: FieldsManag
   )
 
   const handleDragEnd = (event: DragEndEvent) => {
-    const { source, target } = event.operation
-    if (source && target && source.id !== target.id) {
-      const oldIndex = fields.findIndex((f) => f.id === source.id)
-      const newIndex = fields.findIndex((f) => f.id === target.id)
-      const newFields = arrayMove(fields, oldIndex, newIndex)
-      updateFields(newFields)
-      updateFieldsOrder({
-        param: { projectId: projectId },
-        json: newFields.map((f: MetadataFieldInfo) => ({
-          fieldId: f.id!,
-          visible: f.visible || false,
-        })),
-      })
-    }
+    if (event.canceled) return
+    const { source } = event.operation
+    if (!isSortable(source)) return
+    const { initialIndex, index } = source
+    if (initialIndex === index) return
+
+    // Rows are rendered from the search-filtered subset, so indices are
+    // relative to `filteredFields`, not the full `fields` array.
+    const newFields = reorderFieldSubset(fields, filteredFields, initialIndex, index)
+    updateFields(newFields)
+    updateFieldsOrder({
+      param: { projectId: projectId },
+      json: newFields.map((f: MetadataFieldInfo) => ({
+        fieldId: f.id!,
+        visible: f.visible || false,
+      })),
+    })
   }
 
   const handleVisibilityChange = (fieldId: string, visible: boolean) => {

--- a/packages/webui/components/manage-fields-dialog.tsx
+++ b/packages/webui/components/manage-fields-dialog.tsx
@@ -1,18 +1,19 @@
+import { client } from '@/ui/api/client'
+import { Popover, PopoverContent, PopoverTrigger } from '@/ui/components/ui/popover'
+import { reorderFieldSubset } from '@/ui/lib/dnd-utils'
+import { m } from '@/ui/paraglide/messages.js'
+import { useFieldStore } from '@/ui/stores/fields'
+import { PointerActivationConstraints } from '@dnd-kit/dom'
+import { DragDropProvider, KeyboardSensor, PointerSensor, type DragEndEvent } from '@dnd-kit/react'
+import { isSortable, useSortable } from '@dnd-kit/react/sortable'
 import {
-  type FieldInfo as MetadataFieldInfo,
-  type FieldInfo,
   FieldType,
+  type FieldInfo,
+  type FieldInfo as MetadataFieldInfo,
   type SelectOption,
 } from '@shumai/dtos'
-import { ulid } from 'ulid'
-import { client } from '@/ui/api/client'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { InferRequestType, InferResponseType } from 'hono/client'
-import { useFieldStore } from '@/ui/stores/fields'
-import { DragDropProvider, KeyboardSensor, PointerSensor, type DragEndEvent } from '@dnd-kit/react'
-import { useSortable } from '@dnd-kit/react/sortable'
-import { arrayMove } from '@/ui/lib/dnd-utils'
-import { PointerActivationConstraints } from '@dnd-kit/dom'
 import {
   ChevronDown,
   FileText,
@@ -23,15 +24,14 @@ import {
   Sparkles,
   X,
 } from 'lucide-react'
-import { useMemo, useState, useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
-import { Popover, PopoverTrigger, PopoverContent } from '@/ui/components/ui/popover'
-import { m } from '@/ui/paraglide/messages.js'
+import { ulid } from 'ulid'
 import {
-  FIELD_TYPE_ICONS,
-  PREDEFINED_COLORS,
   COLOR_MAP,
+  FIELD_TYPE_ICONS,
   getRandomUnusedColor,
+  PREDEFINED_COLORS,
 } from './fields-manager'
 
 import { Button } from '@/ui/components/ui/button'
@@ -278,25 +278,24 @@ export function ManageFieldsDialog({ projectId, open, onOpenChange }: ManageFiel
   }
 
   const handleDragEnd = (event: DragEndEvent) => {
-    const { source, target } = event.operation
-    if (source && target && source.id !== target.id) {
-      const oldIndex = fields.findIndex((f) => f.id === source.id)
-      const newIndex = fields.findIndex((f) => f.id === target.id)
-      const newFields = arrayMove(fields, oldIndex, newIndex)
-      updateFields(newFields)
+    if (event.canceled) return
+    const { source } = event.operation
+    if (!isSortable(source)) return
+    const { initialIndex, index } = source
+    if (initialIndex === index) return
 
-      // Only persist order if we are in project scope (custom fields)
-      // or if the API supports ordering for other scopes.
-      if (selectedGroup === SCOPE_GROUPS.PROJECT) {
-        updateFieldsOrder({
-          param: { projectId: projectId },
-          json: newFields.map((f: MetadataFieldInfo) => ({
-            fieldId: f.id!,
-            visible: f.visible || false,
-          })),
-        })
-      }
-    }
+    // Sortable rows are rendered from the selected group's subset, so indices are
+    // relative to `filteredFields`, not the full `fields` array.
+    const newFields = reorderFieldSubset(fields, filteredFields, initialIndex, index)
+    updateFields(newFields)
+
+    updateFieldsOrder({
+      param: { projectId: projectId },
+      json: newFields.map((f: MetadataFieldInfo) => ({
+        fieldId: f.id!,
+        visible: f.visible || false,
+      })),
+    })
   }
 
   const handleSaveCreation = () => {
@@ -730,7 +729,7 @@ export function ManageFieldsDialog({ projectId, open, onOpenChange }: ManageFiel
                     index={index}
                     isSelected={selectedFieldId === field.id}
                     onSelect={handleSelectField}
-                    isSortable={selectedGroup === SCOPE_GROUPS.PROJECT}
+                    isSortable
                   />
                 ))}
               </DragDropProvider>

--- a/packages/webui/lib/dnd-utils.ts
+++ b/packages/webui/lib/dnd-utils.ts
@@ -4,6 +4,23 @@ export function arrayMove<T>(array: T[], from: number, to: number): T[] {
   return newArray
 }
 
+/**
+ * Reorders a subset of fields (a grouped/filtered view) within the full list.
+ * `subset` must appear in `full` in the same relative order (filtering preserves order).
+ */
+export function reorderFieldSubset<T extends { id?: string | null }>(
+  full: T[],
+  subset: T[],
+  from: number,
+  to: number,
+): T[] {
+  if (from === to) return full
+  const reordered = arrayMove(subset, from, to)
+  const subsetIds = new Set(subset.map((f) => f.id))
+  let i = 0
+  return full.map((f) => (subsetIds.has(f.id) ? reordered[i++] : f))
+}
+
 interface SafeFileSystemEntry {
   name: string
   isFile: boolean


### PR DESCRIPTION
## Summary

Fix field reordering in the webui Manage Fields dialog and the Fields dropdown. Dragging a field to change its order updated nothing — the order API (`PATCH /projects/:projectId/fields/order`) was never called and the reorder was lost on reload.

## Changes

- **Root cause**: `handleDragEnd` guarded reordering on `source.id !== target.id`. `@dnd-kit/react` 0.4.0 enables the `OptimisticSortingPlugin` by default, which sets the drop target to the dragged item itself during a drag, so `source` and `target` always refer to the same element and the guard never passed.
- **Fix** (in `packages/webui/components/manage-fields-dialog.tsx` and `packages/webui/components/fields-manager.tsx`): detect moves via the sortable-specific `index` / `initialIndex` properties on the source (`isSortable` type guard), skip canceled/no-op drags, then persist the full ordered field list.
- **Index mapping**: sortable rows are rendered from a filtered subset (selected scope group in the dialog, search results in the dropdown) while the store holds the full field list (system + team + project). Added `reorderFieldSubset()` in `packages/webui/lib/dnd-utils.ts` to reorder the subset and merge it back into the full list before calling the order API.
- **All groups reorderable**: removed the PROJECT-only `isSortable` restriction in the dialog, so system/team/project fields can all be reordered (matching the dropdown behavior).

## Verification

- `bun run lint` ✅
- `bun run format` ✅
- `bun run typecheck` ✅
- `bun run test` ✅ (829 tests)
- `bun run test:e2e` ✅ (96 tests)
- `bun run test:e2e:workflow` ✅ (42 tests)

Manual verification per plan (drag in each dialog group + dropdown, order persists after reload, no-op drop makes no API call).

## Notes

Order is stored per-user per-project (`project_field_order:{userId}:{projectId}`), so reordering system/team fields affects that user's view only.
