### PR TITLE
test(e2e): watermarked download-disabled share link coverage (image + video)

### DIFF
--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -84,6 +84,8 @@ apps/web/e2e/
 | Owner searches the file list by Chinese, Japanese, and Korean name keywords | `tests/project/search-file-list.spec.ts` |
 | Owner searches the file list with a keyword and a filter condition | `tests/project/search-file-list.spec.ts` |
 | Owner saves a search result as a collection | `tests/project/save-search-collection.spec.ts` |
+| Image share with watermark + download disabled: no download buttons on public list/detail pages, watermarked proxy served, download-url rejected | `tests/project/share-watermark-no-download.spec.ts` |
+| Video share with watermark + download disabled: no download buttons on public list/detail pages, watermarked proxy served, download-url rejected | `tests/project/share-watermark-no-download.spec.ts` |
 
 ### file
 | Test | File |

--- a/apps/web/e2e/helpers/files.ts
+++ b/apps/web/e2e/helpers/files.ts
@@ -3,6 +3,7 @@ import type { APIRequestContext, Locator, Page } from '@playwright/test'
 interface CreateShareResponse {
   id?: string
   name?: string
+  rootFolderId?: string
 }
 
 /**
@@ -23,7 +24,7 @@ export async function apiCreateShare(
   request: APIRequestContext,
   projectId: string,
   name: string,
-): Promise<{ id: string; name: string }> {
+): Promise<{ id: string; name: string; rootFolderId: string }> {
   const res = await request.post(`/api/projects/${projectId}/shares`, {
     data: { name },
   })
@@ -31,10 +32,10 @@ export async function apiCreateShare(
     throw new Error(`Create share API failed (${res.status()}): ${await res.text()}`)
   }
   const body = (await res.json()) as CreateShareResponse
-  if (!body.id || !body.name) {
+  if (!body.id || !body.name || !body.rootFolderId) {
     throw new Error(`Create share returned an unexpected response: ${JSON.stringify(body)}`)
   }
-  return { id: body.id, name: body.name }
+  return { id: body.id, name: body.name, rootFolderId: body.rootFolderId }
 }
 
 /** Adds assets to a share link through the API. */
@@ -49,6 +50,66 @@ export async function apiAddAssetsToShare(
   if (!res.ok()) {
     throw new Error(`Add assets to share API failed (${res.status()}): ${await res.text()}`)
   }
+}
+
+/** Updates share link settings (e.g. `allowDownload`) through the API. */
+export async function apiUpdateShare(
+  request: APIRequestContext,
+  shareId: string,
+  patch: { allowDownload?: boolean },
+): Promise<void> {
+  const res = await request.put(`/api/shares/${shareId}`, { data: patch })
+  if (!res.ok()) {
+    throw new Error(`Update share API failed (${res.status()}): ${await res.text()}`)
+  }
+}
+
+/**
+ * Enables a text watermark on the share link through the API. Uses the same
+ * default block shape the watermark editor produces (a "CONFIDENTIAL" text
+ * block), so the transcode workflow runs against a realistic config.
+ */
+export async function apiEnableShareWatermark(
+  request: APIRequestContext,
+  shareId: string,
+): Promise<void> {
+  const res = await request.put(`/api/shares/${shareId}/watermark`, {
+    data: {
+      enabled: true,
+      config: {
+        blocks: [
+          {
+            id: `wm-${Date.now()}`,
+            type: 'text',
+            text: 'CONFIDENTIAL',
+            x: 0.5,
+            y: 0.5,
+            // size is a fraction (0..1) of the canvas width
+            size: 0.05,
+            color: '#999999',
+            opacity: 0.5,
+            rotation: -30,
+          },
+        ],
+      },
+    },
+  })
+  if (!res.ok()) {
+    throw new Error(`Enable share watermark API failed (${res.status()}): ${await res.text()}`)
+  }
+}
+
+/** Requests a public download URL. Returns status + body for assertions. */
+export async function apiPublicDownloadUrl(
+  request: APIRequestContext,
+  shareId: string,
+  fileId: string,
+  key: string,
+): Promise<{ status: number; body: unknown }> {
+  const res = await request.post(`/api/shares/${shareId}/files/${fileId}/download-url`, {
+    data: { key },
+  })
+  return { status: res.status(), body: await res.json().catch(() => null) }
 }
 
 /** Uploads a file asset through the official API upload task endpoints. */

--- a/apps/web/e2e/tests/project/share-watermark-no-download.spec.ts
+++ b/apps/web/e2e/tests/project/share-watermark-no-download.spec.ts
@@ -1,0 +1,168 @@
+import { expect, test } from '../../fixtures'
+import {
+  apiAddAssetsToShare,
+  apiCreateShare,
+  apiEnableShareWatermark,
+  apiPublicDownloadUrl,
+  apiUpdateShare,
+  fileCard,
+} from '../../helpers/files'
+
+/**
+ * The watermarked + download-disabled combination is frequently used together:
+ * guests can preview the content but never download it, and any previewed proxy
+ * carries a watermark. This covers both watermarkable media types (image and
+ * video) and asserts, per type:
+ *  - the public share list page exposes no download affordance,
+ *  - the public share file detail page exposes no download affordance,
+ *  - the proxy loaded in the detail page is the watermarked version, and
+ *  - the download-url endpoint rejects guest download attempts with 403.
+ */
+for (const mediaType of ['image', 'video'] as const) {
+  test.use({ fileOptions: { mediaType } })
+
+  // Transcoding (original + watermark) happens through the local workflow
+  // executor, so this test needs a much larger budget than the 60s default.
+  test.setTimeout(300_000)
+
+  test(`${mediaType} share with watermark + download disabled: no download buttons, watermarked proxy`, async ({
+    file,
+    browser,
+    prisma,
+  }) => {
+    const { context, projectId, fileName, fileId } = file
+
+    // The watermark transcode re-encodes from the existing transcode slots, so
+    // the original transcode must finish first.
+    await expect
+      .poll(
+        async () => {
+          const asset = await prisma.asset.findUnique({ where: { id: fileId } })
+          return asset?.status
+        },
+        { timeout: 60_000 },
+      )
+      .toBe('processed')
+
+    // Seed the share through the API (setup, not the flow under test)
+    const share = await apiCreateShare(context.request, projectId, 'Watermarked Share')
+    await apiAddAssetsToShare(context.request, share.id, [fileId])
+    await apiUpdateShare(context.request, share.id, { allowDownload: false })
+    await apiEnableShareWatermark(context.request, share.id)
+
+    // Wait for the watermark transcode to complete and the share to be ready
+    await expect
+      .poll(
+        async () => {
+          const link = await prisma.shareLink.findUnique({ where: { id: share.id } })
+          return link?.watermarkStatus
+        },
+        { timeout: 120_000 },
+      )
+      .toBe('ready')
+
+    const saved = await prisma.shareLink.findUnique({ where: { id: share.id } })
+    expect(saved?.allowDownload).toBe(false)
+    expect(saved?.watermarkConfigId).not.toBeNull()
+
+    // The share root contains a symlink pointing at the real asset; the public
+    // detail page navigates with the symlink id (mirrors the real double-click flow).
+    const symlink = await prisma.asset.findFirst({
+      where: { parentId: share.rootFolderId, targetId: fileId },
+    })
+    expect(symlink).not.toBeNull()
+
+    // Original (unwatermarked) transcode keys, to prove they are never served
+    const asset = await prisma.asset.findUnique({ where: { id: fileId } })
+    const media = asset?.media as {
+      imageTranscodes?: Array<{ key: string }>
+      videoTranscodes?: Array<{ key: string }>
+      original?: { key: string } | null
+    } | null
+    const originalKeys =
+      (mediaType === 'image' ? media?.imageTranscodes : media?.videoTranscodes)?.map(
+        (t) => t.key,
+      ) ?? []
+
+    const guestContext = await browser.newContext()
+    const guestPage = await guestContext.newPage()
+    try {
+      // ---------------- Public share list page ----------------
+      await guestPage.goto(`/share/${share.id}`)
+      await expect(fileCard(guestPage, fileName)).toBeVisible()
+
+      // Card context menu: no Download item
+      const card = fileCard(guestPage, fileName)
+      const kebab = card.locator('button', {
+        has: guestPage.locator('svg.lucide-ellipsis'),
+      })
+      await kebab.click()
+      await expect(guestPage.locator('[data-radix-menu-content]').first()).toBeAttached()
+      await expect(guestPage.getByRole('menuitem', { name: 'Download' })).toHaveCount(0)
+      await guestPage.keyboard.press('Escape')
+
+      // Selection bar: selecting the file must not surface a Download button
+      await card.click()
+      await expect(guestPage.getByText(/1 file selected/)).toBeVisible()
+      await expect(guestPage.getByRole('button', { name: 'Download' })).toHaveCount(0)
+
+      // ---------------- Public share file detail page ----------------
+      // Capture every network request so we can prove the loaded proxy is the
+      // watermarked one and no original transcode key is ever requested.
+      const watermarkedRequests: string[] = []
+      const allRequests: string[] = []
+      guestPage.on('request', (req) => {
+        const url = req.url()
+        allRequests.push(url)
+        if (url.includes('-watermark-')) watermarkedRequests.push(url)
+      })
+
+      const detailFileId = symlink!.id
+      await guestPage.goto(`/share/${share.id}/files/${detailFileId}`)
+
+      // The viewer (image canvas / video element) renders the proxy
+      if (mediaType === 'image') {
+        await expect(guestPage.locator('canvas').first()).toBeVisible({ timeout: 30_000 })
+      } else {
+        await expect(guestPage.locator('video').first()).toBeVisible({ timeout: 30_000 })
+      }
+
+      // The proxy actually loaded is the watermarked version, and no original
+      // (unwatermarked) transcode key was requested
+      await expect.poll(() => watermarkedRequests.length, { timeout: 30_000 }).toBeGreaterThan(0)
+      const leaked = allRequests.filter((url) => originalKeys.some((key) => url.includes(key)))
+      expect(leaked).toEqual([])
+
+      // No download affordance in the viewer control bar
+      await expect(guestPage.getByTitle('Download')).toHaveCount(0)
+      await expect(guestPage.getByTitle('Download original image')).toHaveCount(0)
+      await expect(guestPage.getByRole('button', { name: 'Download' })).toHaveCount(0)
+
+      // Top-nav file dropdown: no Download item (video: also no resolution submenu)
+      await guestPage.getByRole('button', { name: new RegExp(fileName) }).click()
+      await expect(guestPage.locator('[data-radix-menu-content]').first()).toBeAttached()
+      await expect(guestPage.getByRole('menuitem', { name: 'Download' })).toHaveCount(0)
+      if (mediaType === 'video') {
+        await expect(
+          guestPage.locator('[data-radix-menu-content]').getByText('Original', { exact: true }),
+        ).toHaveCount(0)
+        await expect(
+          guestPage.locator('[data-radix-menu-content]').getByText('MP4', { exact: true }),
+        ).toHaveCount(0)
+      }
+
+      // ---------------- Backend enforcement ----------------
+      // Guests cannot obtain a download URL even when they know the storage key
+      const originalKey = originalKeys[0] || media?.original?.key || ''
+      const download = await apiPublicDownloadUrl(
+        guestContext.request,
+        share.id,
+        detailFileId,
+        originalKey,
+      )
+      expect(download.status).toBe(403)
+    } finally {
+      await guestContext.close()
+    }
+  })
+}


### PR DESCRIPTION
## Summary

Adds web app E2E coverage for the frequently-combined **watermark + download-disabled** share link configuration. Guests can preview the content but never download it, and every previewed proxy carries a watermark.

## Changes

- **New spec** `apps/web/e2e/tests/project/share-watermark-no-download.spec.ts` with two tests (image + video), each asserting:
  - **Public share list page**: card context menu has no `Download` item; the selection bar shows no `Download` button when a file is selected.
  - **Public share file detail page**: no download button in the viewer control bar, no `Download` item in the top-nav file dropdown (video also has no resolution submenu); the loaded proxy is the watermarked version (`-watermark-` S3 keys) and no original transcode key is ever requested (network-level assertion).
  - **Backend enforcement**: guest `POST /api/shares/:shareId/files/:fileId/download-url` returns `403`.
- **Helpers** (`apps/web/e2e/helpers/files.ts`): `apiUpdateShare` (allowDownload toggle), `apiEnableShareWatermark` (text watermark via API), `apiPublicDownloadUrl`; `apiCreateShare` now returns `rootFolderId`.
- **Docs**: two new entries in `apps/web/e2e/README.md`.

## Verification

- `bun run lint` — pass
- `bun run format` — pass (no unexpected changes)
- `bun run typecheck` — pass
- `bun run test` — 881/881 pass
- `bun run test:e2e` — app-chromium 29/29 pass (incl. the 2 new tests); harness-chromium has 9 pre-existing video-player failures, confirmed failing on clean `main` (unrelated to this change)
- `bun run test:e2e:workflow` — 48/48 pass

## Notes

- Watermark transcodes run through the local workflow executor, so the spec uses a 300s test timeout and polls `watermarkStatus === 'ready'`.
- Thumbnails/previews are intentionally not watermarked and are not asserted.
