### PR TITLE
fix(share): serve per-file watermark proxies in public share APIs

### DIFF
--- a/packages/api/src/public-share.ts
+++ b/packages/api/src/public-share.ts
@@ -25,45 +25,54 @@ import type { AssetInfo } from '@shumai/dtos'
 
 /**
  * Replaces the served media entries with the watermarked proxy entries produced
- * by the watermark transcode activity. Only the transcode/preview slots are
- * replaced; `original` is intentionally left untouched here.
- * S3 GET URLs are generated for all watermarked proxies and preview thumbnails.
+ * by the watermark transcode activity. When no completed watermark proxy exists
+ * yet (still transcoding, or failed), the video/image transcode slots are emptied
+ * so original, unwatermarked proxies are never exposed on the public share.
+ *
+ * Only video/image assets are subject to watermark protection; other media types
+ * (pdf, audio, ...) never receive watermark transcodes and pass through untouched.
+ * `original`, `thumbnail` and `videoPreview` are intentionally left untouched here.
+ * S3 GET URLs are generated for all watermarked proxies.
  */
 async function applyWatermarkToAssetMedia(
   asset: AssetInfo,
-  watermarkMedia: PrismaJson.MediaInfo,
+  watermarkMedia: PrismaJson.MediaInfo | null,
 ): Promise<AssetInfo> {
   if (!asset.media) return asset
+  if (asset.proxyType !== 'video' && asset.proxyType !== 'image') return asset
+
   const updatedMedia = { ...asset.media }
   const bucket = process.env.S3_BUCKET || 'shumai'
 
-  if (watermarkMedia.videoTranscodes && watermarkMedia.videoTranscodes.length > 0) {
-    updatedMedia.videoTranscodes = await Promise.all(
-      watermarkMedia.videoTranscodes.map(async (vt) => ({
-        id: vt.key ?? '',
-        url: vt.key ? await s3Service.presign(bucket, vt.key, 'GET') : '',
-        key: vt.key ?? '',
-        width: vt.width ?? 0,
-        height: vt.height ?? 0,
-        size: 0,
-        isRaw: false,
-      })),
-    )
-  }
+  updatedMedia.videoTranscodes =
+    watermarkMedia?.videoTranscodes && watermarkMedia.videoTranscodes.length > 0
+      ? await Promise.all(
+          watermarkMedia.videoTranscodes.map(async (vt) => ({
+            id: vt.key ?? '',
+            url: vt.key ? await s3Service.presign(bucket, vt.key, 'GET') : '',
+            key: vt.key ?? '',
+            width: vt.width ?? 0,
+            height: vt.height ?? 0,
+            size: 0,
+            isRaw: false,
+          })),
+        )
+      : []
 
-  if (watermarkMedia.imageTranscodes && watermarkMedia.imageTranscodes.length > 0) {
-    updatedMedia.imageTranscodes = await Promise.all(
-      watermarkMedia.imageTranscodes.map(async (it) => ({
-        id: it.key ?? '',
-        url: it.key ? await s3Service.presign(bucket, it.key, 'GET') : '',
-        key: it.key ?? '',
-        width: it.width ?? 0,
-        height: it.height ?? 0,
-        size: 0,
-        isRaw: false,
-      })),
-    )
-  }
+  updatedMedia.imageTranscodes =
+    watermarkMedia?.imageTranscodes && watermarkMedia.imageTranscodes.length > 0
+      ? await Promise.all(
+          watermarkMedia.imageTranscodes.map(async (it) => ({
+            id: it.key ?? '',
+            url: it.key ? await s3Service.presign(bucket, it.key, 'GET') : '',
+            key: it.key ?? '',
+            width: it.width ?? 0,
+            height: it.height ?? 0,
+            size: 0,
+            isRaw: false,
+          })),
+        )
+      : []
 
   return {
     ...asset,
@@ -180,11 +189,7 @@ const route = app
           order,
         })
 
-        if (
-          shareLink.watermarkConfigId &&
-          shareLink.watermarkStatus === 'ready' &&
-          res.data.length > 0
-        ) {
+        if (shareLink.watermarkConfigId && res.data.length > 0) {
           // Resolve symlink targets once and reuse for the media lookup, so each
           // item costs a single query instead of two.
           const targetIds = await Promise.all(
@@ -196,13 +201,9 @@ const route = app
           )
 
           res.data = await Promise.all(
-            res.data.map(async (item, index) => {
-              const wMedia = wfMap.get(targetIds[index])
-              if (wMedia) {
-                return await applyWatermarkToAssetMedia(item, wMedia)
-              }
-              return item
-            }),
+            res.data.map(async (item, index) =>
+              applyWatermarkToAssetMedia(item, wfMap.get(targetIds[index]) ?? null),
+            ),
           )
         }
 
@@ -221,16 +222,18 @@ const route = app
 
       let asset = await assetService.getAsset({ assetId: fileId })
 
-      if (shareLink.watermarkConfigId && shareLink.watermarkStatus === 'ready') {
+      // Only video/image assets are subject to watermark protection; skip the
+      // watermark lookup entirely for other media types (pdf, audio, ...).
+      if (
+        shareLink.watermarkConfigId &&
+        (asset.proxyType === 'video' || asset.proxyType === 'image')
+      ) {
         const targetAssetId = await assetService.resolveTargetAssetId(fileId)
         const wfMap = await watermarkService.getCompletedWatermarkMediaMap(
           [targetAssetId],
           shareLink.watermarkConfigId,
         )
-        const wMedia = wfMap.get(targetAssetId)
-        if (wMedia) {
-          asset = await applyWatermarkToAssetMedia(asset, wMedia)
-        }
+        asset = await applyWatermarkToAssetMedia(asset, wfMap.get(targetAssetId) ?? null)
       }
 
       return c.json(asset)

--- a/packages/api/src/share.test.ts
+++ b/packages/api/src/share.test.ts
@@ -9,6 +9,8 @@ import { authzService, Permission, ResourceType } from '@shumai/core/src/authz/a
 import { ShareLinkPasswordInvalidError, ShareLinkExpiredError } from '@shumai/core/src/share/errors'
 
 import { auditLogService } from '@shumai/core/src/auditLog/auditLog'
+import { watermarkService } from '@shumai/core/src/watermark/watermark'
+import { s3Service } from '@shumai/core/src/s3/s3'
 
 vi.mock('./middleware/auth', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -46,6 +48,36 @@ vi.mock('@shumai/core/src/project/project', () => ({
     getProjectTeam: vi.fn().mockResolvedValue('t1'),
   },
 }))
+
+function watermarkMediaInfo(overrides: Partial<PrismaJson.MediaInfo> = {}): PrismaJson.MediaInfo {
+  return {
+    duration: 1,
+    filesize: 100,
+    frames: 30,
+    proxyType: 'video',
+    imageTranscodes: [],
+    videoTranscodes: [],
+    finishedAt: new Date().toISOString(),
+    metadata: {
+      originalHeight: 360,
+      originalWidth: 640,
+      hasAudio: false,
+      duration: 1,
+      bitRate: 0,
+      frameRate: 30,
+      totalFrames: 30,
+      startTimecode: '00:00:00:00',
+      format: {},
+    },
+    original: {
+      key: 'files/orig.mp4',
+      downloadUrl: 'u',
+      filesizeInBytes: 100,
+      codec: '',
+    },
+    ...overrides,
+  }
+}
 
 describe('Share API', () => {
   const app = new Hono()
@@ -179,6 +211,294 @@ describe('Share API', () => {
           order: 'asc',
         }),
       )
+    })
+
+    test('applies per-file watermark proxies when watermark enabled', async () => {
+      vi.spyOn(shareService, 'verifyPublicAccess').mockResolvedValue({
+        id: 'share1',
+        name: 'My Share',
+        isDisabled: false,
+        rootFolderId: 'folder1',
+        projectId: 'project1',
+        password: null,
+        expireAt: null,
+        watermarkConfigId: 'cfg1',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+      vi.spyOn(assetService, 'listChildren').mockResolvedValue({
+        data: [
+          {
+            id: 'video-ready',
+            name: 'a.mp4',
+            sizeByte: 1,
+            fileCount: 0,
+            type: 'file',
+            status: 'processed',
+            proxyType: 'video',
+            media: {
+              proxyType: 'video',
+              videoTranscodes: [
+                {
+                  id: 'orig',
+                  url: 'u',
+                  key: 'files/orig.mp4',
+                  width: 640,
+                  height: 360,
+                  size: 1,
+                  isRaw: false,
+                },
+              ],
+              imageTranscodes: [],
+              original: { downloadUrl: 'u', key: 'files/orig.mp4' },
+            },
+          },
+          {
+            id: 'video-pending',
+            name: 'b.mp4',
+            sizeByte: 1,
+            fileCount: 0,
+            type: 'file',
+            status: 'processed',
+            proxyType: 'video',
+            media: {
+              proxyType: 'video',
+              videoTranscodes: [
+                {
+                  id: 'orig',
+                  url: 'u',
+                  key: 'files/orig.mp4',
+                  width: 640,
+                  height: 360,
+                  size: 1,
+                  isRaw: false,
+                },
+              ],
+              imageTranscodes: [],
+              original: { downloadUrl: 'u', key: 'files/orig.mp4' },
+            },
+          },
+          {
+            id: 'doc',
+            name: 'c.pdf',
+            sizeByte: 1,
+            fileCount: 0,
+            type: 'file',
+            status: 'processed',
+            proxyType: 'pdf',
+            media: {
+              proxyType: 'pdf',
+              pdfTranscode: { url: 'u', key: 'files/doc.pdf' },
+              videoTranscodes: [],
+              imageTranscodes: [],
+              original: { downloadUrl: 'u', key: 'files/doc.pdf' },
+            },
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ] as any,
+        pageInfo: { total: 3, cursor: undefined },
+      })
+      vi.spyOn(assetService, 'resolveTargetAssetId').mockImplementation(async (id) => id)
+      vi.spyOn(s3Service, 'presign').mockResolvedValue('http://s3/presigned')
+      vi.spyOn(watermarkService, 'getCompletedWatermarkMediaMap').mockResolvedValue(
+        new Map([
+          [
+            'video-ready',
+            watermarkMediaInfo({
+              videoTranscodes: [{ key: 'files/wm-a.mp4', width: 640, height: 360 }],
+            }),
+          ],
+        ]),
+      )
+
+      const res = await app.request('/shares/share1/folders/folder1/children?assetType=file', {
+        method: 'GET',
+        headers: { 'x-share-password': 'pass' },
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      // Ready item → watermarked proxy
+      expect(body.data[0].media.videoTranscodes).toEqual([
+        {
+          id: 'files/wm-a.mp4',
+          url: 'http://s3/presigned',
+          key: 'files/wm-a.mp4',
+          width: 640,
+          height: 360,
+          size: 0,
+          isRaw: false,
+        },
+      ])
+      // Pending item → original transcodes emptied
+      expect(body.data[1].media.videoTranscodes).toEqual([])
+      expect(body.data[1].media.imageTranscodes).toEqual([])
+      // Non-media item → untouched
+      expect(body.data[2].media.pdfTranscode).toEqual({ url: 'u', key: 'files/doc.pdf' })
+    })
+  })
+
+  describe('GET /shares/:shareId/files/:fileId', () => {
+    const shareLinkWithWatermark = {
+      id: 'share1',
+      name: 'My Share',
+      isDisabled: false,
+      rootFolderId: 'folder1',
+      projectId: 'project1',
+      password: null,
+      expireAt: null,
+      watermarkConfigId: 'cfg1',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+
+    const videoAsset = {
+      id: 'file1',
+      name: 'video.mp4',
+      sizeByte: 1024,
+      fileCount: 0,
+      type: 'file',
+      status: 'processed',
+      proxyType: 'video',
+      media: {
+        proxyType: 'video',
+        videoTranscodes: [
+          {
+            id: 'orig-360p',
+            url: 'http://s3/original-360p',
+            key: 'files/original-360p.mp4',
+            width: 640,
+            height: 360,
+            size: 100,
+            isRaw: false,
+          },
+        ],
+        imageTranscodes: [],
+        original: { downloadUrl: 'http://s3/original', key: 'files/original.mp4' },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+
+    beforeEach(() => {
+      vi.spyOn(assetService, 'getAsset').mockResolvedValue(videoAsset)
+      vi.spyOn(assetService, 'resolveTargetAssetId').mockResolvedValue('file1')
+      vi.spyOn(s3Service, 'presign').mockResolvedValue('http://s3/presigned')
+    })
+
+    test('serves watermarked transcodes when watermark enabled and completed', async () => {
+      vi.spyOn(shareService, 'verifyPublicAccess').mockResolvedValue(shareLinkWithWatermark)
+      vi.spyOn(watermarkService, 'getCompletedWatermarkMediaMap').mockResolvedValue(
+        new Map([
+          [
+            'file1',
+            watermarkMediaInfo({
+              videoTranscodes: [{ key: 'files/watermarked-360p.mp4', width: 640, height: 360 }],
+            }),
+          ],
+        ]),
+      )
+
+      const res = await app.request('/shares/share1/files/file1', {
+        method: 'GET',
+        headers: { 'x-share-password': 'pass' },
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.media.videoTranscodes).toEqual([
+        {
+          id: 'files/watermarked-360p.mp4',
+          url: 'http://s3/presigned',
+          key: 'files/watermarked-360p.mp4',
+          width: 640,
+          height: 360,
+          size: 0,
+          isRaw: false,
+        },
+      ])
+      expect(body.media.imageTranscodes).toEqual([])
+    })
+
+    test('serves empty transcode arrays while watermark transcoding is in flight', async () => {
+      vi.spyOn(shareService, 'verifyPublicAccess').mockResolvedValue(shareLinkWithWatermark)
+      vi.spyOn(watermarkService, 'getCompletedWatermarkMediaMap').mockResolvedValue(new Map())
+
+      const res = await app.request('/shares/share1/files/file1', {
+        method: 'GET',
+        headers: { 'x-share-password': 'pass' },
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.media.videoTranscodes).toEqual([])
+      expect(body.media.imageTranscodes).toEqual([])
+    })
+
+    test('leaves non-video/image media untouched when watermark enabled', async () => {
+      vi.spyOn(shareService, 'verifyPublicAccess').mockResolvedValue(shareLinkWithWatermark)
+      vi.spyOn(assetService, 'getAsset').mockResolvedValue({
+        id: 'file1',
+        name: 'doc.pdf',
+        sizeByte: 1024,
+        fileCount: 0,
+        type: 'file',
+        status: 'processed',
+        proxyType: 'pdf',
+        media: {
+          proxyType: 'pdf',
+          pdfTranscode: { url: 'http://s3/doc', key: 'files/doc.pdf' },
+          videoTranscodes: [],
+          imageTranscodes: [],
+          original: { downloadUrl: 'http://s3/doc-original', key: 'files/doc.pdf' },
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+      const resolveSpy = vi.spyOn(assetService, 'resolveTargetAssetId')
+      const wfSpy = vi.spyOn(watermarkService, 'getCompletedWatermarkMediaMap')
+
+      const res = await app.request('/shares/share1/files/file1', {
+        method: 'GET',
+        headers: { 'x-share-password': 'pass' },
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.media.pdfTranscode).toEqual({ url: 'http://s3/doc', key: 'files/doc.pdf' })
+      expect(resolveSpy).not.toHaveBeenCalled()
+      expect(wfSpy).not.toHaveBeenCalled()
+    })
+
+    test('serves original media unchanged when watermark disabled', async () => {
+      vi.spyOn(shareService, 'verifyPublicAccess').mockResolvedValue({
+        id: 'share1',
+        name: 'My Share',
+        isDisabled: false,
+        rootFolderId: 'folder1',
+        projectId: 'project1',
+        password: null,
+        expireAt: null,
+        watermarkConfigId: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+      const wfSpy = vi.spyOn(watermarkService, 'getCompletedWatermarkMediaMap')
+
+      const res = await app.request('/shares/share1/files/file1', {
+        method: 'GET',
+        headers: { 'x-share-password': 'pass' },
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.media.videoTranscodes).toEqual([
+        {
+          id: 'orig-360p',
+          url: 'http://s3/original-360p',
+          key: 'files/original-360p.mp4',
+          width: 640,
+          height: 360,
+          size: 100,
+          isRaw: false,
+        },
+      ])
+      expect(wfSpy).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/e2e/workflow/transcode-watermark.test.ts
+++ b/packages/e2e/workflow/transcode-watermark.test.ts
@@ -319,5 +319,149 @@ describe.each(['local', 'temporal'] as const)(
       expect(mediaInfo?.videoTranscodes?.length).toBe(1)
       expect(mediaInfo?.videoTranscodes?.[0].resolution).toBe('360p')
     })
+
+    it('should watermark a newly added asset after the sharelink is already ready', async () => {
+      // 1. Seed Database
+      const team = await prisma.team.create({
+        data: { name: 'E2E Watermark Team' },
+      })
+      const projectFolder = await prisma.asset.create({
+        data: { name: 'root', type: 'root', status: 'processed' },
+      })
+      const project = await prisma.project.create({
+        data: { name: 'E2E Watermark Project', teamId: team.id, rootFolderId: projectFolder.id },
+      })
+
+      const readSampleImage = (): Buffer => {
+        const sampleImagePath = path.join(fixturesDir, 'sample.png')
+        if (fs.existsSync(sampleImagePath)) {
+          return fs.readFileSync(sampleImagePath)
+        }
+        // Minimal 1x1 PNG fallback if fixture is missing
+        return Buffer.from(
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+          'base64',
+        )
+      }
+
+      const createImageAsset = async (key: string, name: string) => {
+        const buffer = readSampleImage()
+        const storageKey = await prisma.storageKey.create({ data: { key } })
+        await s3Service.putObject(
+          'shumai-e2e-test-bucket-watermark',
+          key,
+          buffer,
+          buffer.length,
+          'image/png',
+        )
+        return await prisma.asset.create({
+          data: {
+            name,
+            type: 'file',
+            mediaType: 'image/png',
+            status: 'processed',
+            projectId: project.id,
+            storageKeyId: storageKey.id,
+            media: {
+              duration: 0,
+              filesize: buffer.length,
+              frames: 0,
+              proxyType: 'image',
+              imageTranscodes: [{ key, width: 100, height: 100, quality: 90, format: 'webp' }],
+              videoTranscodes: [],
+              videoPreview: { width: 100, height: 100 },
+              finishedAt: new Date().toISOString(),
+              metadata: {
+                originalWidth: 100,
+                originalHeight: 100,
+                duration: 0,
+                bitRate: 0,
+                frameRate: 0,
+                totalFrames: 0,
+                startTimecode: '00:00:00:00',
+                hasAudio: false,
+                format: {},
+              },
+              original: {
+                key,
+                downloadUrl: '',
+                filesizeInBytes: buffer.length,
+                codec: '',
+              },
+            },
+          },
+        })
+      }
+
+      const assetA = await createImageAsset('files/e2e-add-after-ready/a.png', 'a.png')
+      const shareLink = await shareService.createShareLink(project.id, {
+        name: 'Public Watermarked Share',
+      })
+      await shareService.addAssetToShare(shareLink.id, { assetIds: [assetA.id] })
+
+      const watermarkConfig: WatermarkConfigSpec = {
+        blocks: [
+          {
+            id: 'b1',
+            type: 'text',
+            x: 0.5,
+            y: 0.5,
+            opacity: 0.5,
+            rotation: 0,
+            text: 'CONFIDENTIAL E2E',
+            size: 0.2,
+            color: '#FF0000',
+          },
+        ],
+      }
+
+      // 2. Enable Watermark on Sharelink and wait for initial 'ready'
+      const updatedShare = await watermarkService.updateShareLinkWatermark(
+        shareLink.id,
+        true,
+        watermarkConfig,
+      )
+      expect(updatedShare.watermarkStatus).toBe('processing')
+
+      let share = await shareService.getShareLink(shareLink.id)
+      let startTime = Date.now()
+      while (share.watermarkStatus === 'processing' && Date.now() - startTime < 30000) {
+        await new Promise((resolve) => setTimeout(resolve, 500))
+        share = await shareService.getShareLink(shareLink.id)
+      }
+      expect(share.watermarkStatus).toBe('ready')
+      expect(share.watermarkConfigId).toBe(updatedShare.watermarkConfigId)
+
+      // 3. Add a NEW asset to the ready sharelink
+      const assetB = await createImageAsset('files/e2e-add-after-ready/b.png', 'b.png')
+      await shareService.addAssetToShare(shareLink.id, { assetIds: [assetB.id] })
+
+      // 4. Status flips back to 'processing' while the new asset is transcoded
+      share = await shareService.getShareLink(shareLink.id)
+      expect(share.watermarkStatus).toBe('processing')
+
+      // 5. Poll until the sharelink is 'ready' again
+      startTime = Date.now()
+      while (share.watermarkStatus === 'processing' && Date.now() - startTime < 30000) {
+        await new Promise((resolve) => setTimeout(resolve, 500))
+        share = await shareService.getShareLink(shareLink.id)
+      }
+      expect(share.watermarkStatus).toBe('ready')
+
+      // 6. Both assets now have completed watermark files
+      for (const asset of [assetA, assetB]) {
+        const wf = await prisma.watermarkFile.findUnique({
+          where: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            assetId_watermarkConfigId: {
+              assetId: asset.id,
+              watermarkConfigId: updatedShare.watermarkConfigId!,
+            },
+          },
+        })
+        expect(wf).toBeDefined()
+        expect(wf?.status).toBe(WatermarkFileStatus.completed)
+      }
+    })
   },
 )


### PR DESCRIPTION
Stop gating watermark replacement on the share-link-wide watermarkStatus. Public share endpoints now resolve each asset's own completed watermark proxy and:

- replace videoTranscodes/imageTranscodes with the watermarked entries when the watermark file is completed;
- empty those arrays when no completed proxy exists yet (still transcoding or failed) so original, unwatermarked media is never exposed while a newly added file is being processed;
- leave non-video/image media (pdf, audio, ...) untouched, since they never receive watermark transcodes.

This removes the previous behavior where adding a file to a ready watermark share flipped the whole share link to processing and served original media for every file until the new transcode finished.

Adds API tests for detail/children endpoints (ready, in-flight, pdf, and watermark-disabled cases) and a workflow E2E test for adding an asset to an already-ready watermark sharelink.