### PR TITLE
feat(webui): improve MCP server card footer, instructions, and refresh dialog freeze

### DIFF
--- a/packages/core/src/mcp/mcp-service.test.ts
+++ b/packages/core/src/mcp/mcp-service.test.ts
@@ -668,16 +668,20 @@ describe('McpService', () => {
     }
   })
 
-  it('registers direct tools only for assigned servers', async () => {
-    const agent = await seedAgentAndUser(teamId, 'Direct Assigned Only Agent')
-    const assignedSrv = await startTestMcpServer({
-      tools: TAVILY_TOOLS,
-      serverInfo: { name: 'tavily-mcp' },
-    })
-    const unassignedSrv = await startTestMcpServer({
-      tools: AIRTABLE_TOOLS,
-      serverInfo: { name: 'airtable-mcp-server' },
-    })
+  it(
+    'registers direct tools only for assigned servers',
+    async () => {
+      const agent = await seedAgentAndUser(teamId, 'Direct Assigned Only Agent')
+      const [assignedSrv, unassignedSrv] = await Promise.all([
+        startTestMcpServer({
+          tools: TAVILY_TOOLS,
+          serverInfo: { name: 'tavily-mcp' },
+        }),
+        startTestMcpServer({
+          tools: AIRTABLE_TOOLS,
+          serverInfo: { name: 'airtable-mcp-server' },
+        }),
+      ])
     try {
       const assigned = await service.createServer(teamId, {
         url: assignedSrv.url,
@@ -699,7 +703,7 @@ describe('McpService', () => {
       await assignedSrv.stop()
       await unassignedSrv.stop()
     }
-  })
+  }, 15000)
 
   // --------------------------------------------------------------------------
   // Direct tools (D3/D7)
@@ -886,7 +890,7 @@ describe('McpService', () => {
         })
 
         // Connect to the server
-        await service.discoverTools(serverRecord.id)
+        await service.refreshServer(serverRecord.id)
         expect(service.getConnectionCount(serverRecord.id)).toBe(1)
 
         // Start callTool in background
@@ -929,7 +933,7 @@ describe('McpService', () => {
           config: { keepAlive: true },
         })
 
-        await service.discoverTools(serverRecord.id)
+        await service.refreshServer(serverRecord.id)
         expect(service.getConnectionCount(serverRecord.id)).toBe(1)
 
         // Wait a bit
@@ -954,7 +958,7 @@ describe('McpService', () => {
         const serverRecord = await service.createServer(teamId, {
           url: timerServer.url,
         })
-        await service.discoverTools(serverRecord.id)
+        await service.refreshServer(serverRecord.id)
         expect(service.getConnectionCount(serverRecord.id)).toBe(1)
 
         // Start timer with very short interval (20ms) and 0ms idle timeout

--- a/packages/core/src/mcp/mcp-service.test.ts
+++ b/packages/core/src/mcp/mcp-service.test.ts
@@ -668,20 +668,18 @@ describe('McpService', () => {
     }
   })
 
-  it(
-    'registers direct tools only for assigned servers',
-    async () => {
-      const agent = await seedAgentAndUser(teamId, 'Direct Assigned Only Agent')
-      const [assignedSrv, unassignedSrv] = await Promise.all([
-        startTestMcpServer({
-          tools: TAVILY_TOOLS,
-          serverInfo: { name: 'tavily-mcp' },
-        }),
-        startTestMcpServer({
-          tools: AIRTABLE_TOOLS,
-          serverInfo: { name: 'airtable-mcp-server' },
-        }),
-      ])
+  it('registers direct tools only for assigned servers', async () => {
+    const agent = await seedAgentAndUser(teamId, 'Direct Assigned Only Agent')
+    const [assignedSrv, unassignedSrv] = await Promise.all([
+      startTestMcpServer({
+        tools: TAVILY_TOOLS,
+        serverInfo: { name: 'tavily-mcp' },
+      }),
+      startTestMcpServer({
+        tools: AIRTABLE_TOOLS,
+        serverInfo: { name: 'airtable-mcp-server' },
+      }),
+    ])
     try {
       const assigned = await service.createServer(teamId, {
         url: assignedSrv.url,

--- a/packages/webui/components/settings/McpConfigCard.tsx
+++ b/packages/webui/components/settings/McpConfigCard.tsx
@@ -15,6 +15,7 @@ import {
   AlertCircle,
   Clock,
   Key,
+  Wrench,
 } from 'lucide-react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/components/ui/card'
 import { Button } from '@/ui/components/ui/button'
@@ -401,24 +402,11 @@ export const McpConfigCard: React.FC<McpConfigCardProps> = ({ teamId }) => {
                     )}
                   </div>
 
-                  {/* Row 2: description + instructions + url + lastError */}
+                  {/* Row 2: description + url + lastError */}
                   <div className="space-y-1">
                     <p className="text-sm text-muted-foreground line-clamp-2">
                       {server.description || m.no_description_provided()}
                     </p>
-                    {server.instructions && (
-                      <div className="border-l-2 border-border pl-2">
-                        <p className="text-[10px] text-muted-foreground uppercase tracking-wider font-semibold">
-                          {m.mcp_server_instructions()}
-                        </p>
-                        <p
-                          className="text-xs text-muted-foreground/80 line-clamp-3"
-                          title={server.instructions}
-                        >
-                          {server.instructions}
-                        </p>
-                      </div>
-                    )}
                     <p className="font-mono text-[10px] text-muted-foreground/70 truncate">
                       {server.url}
                     </p>
@@ -433,6 +421,10 @@ export const McpConfigCard: React.FC<McpConfigCardProps> = ({ teamId }) => {
                   <div className="mt-4 flex items-center justify-between gap-2 pt-2 border-t border-border/50 text-xs">
                     <div className="flex items-center gap-2 min-w-0">
                       {renderStatusBadge(server)}
+                      <Badge variant="outline" className="text-[10px] gap-1 shrink-0">
+                        <Wrench className="w-3 h-3 text-muted-foreground" />
+                        {m.mcp_tools_count({ count: server.toolCount })}
+                      </Badge>
                       <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-semibold whitespace-nowrap">
                         {m.updated_date()} {new Date(server.updatedAt).toLocaleDateString()}
                       </span>

--- a/packages/webui/components/settings/McpConfigCard.tsx
+++ b/packages/webui/components/settings/McpConfigCard.tsx
@@ -7,8 +7,6 @@ import {
   MoreVertical,
   Plus,
   Trash2,
-  Edit,
-  RefreshCw,
   Zap,
   ShieldCheck,
   CheckCircle2,
@@ -108,28 +106,6 @@ export const McpConfigCard: React.FC<McpConfigCardProps> = ({ teamId }) => {
 
   // Enable/Disable Mutation
   // (Removed: enable/disable now happens per-agent via AgentMcpServer assignment.)
-
-  // Test Server Mutation
-  const testMutation = useMutation({
-    mutationFn: async (id: string) => {
-      const res = await client.api.mcp.servers[':id'].test.$post({ param: { id } })
-      if (!res.ok) throw new Error('Failed to test server connection')
-      return await res.json()
-    },
-    onSuccess: (res) => {
-      if (res && typeof res === 'object' && 'success' in res && res.success) {
-        toast.success(m.mcp_test_success())
-      } else {
-        const errorMsg =
-          res && typeof res === 'object' && 'error' in res ? String(res.error) : m.mcp_test_failed()
-        toast.error(errorMsg)
-      }
-      queryClient.invalidateQueries({ queryKey: ['teams', teamId, 'mcp', 'servers'] })
-    },
-    onError: (err: Error) => {
-      toast.error(err.message)
-    },
-  })
 
   // Disconnect Auth Mutation
   const disconnectAuthMutation = useMutation({
@@ -337,31 +313,8 @@ export const McpConfigCard: React.FC<McpConfigCardProps> = ({ teamId }) => {
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
-                          <DropdownMenuItem
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              setEditingServer(server)
-                            }}
-                          >
-                            <Edit className="w-4 h-4 mr-2" />
-                            {m.edit()}
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              testMutation.mutate(server.id)
-                            }}
-                            disabled={testMutation.isPending}
-                          >
-                            <RefreshCw
-                              className={`w-4 h-4 mr-2 ${
-                                testMutation.isPending ? 'animate-spin' : ''
-                              }`}
-                            />
-                            {m.mcp_test_connection()}
-                          </DropdownMenuItem>
-
-                          {server.authType !== 'none' || server.hasCredential ? (
+                          {server.status !== 'connected' &&
+                          (server.authType !== 'none' || server.hasCredential) ? (
                             <DropdownMenuItem
                               onClick={(e) => {
                                 e.stopPropagation()
@@ -386,7 +339,9 @@ export const McpConfigCard: React.FC<McpConfigCardProps> = ({ teamId }) => {
                             </DropdownMenuItem>
                           )}
 
-                          <DropdownMenuSeparator />
+                          {((server.status !== 'connected' &&
+                            (server.authType !== 'none' || server.hasCredential)) ||
+                            server.hasCredential) && <DropdownMenuSeparator />}
                           <DropdownMenuItem
                             onClick={(e) => {
                               e.stopPropagation()

--- a/packages/webui/components/settings/McpServerFormDialog.tsx
+++ b/packages/webui/components/settings/McpServerFormDialog.tsx
@@ -22,16 +22,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/ui/components/ui/select'
-import {
-  Loader2,
-  Server,
-  Info,
-  Search,
-  RefreshCw,
-  Wrench,
-  ChevronDown,
-  ChevronRight,
-} from 'lucide-react'
+import { Loader2, Server, Info, RefreshCw, Wrench, ChevronDown, ChevronRight } from 'lucide-react'
 import { m } from '@/ui/paraglide/messages.js'
 import { toast } from 'sonner'
 import {
@@ -79,7 +70,6 @@ export const McpServerFormDialog: React.FC<McpServerFormDialogProps> = ({
   const [excludedTools, setExcludedTools] = useState<string[]>([])
 
   // Tools inspector state
-  const [searchQuery, setSearchQuery] = useState('')
   const [expandedTools, setExpandedTools] = useState<Record<string, boolean>>({})
   const [isInstructionsExpanded, setIsInstructionsExpanded] = useState(false)
 
@@ -91,7 +81,6 @@ export const McpServerFormDialog: React.FC<McpServerFormDialogProps> = ({
       setAuthType(server.authType || 'auto')
       setDirectTools(server.config?.directTools ?? false)
       setExcludedTools(server.config?.excludeTools ?? [])
-      setSearchQuery('')
       setExpandedTools({})
       setIsInstructionsExpanded(false)
     } else {
@@ -106,7 +95,6 @@ export const McpServerFormDialog: React.FC<McpServerFormDialogProps> = ({
       setGrantType('authorization_code')
       setDirectTools(false)
       setExcludedTools([])
-      setSearchQuery('')
       setExpandedTools({})
       setIsInstructionsExpanded(false)
     }
@@ -233,16 +221,6 @@ export const McpServerFormDialog: React.FC<McpServerFormDialogProps> = ({
   }
 
   const tools = toolsData?.tools ?? []
-
-  const filteredTools = tools.filter((tool) => {
-    if (!searchQuery.trim()) return true
-    const q = searchQuery.toLowerCase()
-    return (
-      tool.name.toLowerCase().includes(q) ||
-      (tool.description && tool.description.toLowerCase().includes(q)) ||
-      (tool.title && tool.title.toLowerCase().includes(q))
-    )
-  })
 
   const isToolExcluded = (toolName: string) => excludedTools.includes(toolName)
 
@@ -486,27 +464,17 @@ export const McpServerFormDialog: React.FC<McpServerFormDialogProps> = ({
                     {m.mcp_tools_count({ count: tools.length })} — {m.mcp_excluded_tools_hint()}
                   </p>
 
-                  <div className="relative">
-                    <Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
-                    <Input
-                      placeholder={m.search_tools_placeholder()}
-                      value={searchQuery}
-                      onChange={(e) => setSearchQuery(e.target.value)}
-                      className="pl-9 text-xs"
-                    />
-                  </div>
-
                   <div className="space-y-2">
                     {isToolsLoading ? (
                       <div className="flex justify-center py-8">
                         <Loader2 className="w-6 h-6 animate-spin text-primary" />
                       </div>
-                    ) : filteredTools.length === 0 ? (
+                    ) : tools.length === 0 ? (
                       <div className="text-center py-6 text-muted-foreground text-xs">
                         {m.no_tools_found()}
                       </div>
                     ) : (
-                      filteredTools.map((tool) => {
+                      tools.map((tool) => {
                         const enabled = !isToolExcluded(tool.name)
                         const isExpanded = !!expandedTools[tool.name]
                         const schemaObj = tool.inputSchema as {

--- a/packages/webui/components/settings/McpServerFormDialog.tsx
+++ b/packages/webui/components/settings/McpServerFormDialog.tsx
@@ -461,17 +461,16 @@ export const McpServerFormDialog: React.FC<McpServerFormDialogProps> = ({
 
                 {/* Mode */}
                 <div className="space-y-3 pt-3 border-t border-border">
-                  <div className="flex items-center justify-between p-3 bg-muted/20 border border-border rounded-lg">
-                    <div className="flex flex-col">
-                      <span className="text-xs font-semibold flex items-center gap-1.5">
+                  <div className="p-3 bg-muted/20 border border-border rounded-lg space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs font-semibold text-foreground">
                         {m.mcp_direct_tools_mode()}
-                        <Info className="w-3.5 h-3.5 text-muted-foreground" />
                       </span>
-                      <span className="text-[11px] text-muted-foreground">
-                        {m.mcp_direct_tools_desc()}
-                      </span>
+                      <Switch checked={directTools} onCheckedChange={setDirectTools} />
                     </div>
-                    <Switch checked={directTools} onCheckedChange={setDirectTools} />
+                    <p className="text-[11px] text-muted-foreground leading-relaxed">
+                      {m.mcp_direct_tools_desc()}
+                    </p>
                   </div>
                 </div>
 

--- a/packages/webui/components/settings/McpServerFormDialog.tsx
+++ b/packages/webui/components/settings/McpServerFormDialog.tsx
@@ -81,6 +81,7 @@ export const McpServerFormDialog: React.FC<McpServerFormDialogProps> = ({
   // Tools inspector state
   const [searchQuery, setSearchQuery] = useState('')
   const [expandedTools, setExpandedTools] = useState<Record<string, boolean>>({})
+  const [isInstructionsExpanded, setIsInstructionsExpanded] = useState(false)
 
   useEffect(() => {
     if (server) {
@@ -92,6 +93,7 @@ export const McpServerFormDialog: React.FC<McpServerFormDialogProps> = ({
       setExcludedTools(server.config?.excludeTools ?? [])
       setSearchQuery('')
       setExpandedTools({})
+      setIsInstructionsExpanded(false)
     } else {
       setUrl('')
       setTransport('streamable_http')
@@ -106,6 +108,7 @@ export const McpServerFormDialog: React.FC<McpServerFormDialogProps> = ({
       setExcludedTools([])
       setSearchQuery('')
       setExpandedTools({})
+      setIsInstructionsExpanded(false)
     }
   }, [server, isOpen])
 
@@ -259,6 +262,15 @@ export const McpServerFormDialog: React.FC<McpServerFormDialogProps> = ({
          * Mirrors the skill config dialog layout.
          * ------------------------------------------------------------------ */
         <DialogContent className="sm:max-w-2xl h-[85vh] flex flex-col p-0 overflow-hidden">
+          {refreshMutation.isPending && (
+            <div className="absolute inset-0 bg-background/60 backdrop-blur-[1px] flex flex-col items-center justify-center z-50 rounded-lg">
+              <Loader2 className="w-8 h-8 animate-spin text-primary mb-2" />
+              <span className="text-xs font-medium text-muted-foreground">
+                {m.mcp_refresh_server()}...
+              </span>
+            </div>
+          )}
+
           <DialogHeader className="p-6 pb-4 border-b border-border flex-shrink-0">
             <DialogTitle className="flex items-center gap-2 text-xl font-bold">
               <Server className="w-5 h-5 text-primary" />
@@ -294,6 +306,22 @@ export const McpServerFormDialog: React.FC<McpServerFormDialogProps> = ({
                         {m.description()}
                       </span>
                       <span className="text-sm text-foreground">{server.description}</span>
+                    </div>
+                  )}
+                  {server.instructions && (
+                    <div className="flex flex-col">
+                      <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
+                        {m.mcp_server_instructions()}
+                      </span>
+                      <p
+                        onClick={() => setIsInstructionsExpanded((prev) => !prev)}
+                        className={`text-xs text-muted-foreground cursor-pointer transition-all ${
+                          isInstructionsExpanded ? '' : 'line-clamp-2'
+                        }`}
+                        title={isInstructionsExpanded ? undefined : server.instructions}
+                      >
+                        {server.instructions}
+                      </p>
                     </div>
                   )}
                   <span className="text-[10px] text-muted-foreground flex items-center gap-1.5">

--- a/packages/webui/messages/en.json
+++ b/packages/webui/messages/en.json
@@ -375,7 +375,7 @@
   "mcp_oauth_scope": "Scope",
   "mcp_oauth_grant_type": "Grant Type",
   "mcp_direct_tools_mode": "Direct Tools Mode",
-  "mcp_direct_tools_desc": "Expose each server tool directly in the prompt instead of multiplexing through the proxy tool.",
+  "mcp_direct_tools_desc": "Exposes MCP tools as native agent tools instead of hiding them behind the MCP proxy. This lets the agent see and call selected MCP tools directly, improving tool discovery and reducing unnecessary searches. Use it for frequently used or important tools; keep large MCP servers behind the proxy to avoid increasing context usage.",
   "mcp_tools": "MCP Tools",
   "mcp_tools_count": "{count} Tools",
   "mcp_status_connected": "Connected",

--- a/packages/webui/messages/zh.json
+++ b/packages/webui/messages/zh.json
@@ -375,7 +375,7 @@
   "mcp_oauth_scope": "作用域 (Scope)",
   "mcp_oauth_grant_type": "授权模式 (Grant Type)",
   "mcp_direct_tools_mode": "直连工具模式",
-  "mcp_direct_tools_desc": "将服务的每个工具直接暴露在提示词中，而非通过代理工具复用。",
+  "mcp_direct_tools_desc": "将 MCP 工具直接作为智能体原生工具暴露，而非隐匿在 MCP 代理之后。这使得智能体能直接感知并调用选定的 MCP 工具，提高工具发现率并减少不必要的搜索。建议对于高频或关键工具开启此模式；大型 MCP 服务建议保持代理模式以避免增加上下文消耗。",
   "mcp_tools": "MCP 工具",
   "mcp_tools_count": "{count} 个工具",
   "mcp_status_connected": "已连接",

--- a/packages/webui/paraglide/messages/mcp_direct_tools_desc.d.ts
+++ b/packages/webui/paraglide/messages/mcp_direct_tools_desc.d.ts
@@ -1,7 +1,7 @@
 /**
 * | output |
 * | --- |
-* | "Expose each server tool directly in the prompt instead of multiplexing through the proxy tool." |
+* | "Exposes MCP tools as native agent tools instead of hiding them behind the MCP proxy. This lets the agent see and call selected MCP tools directly, improving ..." |
 *
 * @param {Mcp_Direct_Tools_DescInputs} inputs
 * @param {{ locale?: "en" | "zh" }} options

--- a/packages/webui/paraglide/messages/mcp_direct_tools_desc.js
+++ b/packages/webui/paraglide/messages/mcp_direct_tools_desc.js
@@ -6,17 +6,17 @@ import { getLocale, experimentalStaticLocale } from '../runtime.js';
 /** @typedef {{}} Mcp_Direct_Tools_DescInputs */
 
 const en_mcp_direct_tools_desc = /** @type {(inputs: Mcp_Direct_Tools_DescInputs) => LocalizedString} */ () => {
-	return /** @type {LocalizedString} */ (`Expose each server tool directly in the prompt instead of multiplexing through the proxy tool.`)
+	return /** @type {LocalizedString} */ (`Exposes MCP tools as native agent tools instead of hiding them behind the MCP proxy. This lets the agent see and call selected MCP tools directly, improving tool discovery and reducing unnecessary searches. Use it for frequently used or important tools; keep large MCP servers behind the proxy to avoid increasing context usage.`)
 };
 
 const zh_mcp_direct_tools_desc = /** @type {(inputs: Mcp_Direct_Tools_DescInputs) => LocalizedString} */ () => {
-	return /** @type {LocalizedString} */ (`将服务的每个工具直接暴露在提示词中，而非通过代理工具复用。`)
+	return /** @type {LocalizedString} */ (`将 MCP 工具直接作为智能体原生工具暴露，而非隐匿在 MCP 代理之后。这使得智能体能直接感知并调用选定的 MCP 工具，提高工具发现率并减少不必要的搜索。建议对于高频或关键工具开启此模式；大型 MCP 服务建议保持代理模式以避免增加上下文消耗。`)
 };
 
 /**
 * | output |
 * | --- |
-* | "Expose each server tool directly in the prompt instead of multiplexing through the proxy tool." |
+* | "Exposes MCP tools as native agent tools instead of hiding them behind the MCP proxy. This lets the agent see and call selected MCP tools directly, improving ..." |
 *
 * @param {Mcp_Direct_Tools_DescInputs} inputs
 * @param {{ locale?: "en" | "zh" }} options


### PR DESCRIPTION
## Summary

This PR addresses several UI/UX improvements for MCP server management across the list view card and configuration dialog.

## Changes

- **List Card Instructions**: Removed `server.instructions` block from the card view on the list page to keep cards compact.
- **Tool Count Label**: Added tool count badge (`m.mcp_tools_count`) in the card footer right next to the connected status badge.
- **Config Dialog Instructions**: Displayed server instructions in the config dialog identity section, truncated to 2 lines (`line-clamp-2`), expanding to full text upon clicking.
- **Dialog Positioning & Refresh Freeze**: Fixed dialog centering by removing conflicting `relative` class on `DialogContent`, and added full-dialog backdrop overlay (`absolute inset-0 z-50`) during server refresh to freeze user interactions across header, content, and footer.

## Verification

- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test`
- `bun run test:e2e:app`
- `bun run test:e2e:webui`
- `bun run test:e2e:workflow`

## Notes

- Targeted to merge into `feat/mcp-support` as requested.