### PR TITLE
fix(webui): resolve upload card freeze for unsupported files

### DIFF
--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -68,7 +68,7 @@ apps/web/e2e/
 | Test | File |
 |---|---|
 | Owner creates a project with a cover image | `tests/project/create-project.spec.ts` |
-| Owner uploads a file via the "Upload File" context menu action | `tests/project/upload-file.spec.ts` |
+| Owner uploads a file or an unsupported file via the "Upload File" context menu action | `tests/project/upload-file.spec.ts` |
 | Owner deletes a file, finds it in recently deleted, and restores it | `tests/project/delete-restore.spec.ts` |
 | Owner creates a share link from a file context menu and lands on the share page | `tests/project/create-share-link.spec.ts` |
 | Owner protects a share with a password; guests must enter it to view | `tests/project/share-password.spec.ts` |

--- a/apps/web/e2e/tests/project/upload-file.spec.ts
+++ b/apps/web/e2e/tests/project/upload-file.spec.ts
@@ -47,3 +47,39 @@ test('owner uploads a file via the "Upload File" context menu action', async ({
   const projectRow = await prisma.project.findUnique({ where: { id: projectId } })
   expect(asset!.parentId).toBe(projectRow?.rootFolderId)
 })
+
+test('owner uploads an unsupported file via context menu action', async ({ project, prisma }) => {
+  const { page, projectId } = project
+  const fileName = `e2e-upload-${Date.now()}.bin`
+  const binBuffer = Buffer.from([0x00, 0x01, 0x02, 0x03])
+
+  await page.goto(`/projects/${projectId}`)
+  await expect(page.getByText('This folder is empty')).toBeVisible()
+
+  await page.getByText('This folder is empty').click({ button: 'right' })
+  const [fileChooser] = await Promise.all([
+    page.waitForEvent('filechooser'),
+    page.getByRole('menuitem', { name: 'Upload File' }).click(),
+  ])
+  await fileChooser.setFiles({
+    name: fileName,
+    mimeType: 'application/octet-stream',
+    buffer: binBuffer,
+  })
+
+  const card = fileCard(page, fileName)
+  await expect(card).toBeVisible()
+
+  await expect
+    .poll(
+      async () => {
+        const asset = await prisma.asset.findFirst({ where: { name: fileName } })
+        return asset?.status
+      },
+      { timeout: 30_000 },
+    )
+    .toBe('processed')
+
+  // Verify that the file card shows the generic file icon and is not stuck in uploading state
+  await expect(card.locator('svg.lucide-file')).toBeVisible({ timeout: 10_000 })
+})

--- a/packages/webui/components/file-browser/file-card.tsx
+++ b/packages/webui/components/file-browser/file-card.tsx
@@ -116,7 +116,15 @@ export function FileCard({
     },
   })
 
-  const displayItem = polledItem || item
+  const displayItem = useMemo(() => {
+    if (item.status === 'processed' || item.status === 'error') {
+      return item
+    }
+    if (polledItem?.status === 'processed' || polledItem?.status === 'error') {
+      return polledItem
+    }
+    return polledItem || item
+  }, [item, polledItem])
 
   // dnd-kit hooks
   const { ref: setDraggableRef, isDragging: isDraggableDragging } = useDraggable({

--- a/packages/webui/components/file-browser/file-list-item.tsx
+++ b/packages/webui/components/file-browser/file-list-item.tsx
@@ -91,7 +91,15 @@ export function FileListItem({
     },
   })
 
-  const displayItem = polledItem || item
+  const displayItem = useMemo(() => {
+    if (item.status === 'processed' || item.status === 'error') {
+      return item
+    }
+    if (polledItem?.status === 'processed' || polledItem?.status === 'error') {
+      return polledItem
+    }
+    return polledItem || item
+  }, [item, polledItem])
 
   // dnd-kit hooks
   const { ref: setDraggableRef, isDragging: isDraggableDragging } = useDraggable({


### PR DESCRIPTION
## Summary

Fixes a bug where uploading unsupported files (files with no preview proxy support) causes the file card / list item to freeze at 100% progress circle rather than transitioning to the file icon.

## Changes

- Updated `displayItem` resolution in `packages/webui/components/file-browser/file-card.tsx` and `packages/webui/components/file-browser/file-list-item.tsx` to prioritize terminal statuses (`'processed'`, `'error'`) on `item` over stale cached data in `polledItem`.
- Added E2E test case in `apps/web/e2e/tests/project/upload-file.spec.ts` for uploading unsupported files and updated `apps/web/e2e/README.md`.

## Verification

- `bun run lint` (Passed)
- `bun run format` (Passed)
- `bun run typecheck` (Passed)
- `bun run test` (Passed - 104 files, 913 tests)
- `bun run test:e2e:app` (Passed - 30 tests)
- `bun run test:e2e:webui` (Passed - 9 tests)
- `bun run test:e2e:workflow` (Passed - 13 files, 54 tests)

## Notes

No breaking changes.