### PR TITLE
fix: use renamed asset name in download Content-Disposition

### DIFF
--- a/packages/api/src/s3.test.ts
+++ b/packages/api/src/s3.test.ts
@@ -39,7 +39,7 @@ describe('S3 API', () => {
     }
   })
 
-  it('GET /files/* sets Content-Disposition: attachment only when download=1 query param is present', async () => {
+  it('GET /files/* sets Content-Disposition with filename when download=1 & filename query params are present', async () => {
     // We need to capture the onFound callback from serveStatic options
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let onFoundCallback: ((path: string, c: any) => void) | undefined
@@ -54,19 +54,36 @@ describe('S3 API', () => {
     const { default: route } = await import('./s3')
     const app = new Hono().route('/files', route)
 
-    await app.request('/files/b1/test.webp?download=1')
+    await app.request('/files/b1/test.webp?download=1&filename=foo.png')
 
     expect(onFoundCallback).toBeDefined()
 
-    // Test with download=1
+    // Test with download=1 and filename
     const mockContextWithDownload = {
-      req: { query: (key: string) => (key === 'download' ? '1' : undefined) },
+      req: {
+        query: (key: string) =>
+          key === 'download' ? '1' : key === 'filename' ? 'foo.png' : undefined,
+      },
       header: vi.fn(),
     }
 
     if (onFoundCallback) {
       onFoundCallback('/files/b1/test.webp', mockContextWithDownload)
       expect(mockContextWithDownload.header).toHaveBeenCalledWith(
+        'Content-Disposition',
+        'attachment; filename="foo.png"; filename*=UTF-8\'\'foo.png',
+      )
+    }
+
+    // Test with download=1 but no filename
+    const mockContextDownloadNoFilename = {
+      req: { query: (key: string) => (key === 'download' ? '1' : undefined) },
+      header: vi.fn(),
+    }
+
+    if (onFoundCallback) {
+      onFoundCallback('/files/b1/test.webp', mockContextDownloadNoFilename)
+      expect(mockContextDownloadNoFilename.header).toHaveBeenCalledWith(
         'Content-Disposition',
         'attachment',
       )

--- a/packages/api/src/s3.ts
+++ b/packages/api/src/s3.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { s3Service } from '@shumai/core/src/s3/s3'
+import { buildContentDisposition, s3Service } from '@shumai/core/src/s3/s3'
 import { serveStatic } from 'hono/bun'
 
 const route = new Hono()
@@ -10,7 +10,7 @@ const route = new Hono()
       rewriteRequestPath: (path) => path.replace(/^\/files\//, ''),
       onFound: (_path, c) => {
         if (c.req.query('download') === '1') {
-          c.header('Content-Disposition', 'attachment')
+          c.header('Content-Disposition', buildContentDisposition(c.req.query('filename')))
         }
       },
     }),

--- a/packages/core/src/asset/asset.test.ts
+++ b/packages/core/src/asset/asset.test.ts
@@ -4,6 +4,7 @@ import { setupTestDbHooks } from '@shumai/db/test'
 import { HTTPException } from 'hono/http-exception'
 
 import { AssetType, AssetStatus, Prisma } from '@shumai/db'
+import { s3Service } from '@shumai/core/src/s3/s3'
 import { AssetService } from './asset'
 
 vi.mock('@shumai/core/src/s3/s3', () => ({
@@ -2229,6 +2230,18 @@ describe('AssetService — natural sort by name', () => {
       for (const item of result) {
         expect(item.url).toBe('http://mock-s3-url')
       }
+
+      // Renamed file names must be passed to presign so the download
+      // Content-Disposition header uses the asset name, not the storage key
+      for (const name of ['file1.txt', 'file2.txt', 'version2.txt']) {
+        expect(s3Service.presign).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.any(String),
+          'GET',
+          true,
+          name,
+        )
+      }
     })
 
     it('resolves top-level symlinks to their targets when passed as direct starting IDs', async () => {
@@ -2539,6 +2552,40 @@ describe('AssetService — natural sort by name', () => {
       )
 
       expect(url).toBe('http://mock-s3-url')
+      expect(s3Service.presign).toHaveBeenCalledWith(
+        expect.any(String),
+        'files/01TESTULID000000000000000/test-720p.mp4',
+        'GET',
+        true,
+        'test.mp4',
+      )
+    })
+
+    it('should use the renamed asset name as the download filename', async () => {
+      const asset = await prisma.asset.create({
+        data: {
+          name: 'foo.png',
+          type: AssetType.file,
+          status: AssetStatus.uploaded,
+          storageKey: {
+            create: { key: 'files/01RENAMEDULID0000000000000/test.png' },
+          },
+        },
+      })
+
+      const url = await assetService.getDownloadUrl(
+        asset.id,
+        'files/01RENAMEDULID0000000000000/test.png',
+      )
+
+      expect(url).toBe('http://mock-s3-url')
+      expect(s3Service.presign).toHaveBeenCalledWith(
+        expect.any(String),
+        'files/01RENAMEDULID0000000000000/test.png',
+        'GET',
+        true,
+        'foo.png',
+      )
     })
 
     it('should return a presigned download URL for the original key', async () => {

--- a/packages/core/src/asset/asset.ts
+++ b/packages/core/src/asset/asset.ts
@@ -1966,7 +1966,13 @@ export class AssetService {
         const key = file.storageKeyId ? storageKeyMap.get(file.storageKeyId) : null
         if (!key) return null
 
-        const url = await s3Service.presign(process.env.S3_BUCKET || 'shumai', key, 'GET', true)
+        const url = await s3Service.presign(
+          process.env.S3_BUCKET || 'shumai',
+          key,
+          'GET',
+          true,
+          file.name,
+        )
 
         return {
           id: file.id,
@@ -1988,7 +1994,7 @@ export class AssetService {
     const targetAssetId = await this.resolveLatestVersionId(assetId)
     const asset = await this.prismaClient.asset.findUnique({
       where: { id: targetAssetId },
-      select: { id: true, parentId: true, storageKey: { select: { key: true } } },
+      select: { id: true, name: true, parentId: true, storageKey: { select: { key: true } } },
     })
 
     if (!asset?.storageKey?.key) {
@@ -2022,7 +2028,13 @@ export class AssetService {
       throw new Error('Key does not belong to this asset')
     }
 
-    return s3Service.presign(process.env.S3_BUCKET || 'shumai', key, 'GET', true)
+    return s3Service.presign(
+      process.env.S3_BUCKET || 'shumai',
+      key,
+      'GET',
+      true,
+      asset.name ?? undefined,
+    )
   }
 
   private async toPreviewInfo(asset: Asset | AssetWithIncludes): Promise<PreviewInfo | null> {

--- a/packages/core/src/s3/s3.test.ts
+++ b/packages/core/src/s3/s3.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
-import { LocalStorageService, S3StorageService } from './s3'
+import { buildContentDisposition, LocalStorageService, S3StorageService } from './s3'
 
 // Mock Bun S3Client
 const s3ClientConstructorSpy = vi.fn()
@@ -140,6 +140,30 @@ describe('S3Service implementations', () => {
       )
     })
 
+    it('should set contentDisposition with the filename when download filename is provided', async () => {
+      const s3 = new S3StorageService('http://localhost:9000', 'key', 'secret', 'test-bucket')
+      await s3.presign('bucket', 'key', 'GET', true, 'foo.png')
+
+      expect(s3PresignSpy).toHaveBeenCalledWith(
+        'key',
+        expect.objectContaining({
+          contentDisposition: 'attachment; filename="foo.png"; filename*=UTF-8\'\'foo.png',
+        }),
+      )
+    })
+
+    it('should include an RFC 5987 filename* for non-ASCII filenames', async () => {
+      const s3 = new S3StorageService('http://localhost:9000', 'key', 'secret', 'test-bucket')
+      await s3.presign('bucket', 'key', 'GET', true, '报告.png')
+
+      expect(s3PresignSpy).toHaveBeenCalledWith(
+        'key',
+        expect.objectContaining({
+          contentDisposition: expect.stringContaining("filename*=UTF-8''"),
+        }),
+      )
+    })
+
     it('should not cache download presign URLs', async () => {
       const s3 = new S3StorageService('http://localhost:9000', 'key', 'secret', 'test-bucket')
 
@@ -248,6 +272,18 @@ describe('S3Service implementations', () => {
       expect(url).toBe('http://localhost:3000/files/my-bucket/dir/file.txt?download=1')
     })
 
+    it('should include an encoded filename in the local download URL', async () => {
+      const url = await localS3.presign('my-bucket', 'dir/file.txt', 'GET', true, 'foo bar.png')
+      expect(url).toBe(
+        'http://localhost:3000/files/my-bucket/dir/file.txt?download=1&filename=foo%20bar.png',
+      )
+    })
+
+    it('should not append a filename param when none is provided', async () => {
+      const url = await localS3.presign('my-bucket', 'dir/file.txt', 'GET', true)
+      expect(url).not.toContain('filename=')
+    })
+
     it('should throw an error for unsupported presign methods', async () => {
       await expect(localS3.presign('b', 'k', 'POST')).rejects.toThrow()
     })
@@ -285,6 +321,32 @@ describe('S3Service implementations', () => {
       const url = await s3Service.presign('bucket', 'key', 'GET')
       expect(url).toContain('http://123.456.7.8:12345')
       expect(url).not.toContain('4567')
+    })
+  })
+
+  describe('buildContentDisposition', () => {
+    it('returns plain attachment when no filename is provided', () => {
+      expect(buildContentDisposition()).toBe('attachment')
+      expect(buildContentDisposition('')).toBe('attachment')
+      expect(buildContentDisposition(null)).toBe('attachment')
+    })
+
+    it('builds a disposition with quoted filename and RFC 5987 filename*', () => {
+      expect(buildContentDisposition('foo.png')).toBe(
+        'attachment; filename="foo.png"; filename*=UTF-8\'\'foo.png',
+      )
+    })
+
+    it('strips control characters and quotes to prevent header injection', () => {
+      expect(buildContentDisposition('a\r\nb"c\\d')).toBe(
+        'attachment; filename="abcd"; filename*=UTF-8\'\'abcd',
+      )
+    })
+
+    it('percent-encodes reserved RFC 5987 characters', () => {
+      expect(buildContentDisposition("it's (final).png")).toBe(
+        "attachment; filename=\"it's (final).png\"; filename*=UTF-8''it%27s%20%28final%29.png",
+      )
     })
   })
 })

--- a/packages/core/src/s3/s3.test.ts
+++ b/packages/core/src/s3/s3.test.ts
@@ -159,7 +159,9 @@ describe('S3Service implementations', () => {
       expect(s3PresignSpy).toHaveBeenCalledWith(
         'key',
         expect.objectContaining({
-          contentDisposition: expect.stringContaining("filename*=UTF-8''"),
+          // Non-ASCII names are conveyed only via filename* (percent-encoded),
+          // keeping the header value pure ASCII (RFC 7230).
+          contentDisposition: "attachment; filename*=UTF-8''%E6%8A%A5%E5%91%8A.png",
         }),
       )
     })
@@ -347,6 +349,22 @@ describe('S3Service implementations', () => {
       expect(buildContentDisposition("it's (final).png")).toBe(
         "attachment; filename=\"it's (final).png\"; filename*=UTF-8''it%27s%20%28final%29.png",
       )
+    })
+
+    it('percent-encodes the * character in filename*', () => {
+      expect(buildContentDisposition('foo*bar.png')).toBe(
+        'attachment; filename="foo*bar.png"; filename*=UTF-8\'\'foo%2Abar.png',
+      )
+    })
+
+    it('omits the quoted filename fallback for non-ASCII names to keep the header ASCII', () => {
+      expect(buildContentDisposition('幻境边界.pptx')).toBe(
+        "attachment; filename*=UTF-8''%E5%B9%BB%E5%A2%83%E8%BE%B9%E7%95%8C.pptx",
+      )
+      // The whole header value must remain pure ASCII so Bun/Node Headers accept it
+      expect(
+        [...buildContentDisposition('幻境边界.pptx')].every((ch) => ch.charCodeAt(0) <= 0x7f),
+      ).toBe(true)
     })
   })
 })

--- a/packages/core/src/s3/s3.ts
+++ b/packages/core/src/s3/s3.ts
@@ -31,7 +31,9 @@ export function verifyLocalUrlSignature(bucket: string, key: string, signature: 
  * Build a Content-Disposition header value for downloads.
  * - Falls back to plain `attachment` when no filename is provided.
  * - Strips control characters (CR/LF header injection), quotes, and backslashes.
- * - Includes the RFC 5987 `filename*` form so non-ASCII (e.g. Chinese) names survive.
+ * - Header values must be ASCII (RFC 7230): non-ASCII names are conveyed only
+ *   via the percent-encoded RFC 5987 `filename*` parameter; the quoted
+ *   `filename="..."` fallback is included only when the name is pure ASCII.
  */
 export function buildContentDisposition(filename?: string | null): string {
   if (!filename) return 'attachment'
@@ -45,11 +47,15 @@ export function buildContentDisposition(filename?: string | null): string {
     .join('')
     .trim()
   if (!sanitized) return 'attachment'
-  // RFC 5987 attr-char excludes ' ( ) — percent-encode them explicitly
+  // RFC 5987 attr-char excludes ' ( ) * — percent-encode them explicitly
   const encoded = encodeURIComponent(sanitized).replace(
-    /['()]/g,
+    /['()*]/g,
     (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
   )
+  const isAscii = [...sanitized].every((ch) => ch.charCodeAt(0) <= 0x7f)
+  if (!isAscii) {
+    return `attachment; filename*=UTF-8''${encoded}`
+  }
   return `attachment; filename="${sanitized}"; filename*=UTF-8''${encoded}`
 }
 

--- a/packages/core/src/s3/s3.ts
+++ b/packages/core/src/s3/s3.ts
@@ -27,6 +27,32 @@ export function verifyLocalUrlSignature(bucket: string, key: string, signature: 
   }
 }
 
+/**
+ * Build a Content-Disposition header value for downloads.
+ * - Falls back to plain `attachment` when no filename is provided.
+ * - Strips control characters (CR/LF header injection), quotes, and backslashes.
+ * - Includes the RFC 5987 `filename*` form so non-ASCII (e.g. Chinese) names survive.
+ */
+export function buildContentDisposition(filename?: string | null): string {
+  if (!filename) return 'attachment'
+  // Strip C0 control characters (incl. CR/LF header injection) and DEL, then
+  // quotes/backslashes which would break the quoted-string form.
+  const sanitized = [...filename]
+    .filter((ch) => {
+      const code = ch.charCodeAt(0)
+      return code > 0x1f && code !== 0x7f && ch !== '"' && ch !== '\\'
+    })
+    .join('')
+    .trim()
+  if (!sanitized) return 'attachment'
+  // RFC 5987 attr-char excludes ' ( ) — percent-encode them explicitly
+  const encoded = encodeURIComponent(sanitized).replace(
+    /['()]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  )
+  return `attachment; filename="${sanitized}"; filename*=UTF-8''${encoded}`
+}
+
 export interface S3Object {
   buffer: Buffer
   contentType: string
@@ -55,7 +81,13 @@ export interface S3Service {
   listObjects: (bucket: string, prefix: string) => Promise<string[]>
   uploadFile: (filePath: string, contentType: string) => Promise<string>
   uploadFileToKey: (filePath: string, key: string, contentType: string) => Promise<void>
-  presign: (bucket: string, key: string, method: string, download?: boolean) => Promise<string>
+  presign: (
+    bucket: string,
+    key: string,
+    method: string,
+    download?: boolean,
+    filename?: string,
+  ) => Promise<string>
 }
 
 export class S3StorageService implements S3Service {
@@ -214,7 +246,13 @@ export class S3StorageService implements S3Service {
     })
   }
 
-  async presign(bucket: string, key: string, method: string, download?: boolean): Promise<string> {
+  async presign(
+    bucket: string,
+    key: string,
+    method: string,
+    download?: boolean,
+    filename?: string,
+  ): Promise<string> {
     const expireHours = parseInt(process.env.PRESIGNED_URL_EXPIRES_IN || '5', 10)
     const expiresInSeconds = expireHours * 3600
     // Cache time is 2/3 of expire time, rounded to minute
@@ -237,7 +275,7 @@ export class S3StorageService implements S3Service {
     }
 
     if (download) {
-      options.contentDisposition = 'attachment'
+      options.contentDisposition = buildContentDisposition(filename)
     }
 
     const url = this.client.presign(key, options)
@@ -461,7 +499,13 @@ export class LocalStorageService implements S3Service {
     await fs.promises.copyFile(filePath, destPath)
   }
 
-  async presign(bucket: string, key: string, method: string, download?: boolean): Promise<string> {
+  async presign(
+    bucket: string,
+    key: string,
+    method: string,
+    download?: boolean,
+    filename?: string,
+  ): Promise<string> {
     if (method !== 'GET' && method !== 'PUT') {
       throw new Error(`Invalid method: ${method}`)
     }
@@ -471,6 +515,9 @@ export class LocalStorageService implements S3Service {
     let url = `${this.endpoint}/files/${bucket}/${key}`
     if (download) {
       url += '?download=1'
+      if (filename) {
+        url += `&filename=${encodeURIComponent(filename)}`
+      }
     }
     return url
   }


### PR DESCRIPTION
## Summary

Fixes the bug where downloading a file that was renamed in Shumai (e.g. `test.png` → `foo.png`) still saves to disk under the original upload name (`test.png`).

**Root cause**: Download URLs were generated with `Content-Disposition: attachment` but no filename. Since the HTML `download` attribute is ignored for cross-origin URLs (S3 presigned links), browsers fell back to extracting the name from the storage key path.

## Changes

- **`packages/core/src/s3/s3.ts`**: Added `buildContentDisposition()` helper producing a sanitized `attachment; filename="..."; filename*=UTF-8''...` header (RFC 5987 for non-ASCII names, CR/LF/quote stripped to prevent header injection). Threaded an optional `filename` through `S3Service.presign()`:
  - S3 backend: passed as `contentDisposition` → `response-content-disposition` query param on the presigned URL.
  - Local backend: appended as an encoded `?filename=` query param.
- **`packages/api/src/s3.ts`**: The local `/files` static handler now emits the full `Content-Disposition` (with filename) in `onFound` when `download=1`.
- **`packages/core/src/asset/asset.ts`**: `getDownloadLinks` and `getDownloadUrl` now pass the renamed asset name (from the DB) to `presign`, so the fix covers all download flows (file browser, viewers, breadcrumb, share/public) with no API contract or frontend changes.

## Verification

- `bun run lint` ✅
- `bun run format` ✅
- `bun run typecheck` ✅
- `bun run test` — 922 passed ✅
- `bun run test:e2e:app` — 30 passed ✅
- `bun run test:e2e:webui` — 9 passed ✅
- `bun run test:e2e:workflow` — 54 passed ✅
- Added unit tests: presign filename for both storage backends, local URL encoding, `buildContentDisposition` sanitization/RFC 5987, `getDownloadLinks`/`getDownloadUrl` passing the renamed name.

## Notes

Both storage backends are covered (S3 presigned URL param, local query param + handler header). The presign cache only applies to non-download GETs, so no caching impact.