### PR TITLE
fix(webui): enable rename and delete actions in file detail top bar breadcrumb

### DIFF
--- a/packages/webui/components/breadcrumb-nav.tsx
+++ b/packages/webui/components/breadcrumb-nav.tsx
@@ -65,6 +65,8 @@ interface BreadcrumbNavProps {
   shareId?: string
   allowDownload?: boolean
   onFolderClick?: (folderId: string) => void
+  onRename?: () => void
+  onDelete?: () => void
   fileId?: string
   downloadInfo?: {
     originalKey?: string
@@ -103,6 +105,8 @@ export function BreadcrumbNav({
   onChatbotToggle,
   isPublic = false,
   onFolderClick,
+  onRename,
+  onDelete,
   fileId,
   shareId,
   allowDownload = true,
@@ -290,14 +294,15 @@ export function BreadcrumbNav({
                         {m.download()}
                       </DropdownMenuItem>
                     ))}
-                  {canEdit && (
-                    <DropdownMenuItem onClick={() => console.log('Rename')}>
-                      Rename
-                    </DropdownMenuItem>
+                  {canEdit && onRename && (
+                    <DropdownMenuItem onClick={onRename}>{m.rename()}</DropdownMenuItem>
                   )}
-                  {canEdit && (
-                    <DropdownMenuItem onClick={() => console.log('Delete')}>
-                      Delete
+                  {canEdit && onDelete && (
+                    <DropdownMenuItem
+                      onClick={onDelete}
+                      className="text-destructive focus:text-destructive"
+                    >
+                      {m.delete()}
                     </DropdownMenuItem>
                   )}
 

--- a/packages/webui/components/top-nav.tsx
+++ b/packages/webui/components/top-nav.tsx
@@ -27,6 +27,8 @@ export function TopNav() {
     shareId,
     allowDownload,
     onFolderClick,
+    onRename,
+    onDelete,
     compareMode,
     canCompareVersions,
     onCompareVersions,
@@ -118,6 +120,8 @@ export function TopNav() {
       downloadInfo={downloadInfo}
       versions={versions}
       onFolderClick={onFolderClick}
+      onRename={onRename}
+      onDelete={onDelete}
       compareMode={compareMode}
       canCompareVersions={canCompareVersions}
       onCompareVersions={onCompareVersions}

--- a/packages/webui/routes/projects/$projectId/files/$fileId.lazy.tsx
+++ b/packages/webui/routes/projects/$projectId/files/$fileId.lazy.tsx
@@ -18,6 +18,26 @@ import { useMutation } from '@tanstack/react-query'
 import { createLazyFileRoute } from '@tanstack/react-router'
 import { InferRequestType, InferResponseType } from 'hono/client'
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/ui/components/ui/alert-dialog'
+import { Button } from '@/ui/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/ui/components/ui/dialog'
+import { Input } from '@/ui/components/ui/input'
+import { toast } from 'sonner'
 import type { MediaController } from '@/ui/components/viewers/types'
 import type { AssetInfo, AssetInfoPaginatedList, CommentInfo } from '@shumai/dtos'
 import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query'
@@ -147,6 +167,82 @@ function FileViewPage() {
   const fileData = versionData || stackData
   const versionsDataList = versionAssetId ? versionsList : stackData?.versionStack?.versions
 
+  const parentFolderId = fileData?.ancestorFolders?.[0]?.id ?? projectInfo?.rootFolder ?? ''
+
+  const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false)
+  const [renameInput, setRenameInput] = useState('')
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+
+  const $renameFile = client.api.files[':fileId'].$put
+  const { mutate: renameFile, isPending: isRenaming } = useMutation<
+    InferResponseType<typeof $renameFile, 200>,
+    Error,
+    InferRequestType<typeof $renameFile>
+  >({
+    mutationFn: async (request) => {
+      const res = await $renameFile(request)
+      if (!res.ok) throw new Error('Failed to rename file')
+      return (await res.json()) as unknown as InferResponseType<typeof $renameFile, 200>
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['files'] })
+      queryClient.invalidateQueries({ queryKey: ['version_stacks'] })
+      toast.success(m.renamed_successfully?.() || 'Renamed successfully')
+      setIsRenameDialogOpen(false)
+    },
+    onError: () => {
+      toast.error(m.failed_to_rename?.() || 'Failed to rename')
+    },
+  })
+
+  const $deleteFiles = client.api.files.$delete
+  const { mutate: deleteFiles, isPending: isDeleting } = useMutation<
+    void,
+    Error,
+    InferRequestType<typeof $deleteFiles>
+  >({
+    mutationFn: async (request) => {
+      const res = await $deleteFiles(request)
+      if (!res.ok) throw new Error('Failed to delete file')
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['files'] })
+      queryClient.invalidateQueries({ queryKey: ['version_stacks'] })
+      toast.success(m.deleted?.() || 'Deleted')
+      setIsDeleteDialogOpen(false)
+      if (parentFolderId && parentFolderId !== projectInfo?.rootFolder) {
+        navigate({
+          to: '/projects/$projectId/folders/$folderId',
+          params: { projectId, folderId: parentFolderId },
+        })
+      } else {
+        navigate({
+          to: '/projects/$projectId',
+          params: { projectId },
+        })
+      }
+    },
+    onError: () => {
+      toast.error(m.failed_to_delete?.() || 'Failed to delete')
+    },
+  })
+
+  const handleRenameSubmit = (e?: React.FormEvent) => {
+    e?.preventDefault()
+    if (!renameInput.trim() || !activeFileId) return
+    renameFile({
+      param: { fileId: activeFileId },
+      json: { name: renameInput.trim() },
+    })
+  }
+
+  const handleDeleteSubmit = () => {
+    if (!activeFileId) return
+    deleteFiles({
+      json: { ids: [activeFileId] },
+    })
+  }
+
   useEffect(() => {
     if (fileData && projectInfo && teamId) {
       setProjectState({
@@ -198,6 +294,13 @@ function FileViewPage() {
             params: { projectId, folderId: id },
           })
         },
+        onRename: () => {
+          setRenameInput(fileData?.name ?? '')
+          setIsRenameDialogOpen(true)
+        },
+        onDelete: () => {
+          setIsDeleteDialogOpen(true)
+        },
       })
     }
 
@@ -215,8 +318,6 @@ function FileViewPage() {
     clearProjectState,
     navigate,
   ])
-
-  const parentFolderId = fileData?.ancestorFolders?.[0]?.id ?? projectInfo?.rootFolder ?? ''
 
   useEffect(() => {
     if (!parentFolderId || !activeFileId) return
@@ -470,6 +571,56 @@ function FileViewPage() {
           </>
         )}
       </div>
+
+      <Dialog open={isRenameDialogOpen} onOpenChange={setIsRenameDialogOpen}>
+        <DialogContent>
+          <form onSubmit={handleRenameSubmit}>
+            <DialogHeader>
+              <DialogTitle>{m.rename()}</DialogTitle>
+            </DialogHeader>
+            <div className="py-4">
+              <Input
+                value={renameInput}
+                onChange={(e) => setRenameInput(e.target.value)}
+                placeholder={m.enter_new_name?.() || 'Enter new name'}
+                autoFocus
+              />
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setIsRenameDialogOpen(false)}>
+                {m.cancel()}
+              </Button>
+              <Button type="submit" disabled={isRenaming || !renameInput.trim()}>
+                {isRenaming && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {m.save()}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{m.delete_asset_title?.() || 'Delete Asset?'}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {m.delete_asset_description?.() ||
+                'Deleted items can be recovered for 30 days before being permanently deleted.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{m.cancel()}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteSubmit}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isDeleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {m.delete()}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/packages/webui/routes/projects/$projectId/files/$fileId.lazy.tsx
+++ b/packages/webui/routes/projects/$projectId/files/$fileId.lazy.tsx
@@ -37,6 +37,7 @@ import {
   DialogTitle,
 } from '@/ui/components/ui/dialog'
 import { Input } from '@/ui/components/ui/input'
+import { selectFileNameWithoutExtension } from '@/ui/lib/rename-utils'
 import { toast } from 'sonner'
 import type { MediaController } from '@/ui/components/viewers/types'
 import type { AssetInfo, AssetInfoPaginatedList, CommentInfo } from '@shumai/dtos'
@@ -171,6 +172,8 @@ function FileViewPage() {
 
   const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false)
   const [renameInput, setRenameInput] = useState('')
+  const renameInputRef = useRef<HTMLInputElement>(null)
+  const renameSettledRef = useRef(false)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
 
   const $renameFile = client.api.files[':fileId'].$put
@@ -295,6 +298,7 @@ function FileViewPage() {
           })
         },
         onRename: () => {
+          renameSettledRef.current = false
           setRenameInput(fileData?.name ?? '')
           setIsRenameDialogOpen(true)
         },
@@ -318,6 +322,30 @@ function FileViewPage() {
     clearProjectState,
     navigate,
   ])
+
+  useEffect(() => {
+    if (!isRenameDialogOpen) return
+    // Stop correcting the selection shortly after the dialog opens so user
+    // edits are not disturbed. The dropdown's focus restoration settles well
+    // within this window.
+    const timeoutId = setTimeout(() => {
+      renameSettledRef.current = true
+    }, 1000)
+    return () => clearTimeout(timeoutId)
+  }, [isRenameDialogOpen])
+
+  const handleRenameInputFocus = () => {
+    if (renameSettledRef.current) return
+    // The dialog focus scope calls select() synchronously right after the
+    // focus event, and the breadcrumb dropdown restores focus ~150ms later
+    // (after its exit animation), re-triggering the trap's select-all. Defer
+    // the base-name selection so it runs after those select-all calls.
+    setTimeout(() => {
+      if (renameInputRef.current) {
+        selectFileNameWithoutExtension(renameInputRef.current)
+      }
+    }, 0)
+  }
 
   useEffect(() => {
     if (!parentFolderId || !activeFileId) return
@@ -580,9 +608,11 @@ function FileViewPage() {
             </DialogHeader>
             <div className="py-4">
               <Input
+                ref={renameInputRef}
                 value={renameInput}
                 onChange={(e) => setRenameInput(e.target.value)}
                 placeholder={m.enter_new_name?.() || 'Enter new name'}
+                onFocus={handleRenameInputFocus}
                 autoFocus
               />
             </div>

--- a/packages/webui/stores/top-nav.ts
+++ b/packages/webui/stores/top-nav.ts
@@ -34,6 +34,8 @@ export interface TopNavProjectState {
   /** When false, the public share hides download affordances. Defaults to true. */
   allowDownload?: boolean
   onFolderClick?: (folderId: string) => void
+  onRename?: () => void
+  onDelete?: () => void
   isRightSidebarCollapsed?: boolean
   onRightSidebarToggle?: () => void
   // Compare Versions


### PR DESCRIPTION
## Summary

Fixes a bug where clicking the **Rename** or **Delete** options in the top bar breadcrumb dropdown menu on the file detail page executed dummy `console.log` statements without performing any action or opening dialogs.

## Changes

- **Store**: Added optional `onRename` and `onDelete` callback definitions to `TopNavProjectState` in `packages/webui/stores/top-nav.ts`.
- **TopNav & BreadcrumbNav**: Updated `top-nav.tsx` and `breadcrumb-nav.tsx` to accept and wire up `onRename` and `onDelete` props, and replaced hardcoded text with i18n messages (`m.rename()` and `m.delete()`).
- **File Detail Route**: Added `Dialog` (for Rename) and `AlertDialog` (for Delete) in `packages/webui/routes/projects/$projectId/files/$fileId.lazy.tsx` using Hono RPC client API calls, query invalidations, toast feedback, and post-delete navigation.

## Verification

Ran all mandatory workspace quality and test suites simultaneously:
- `bun run lint` (passed cleanly with 0 warnings)
- `bun run format` (passed cleanly)
- `bun run typecheck` (passed cleanly)
- `bun run test` (105 test files, 931 tests passed)
- `bun run test:e2e:app` (30 tests passed)
- `bun run test:e2e:webui` (9 tests passed)
- `bun run test:e2e:workflow` (13 files, 54 tests passed)

## Notes

None.