### PR TITLE
fix(webui): exclude file extension when selecting file name during inline rename

### DIFF
--- a/packages/webui/components/file-browser/file-card.tsx
+++ b/packages/webui/components/file-browser/file-card.tsx
@@ -17,6 +17,7 @@ import { EditableText } from '@/ui/components/ui/editable-text'
 import { ProgressCircle } from '@/ui/components/ui/progress-circle'
 import { Skeleton } from '@/ui/components/ui/skeleton'
 import { formatTimeAgo } from '@/ui/lib/time'
+import { selectFileNameWithoutExtension } from '@/ui/lib/rename-utils'
 import { cn } from '@/ui/lib/utils'
 import { useUploadStore } from '@/ui/stores/upload'
 import { useDraggable, useDroppable } from '@dnd-kit/react'
@@ -188,8 +189,9 @@ export function FileCard({
       // the DOM has stabilized before focusing. Radix focus restoration
       // can sometimes conflict with immediate focus calls.
       const timeoutId = setTimeout(() => {
-        inputRef.current?.focus()
-        inputRef.current?.select()
+        if (inputRef.current) {
+          selectFileNameWithoutExtension(inputRef.current)
+        }
       }, 150)
       return () => clearTimeout(timeoutId)
     }

--- a/packages/webui/components/file-browser/file-list-item.tsx
+++ b/packages/webui/components/file-browser/file-list-item.tsx
@@ -7,6 +7,7 @@ import { File, Folder, MoreVertical, AudioLines } from 'lucide-react'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { cn } from '@/ui/lib/utils'
 import { formatSize } from '@/ui/lib/format'
+import { selectFileNameWithoutExtension } from '@/ui/lib/rename-utils'
 import type { DragState } from '../dnd-types'
 import FieldRenderer from '../field-renderer'
 import { Badge } from '@/ui/components/ui/badge'
@@ -133,8 +134,9 @@ export function FileListItem({
       // the DOM has stabilized before focusing. Radix focus restoration
       // can sometimes conflict with immediate focus calls.
       const timeoutId = setTimeout(() => {
-        inputRef.current?.focus()
-        inputRef.current?.select()
+        if (inputRef.current) {
+          selectFileNameWithoutExtension(inputRef.current)
+        }
       }, 150)
       return () => clearTimeout(timeoutId)
     }

--- a/packages/webui/lib/rename-utils.test.ts
+++ b/packages/webui/lib/rename-utils.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getFileNameBaseRange, selectFileNameWithoutExtension } from './rename-utils'
+
+describe('rename-utils', () => {
+  describe('getFileNameBaseRange', () => {
+    it('returns range excluding file extension for standard filenames', () => {
+      expect(getFileNameBaseRange('test.png')).toEqual([0, 4])
+      expect(getFileNameBaseRange('document.pdf')).toEqual([0, 8])
+      expect(getFileNameBaseRange('archive.tar.gz')).toEqual([0, 11])
+    })
+
+    it('returns full length range for filenames without extension', () => {
+      expect(getFileNameBaseRange('README')).toEqual([0, 6])
+      expect(getFileNameBaseRange('my-folder')).toEqual([0, 9])
+    })
+
+    it('returns full length range for dotfiles starting with dot', () => {
+      expect(getFileNameBaseRange('.gitignore')).toEqual([0, 10])
+      expect(getFileNameBaseRange('.env')).toEqual([0, 4])
+    })
+
+    it('returns range excluding trailing dot for filenames ending with dot', () => {
+      expect(getFileNameBaseRange('file.')).toEqual([0, 4])
+    })
+
+    it('returns [0, 0] for empty string', () => {
+      expect(getFileNameBaseRange('')).toEqual([0, 0])
+    })
+  })
+
+  describe('selectFileNameWithoutExtension', () => {
+    it('calls focus and setSelectionRange on input element', () => {
+      const input = {
+        focus: vi.fn(),
+        value: 'image.png',
+        setSelectionRange: vi.fn(),
+        select: vi.fn(),
+      } as unknown as HTMLInputElement
+
+      selectFileNameWithoutExtension(input)
+
+      expect(input.focus).toHaveBeenCalled()
+      expect(input.setSelectionRange).toHaveBeenCalledWith(0, 5)
+      expect(input.select).not.toHaveBeenCalled()
+    })
+
+    it('falls back to select() if setSelectionRange is not a function', () => {
+      const input = {
+        focus: vi.fn(),
+        value: 'image.png',
+        setSelectionRange: undefined,
+        select: vi.fn(),
+      } as unknown as HTMLInputElement
+
+      selectFileNameWithoutExtension(input)
+
+      expect(input.focus).toHaveBeenCalled()
+      expect(input.select).toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/webui/lib/rename-utils.ts
+++ b/packages/webui/lib/rename-utils.ts
@@ -1,0 +1,27 @@
+/**
+ * Calculates the start and end selection range for a file name to exclude its extension.
+ * e.g. "test.png" -> [0, 4] ("test")
+ * e.g. "archive.tar.gz" -> [0, 11] ("archive.tar")
+ * e.g. "file_without_ext" -> [0, 16] ("file_without_ext")
+ * e.g. ".gitignore" -> [0, 10] (".gitignore")
+ */
+export function getFileNameBaseRange(name: string): [number, number] {
+  const lastDotIndex = name.lastIndexOf('.')
+  if (lastDotIndex > 0) {
+    return [0, lastDotIndex]
+  }
+  return [0, name.length]
+}
+
+/**
+ * Focuses the input element and selects the base file name, excluding the extension.
+ */
+export function selectFileNameWithoutExtension(input: HTMLInputElement) {
+  input.focus()
+  const [start, end] = getFileNameBaseRange(input.value)
+  if (typeof input.setSelectionRange === 'function') {
+    input.setSelectionRange(start, end)
+  } else {
+    input.select()
+  }
+}


### PR DESCRIPTION
## Summary

Excludes file extension from text selection when triggering inline rename in WebUI (e.g. selecting `test` instead of `test.png`).

## Changes

- Created `packages/webui/lib/rename-utils.ts` with `getFileNameBaseRange` and `selectFileNameWithoutExtension` helpers to compute base filename selection ranges.
- Created `packages/webui/lib/rename-utils.test.ts` to unit test filename range selection (including dotfiles, multi-dot extensions, files without extensions, etc.).
- Updated `FileCard` (`packages/webui/components/file-browser/file-card.tsx`) and `FileListItem` (`packages/webui/components/file-browser/file-list-item.tsx`) to use `selectFileNameWithoutExtension` when entering edit mode.

## Verification

Ran all mandatory quality checks:
- `bun run lint`: Passed with zero warnings/errors.
- `bun run format`: Passed.
- `bun run typecheck`: Passed cleanly with zero TypeScript errors.
- `bun run test`: 105 test files passed (920 tests), including `rename-utils.test.ts`.
- `bun run test:e2e:webui`: 9 tests passed.
- `bun run test:e2e:workflow`: 13 test files passed (54 tests).
- `bun run test:e2e:app`: 30 tests passed.

## Notes

Bug 2 investigation and fix will be addressed separately as requested.