### PR TITLE
fix(webui): batch download no longer flashes a tab per file

### DIFF
--- a/packages/webui/components/file-browser/use-file-actions.ts
+++ b/packages/webui/components/file-browser/use-file-actions.ts
@@ -303,13 +303,17 @@ export function useFileActions({
       for (let i = 0; i < files.length; i += batchSize) {
         const chunk = files.slice(i, i + batchSize)
         for (const file of chunk) {
-          const a = document.createElement('a')
-          a.href = file.url
-          a.download = file.name
-          a.target = '_blank'
-          document.body.appendChild(a)
-          a.click()
-          document.body.removeChild(a)
+          // Use a hidden iframe instead of an anchor with target="_blank".
+          // Download URLs respond with Content-Disposition: attachment, so the
+          // browser starts the download in the background: no flash of a tab
+          // that opens and auto-closes. A failed/expired link renders inside
+          // the hidden iframe instead of navigating the SPA tab away.
+          const iframe = document.createElement('iframe')
+          iframe.style.display = 'none'
+          iframe.src = file.url
+          document.body.appendChild(iframe)
+          // Remove the iframe once the download has had time to start.
+          window.setTimeout(() => iframe.remove(), 60_000)
         }
         if (i + batchSize < files.length) {
           await delay(600)


### PR DESCRIPTION
## Summary

Fixes the UX wart where batch-downloading N files in the file browser opened N tabs in Chrome that each auto-closed as soon as the download started.

**Root cause**: `startDownload()` created `<a target="_blank" download>` anchors. `target="_blank"` told Chrome to open a new tab per file; the server's `Content-Disposition: attachment` response immediately converted each tab into a download, closing it — hence the tab flash.

## Changes

- **`packages/webui/components/file-browser/use-file-actions.ts`**: `startDownload()` now triggers each download via a hidden iframe instead of an anchor:
  - Downloads start in the background — no tab is opened or closed.
  - A failed/expired link renders inside the hidden iframe instead of navigating the SPA tab away (the original reason `target="_blank"` was added).
  - Download filenames still come from the `Content-Disposition` header (see #286), so the iframe approach loses nothing.
  - Iframes are removed 60s after creation.

## Verification

- `bun run lint` ✅
- `bun run format` ✅
- `bun run typecheck` ✅
- `bun run test` — 931 passed ✅
- `bun run test:e2e:app` — 30 passed ✅
- `bun run test:e2e:webui` — 9 passed ✅
- `bun run test:e2e:workflow` — 54 passed ✅

## Notes

No e2e test added — small, UI-only change; behavior verified via existing e2e suites.