### PR TITLE
feat(mcp): add in-flight request tracking and idle connection cleanup

### DIFF
--- a/packages/core/src/mcp/mcp-server-manager.ts
+++ b/packages/core/src/mcp/mcp-server-manager.ts
@@ -321,9 +321,9 @@ export class McpServerManager {
     if (!connection || connection.status !== 'connected') {
       throw new Error(`Server is not connected`)
     }
+    this.incrementInFlight(serverId)
     try {
       this.touch(serverId)
-      connection.inFlight++
       const result = await connection.client.callTool(
         { name: toolName, arguments: args },
         this.buildRequestOptions(connection.definition),
@@ -334,9 +334,43 @@ export class McpServerManager {
         isError: result.isError,
       }
     } finally {
-      connection.inFlight--
+      this.decrementInFlight(serverId)
       this.touch(serverId)
     }
+  }
+
+  incrementInFlight(serverId: string): void {
+    const connection = this.connections.get(serverId)
+    if (connection) {
+      connection.inFlight = (connection.inFlight ?? 0) + 1
+    }
+  }
+
+  decrementInFlight(serverId: string): void {
+    const connection = this.connections.get(serverId)
+    if (connection && connection.inFlight > 0) {
+      connection.inFlight--
+    }
+  }
+
+  isIdle(serverId: string, timeoutMs: number): boolean {
+    const connection = this.connections.get(serverId)
+    if (!connection || connection.status !== 'connected') return false
+    if (connection.inFlight > 0) return false
+    return Date.now() - connection.lastUsedAt > timeoutMs
+  }
+
+  async closeIdleConnections(defaultTimeoutMs = 10 * 60 * 1000): Promise<string[]> {
+    const closedIds: string[] = []
+    for (const [serverId, connection] of this.connections) {
+      if (connection.definition.config?.keepAlive) continue
+      const timeoutMs = connection.definition.config?.idleTimeoutMs ?? defaultTimeoutMs
+      if (this.isIdle(serverId, timeoutMs)) {
+        await this.close(serverId)
+        closedIds.push(serverId)
+      }
+    }
+    return closedIds
   }
 
   touch(serverId: string): void {

--- a/packages/core/src/mcp/mcp-service.test.ts
+++ b/packages/core/src/mcp/mcp-service.test.ts
@@ -749,5 +749,31 @@ describe('McpService', () => {
         await keepAliveServer.stop()
       }
     })
+
+    it('can run periodic idle cleanup background timer', async () => {
+      const timerServer = await startTestMcpServer({
+        tools: standardTestTools(),
+        serverInfo: { name: 'timer-mcp' },
+      })
+
+      try {
+        const serverRecord = await service.createServer(teamId, {
+          url: timerServer.url,
+        })
+        await service.discoverTools(serverRecord.id)
+        expect(service.getConnectionCount(serverRecord.id)).toBe(1)
+
+        // Start timer with very short interval (20ms) and 0ms idle timeout
+        service.startIdleCleanupTimer(20, 0)
+
+        // Wait for timer tick
+        await new Promise((r) => setTimeout(r, 60))
+
+        expect(service.getConnectionCount(serverRecord.id)).toBe(0)
+      } finally {
+        service.stopIdleCleanupTimer()
+        await timerServer.stop()
+      }
+    })
   })
 })

--- a/packages/core/src/mcp/mcp-service.test.ts
+++ b/packages/core/src/mcp/mcp-service.test.ts
@@ -665,4 +665,89 @@ describe('McpService', () => {
       await srvB.stop()
     }
   })
+
+  describe('Idle connection and in-flight tracking', () => {
+    it('tracks in-flight requests and safely prunes idle connections', async () => {
+      let resolveSlowTool: () => void = () => {}
+      const slowServer = await startTestMcpServer({
+        tools: [
+          {
+            name: 'slow_tool',
+            description: 'Slow tool',
+            handler: async () => {
+              await new Promise<void>((resolve) => {
+                resolveSlowTool = resolve
+              })
+              return 'slow-done'
+            },
+          },
+        ],
+        serverInfo: { name: 'slow-mcp' },
+      })
+
+      try {
+        const serverRecord = await service.createServer(teamId, {
+          url: slowServer.url,
+          config: { idleTimeoutMs: 50 },
+        })
+
+        // Connect to the server
+        await service.discoverTools(serverRecord.id)
+        expect(service.getConnectionCount(serverRecord.id)).toBe(1)
+
+        // Start callTool in background
+        const callPromise = service.callMcpTool(serverRecord.id, 'slow_tool', {})
+
+        // Give tool execution a tick to start
+        await new Promise((r) => setTimeout(r, 10))
+
+        // Connection should NOT be idle while tool is in-flight
+        const closedDuringCall = await service.closeIdleConnections(0)
+        expect(closedDuringCall).not.toContain(serverRecord.id)
+        expect(service.getConnectionCount(serverRecord.id)).toBe(1)
+
+        // Complete tool execution
+        resolveSlowTool()
+        const toolResult = await callPromise
+        expect(toolResult.ok).toBe(true)
+
+        // Wait past idle timeout threshold
+        await new Promise((r) => setTimeout(r, 60))
+
+        // Now idle connection should be closed
+        const closedAfterIdle = await service.closeIdleConnections(50)
+        expect(closedAfterIdle).toContain(serverRecord.id)
+        expect(service.getConnectionCount(serverRecord.id)).toBe(0)
+      } finally {
+        await slowServer.stop()
+      }
+    })
+
+    it('respects keepAlive setting when closing idle connections', async () => {
+      const keepAliveServer = await startTestMcpServer({
+        tools: standardTestTools(),
+        serverInfo: { name: 'keep-alive-mcp' },
+      })
+
+      try {
+        const serverRecord = await service.createServer(teamId, {
+          url: keepAliveServer.url,
+          config: { keepAlive: true },
+        })
+
+        await service.discoverTools(serverRecord.id)
+        expect(service.getConnectionCount(serverRecord.id)).toBe(1)
+
+        // Wait a bit
+        await new Promise((r) => setTimeout(r, 20))
+
+        // Should not close server marked with keepAlive even with 0 timeout
+        const closed = await service.closeIdleConnections(0)
+        expect(closed).not.toContain(serverRecord.id)
+        expect(service.getConnectionCount(serverRecord.id)).toBe(1)
+      } finally {
+        await keepAliveServer.stop()
+      }
+    })
+  })
 })

--- a/packages/core/src/mcp/mcp-service.ts
+++ b/packages/core/src/mcp/mcp-service.ts
@@ -863,8 +863,8 @@ export class McpService {
 
   private idleCleanupInterval?: ReturnType<typeof setInterval>
 
-  /** Start a periodic background timer to prune idle connections. */
-  startIdleCleanupTimer(intervalMs = 5 * 60 * 1000, defaultTimeoutMs?: number): void {
+  /** Start a periodic background timer to prune idle connections. Default check interval is 30 seconds. */
+  startIdleCleanupTimer(intervalMs = 30 * 1000, defaultTimeoutMs?: number): void {
     if (this.idleCleanupInterval) return
     this.idleCleanupInterval = setInterval(() => {
       this.closeIdleConnections(defaultTimeoutMs).catch((error) => {

--- a/packages/core/src/mcp/mcp-service.ts
+++ b/packages/core/src/mcp/mcp-service.ts
@@ -861,8 +861,30 @@ export class McpService {
     return formatToolName(serverName, toolName)
   }
 
+  private idleCleanupInterval?: ReturnType<typeof setInterval>
+
+  /** Start a periodic background timer to prune idle connections. */
+  startIdleCleanupTimer(intervalMs = 5 * 60 * 1000, defaultTimeoutMs?: number): void {
+    if (this.idleCleanupInterval) return
+    this.idleCleanupInterval = setInterval(() => {
+      this.closeIdleConnections(defaultTimeoutMs).catch((error) => {
+        logger.debug({ error }, 'Failed to close idle connections in background timer')
+      })
+    }, intervalMs)
+    this.idleCleanupInterval.unref?.()
+  }
+
+  /** Stop the background idle cleanup timer. */
+  stopIdleCleanupTimer(): void {
+    if (this.idleCleanupInterval) {
+      clearInterval(this.idleCleanupInterval)
+      this.idleCleanupInterval = undefined
+    }
+  }
+
   /** Close all in-process MCP connections (used by tests/shutdown). */
   async closeAllConnections(): Promise<void> {
+    this.stopIdleCleanupTimer()
     await this.manager.closeAll()
   }
 

--- a/packages/core/src/mcp/mcp-service.ts
+++ b/packages/core/src/mcp/mcp-service.ts
@@ -866,6 +866,11 @@ export class McpService {
     await this.manager.closeAll()
   }
 
+  /** Close idle connections across all active server connections. */
+  async closeIdleConnections(defaultTimeoutMs?: number): Promise<string[]> {
+    return this.manager.closeIdleConnections(defaultTimeoutMs)
+  }
+
   /** Number of live in-process connections (used by tests). */
   getConnectionCount(serverId: string): number {
     return this.manager.getConnection(serverId) ? 1 : 0

--- a/packages/db/src/prisma-json-types.ts
+++ b/packages/db/src/prisma-json-types.ts
@@ -385,6 +385,8 @@ declare global {
     export interface McpServerConfig {
       excludeTools?: string[]
       requestTimeoutMs?: number
+      idleTimeoutMs?: number
+      keepAlive?: boolean
       protocolVersion?: 'legacy' | 'auto' | '2026-07-28'
       directTools?: boolean
     }

--- a/packages/dtos/src/mcp.ts
+++ b/packages/dtos/src/mcp.ts
@@ -33,6 +33,8 @@ export type McpServerAuthConfig = z.infer<typeof mcpServerAuthConfigSchema>
 export const mcpServerConfigSchema = z.object({
   excludeTools: z.array(z.string()).optional(),
   requestTimeoutMs: z.number().int().positive().optional(),
+  idleTimeoutMs: z.number().int().positive().optional(),
+  keepAlive: z.boolean().optional(),
   protocolVersion: z.enum(['legacy', 'auto', '2026-07-28']).optional(),
   directTools: z.boolean().optional(),
 })


### PR DESCRIPTION
## Summary

Implemented in-flight request tracking and idle connection pruning for MCP servers, following `pi-mcp-adapter`'s connection lifecycle model.

## Changes

- **DTO & Prisma JSON**: Added optional `idleTimeoutMs` and `keepAlive` fields to `mcpServerConfigSchema` and `PrismaJson.McpServerConfig`.
- **McpServerManager**: Added `incrementInFlight()`, `decrementInFlight()`, `isIdle()`, and `closeIdleConnections()`.
- **McpService**: Added `closeIdleConnections()`, `startIdleCleanupTimer()`, and `stopIdleCleanupTimer()` with a 30-second default background interval.
- **Tests**: Added unit test coverage for in-flight protection during slow tool calls, `keepAlive` overrides, and background timer connection pruning.

## Verification

- `bun run lint` passed.
- `bun run format` passed.
- `bun run typecheck` passed.
- `bun run test packages/core/src/mcp/mcp-service.test.ts` (28/28 tests passed).

## Notes

Target branch is `feat/mcp-support`.