### PR TITLE
docs(agent): clarify create_file/create_version context param guidance

### DIFF
--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -96,7 +96,7 @@ shumai has its own cloud file system. If a user asks you to perform file system 
 
 If you need to create files in the local filesystem (for example, a temporary file for uploading), only the '.pi' folder in the current directory has write permissions. Do NOT attempt to create files in any other directories.
 
-When creating a file or version, first use 'list_autofill_fields' to inspect the project's AI-autofillable metadata fields. If relevant metadata depends on information unavailable from the file content (for example, the AI model or tool used to generate it), include a brief context hint (maximum 50 words) in the 'context' field of 'create_file' or 'create_version' tool.`
+When creating a file or version, first use 'list_autofill_fields' to inspect the project's AI-autofillable metadata fields. If relevant metadata depends on information unavailable from the file content (for example, the AI model or prompt used to generate the asset), include a context in the 'context' field of 'create_file' or 'create_version'. Keep the context short and only include information relevant to those fields.`
 
   if (agent.soul) {
     systemPrompt = `${systemPrompt}\n\nAgent Personality and Core Instructions:\n${agent.soul}`

--- a/packages/agent/src/tools/create-file.ts
+++ b/packages/agent/src/tools/create-file.ts
@@ -33,9 +33,10 @@ const createFileSchema = Type.Object({
   context: Type.Optional(
     Type.String({
       description:
-        'Optional short context about this file and how it was generated (max 50 words, e.g. "Generated using gemini"). ' +
-        'Passed to the AI metadata autofill workflow to fill fields that cannot be determined from file content alone. ' +
-        'Check autofillable fields with list_autofill_fields first.',
+        'Optional context passed to the AI metadata autofill workflow for fields that cannot be inferred from file content alone ' +
+        '(e.g. the model or prompt used to generate the asset). ' +
+        'Use list_autofill_fields first to check which fields can be autofilled. ' +
+        'Keep the context short and only include information relevant to those fields.',
     }),
   ),
 })

--- a/packages/agent/src/tools/create-version.ts
+++ b/packages/agent/src/tools/create-version.ts
@@ -20,9 +20,10 @@ const createVersionSchema = Type.Object({
   context: Type.Optional(
     Type.String({
       description:
-        'Optional short context about this version and how it was generated (max 50 words, e.g. "Generated using gemini"). ' +
-        'Passed to the AI metadata autofill workflow to fill fields that cannot be determined from file content alone. ' +
-        'Check autofillable fields with list_autofill_fields first.',
+        'Optional context passed to the AI metadata autofill workflow for fields that cannot be inferred from file content alone ' +
+        '(e.g. the model or prompt used to generate the asset). ' +
+        'Use list_autofill_fields first to check which fields can be autofilled. ' +
+        'Keep the context short and only include information relevant to those fields.',
     }),
   ),
 })

--- a/packages/agent/src/tools/list-autofill-fields.ts
+++ b/packages/agent/src/tools/list-autofill-fields.ts
@@ -17,7 +17,7 @@ export function createListAutofillFieldsTool(
     label: 'List Autofill Fields',
     description:
       'List the AI-autofillable metadata fields defined for the project of a parent folder, including their types and available options. ' +
-      'Use this before creating a file or version so you can pass relevant context (e.g. generation source) to create_file/create_version.',
+      'Use this before creating a file or version so you can pass relevant context (e.g. the model or prompt used to generate the asset) to create_file/create_version.',
     parameters: listAutofillFieldsSchema,
     execute: async (_toolCallId, params) => {
       const result = await executeAgentToolWorkflow({


### PR DESCRIPTION
## Summary

Updates the `context` parameter guidance for the `create_file` and `create_version` agent tools and related places, removing the artificial 50-word limit so users can pass longer context (e.g. a full generation prompt) when autofilling metadata.

## Changes

- **`packages/agent/src/tools/create-file.ts`**: Rewrote the `context` param description to explain it is passed to the AI metadata autofill workflow for fields not inferable from file content (e.g. model or prompt used to generate the asset), directs users to `list_autofill_fields` first, and advises keeping context short and relevant — no 50-word limit.
- **`packages/agent/src/tools/create-version.ts`**: Same description update for the version tool.
- **`packages/agent/src/tools/list-autofill-fields.ts`**: Aligned the example in the tool description (model or prompt used to generate the asset).
- **`packages/agent/src/activities/agent.ts`**: Updated the agent system prompt to remove the `maximum 50 words` hint and match the new guidance.

Note: there is no code-level enforcement of the 50-word limit (it was purely LLM guidance in descriptions), so no logic changes were required.

## Verification

- `bun run lint` — pass
- `bun run format` — pass
- `bun run typecheck` — pass
- `bun run test` — 103 files / 884 tests pass
- `bun run test:e2e:workflow` — 12 files / 48 tests pass
- `bun run test:e2e:app` — 29 tests pass
- `bun run test:e2e:webui` — 9 tests pass

## Notes

No tests assert the exact description strings, so no test changes were needed.