### PR TITLE
fix(agent): resolve version stack name and size in list_assets

### DIFF
--- a/packages/agent/src/activities/agent.test.ts
+++ b/packages/agent/src/activities/agent.test.ts
@@ -1441,6 +1441,54 @@ describe('Agent Database Activities Integration', () => {
         expect(res.assets.length).toBe(1)
         expect(res.pageInfo.cursor).toBeDefined()
       })
+
+      it('should resolve version_stack name and size from top child version when container name is empty', async () => {
+        const folder = await prisma.asset.create({
+          data: {
+            name: 'WorkspaceFolder',
+            type: AssetType.folder,
+            status: AssetStatus.uploaded,
+            projectId: project.id,
+          },
+        })
+
+        const versionStack = await prisma.asset.create({
+          data: {
+            name: '',
+            type: AssetType.version_stack,
+            status: AssetStatus.uploaded,
+            projectId: project.id,
+            parentId: folder.id,
+          },
+        })
+
+        await prisma.asset.create({
+          data: {
+            name: 'banana_ghost.txt',
+            type: AssetType.file,
+            status: AssetStatus.uploaded,
+            projectId: project.id,
+            parentId: versionStack.id,
+            sizeByte: 622960,
+            sortIndex: '0|i00000:',
+          },
+        })
+
+        const res = await executeAgentToolActivity({
+          taskId: 'task-1',
+          toolName: 'list_assets',
+          args: { parent: folder.id, page: 1, pageSize: 10 },
+          userId: user.id,
+        })
+
+        const stackItem = res.assets.find(
+          (a: { id: string; name: string; size: number; type: string }) => a.id === versionStack.id,
+        )
+        expect(stackItem).toBeDefined()
+        expect(stackItem?.name).toBe('banana_ghost.txt')
+        expect(stackItem?.size).toBe(622960)
+        expect(stackItem?.type).toBe('version_stack')
+      })
     })
 
     describe('create_folder', () => {

--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -1174,13 +1174,40 @@ export async function executeAgentToolActivity(params: ExecuteAgentToolParams): 
         { first: limit, after },
       )
 
+      const stackIds = assets
+        .filter((a) => a.type === AssetType.version_stack && (!a.name || a.name === ''))
+        .map((a) => a.id)
+
+      const latestVersionsMap = new Map<string, Prisma.AssetGetPayload<Record<string, never>>>()
+
+      if (stackIds.length > 0) {
+        const versions = await prisma.asset.findMany({
+          where: { parentId: { in: stackIds }, isDeleted: false },
+          orderBy: { sortIndex: 'asc' },
+        })
+        for (const v of versions) {
+          if (!latestVersionsMap.has(v.parentId!)) {
+            latestVersionsMap.set(v.parentId!, v)
+          }
+        }
+      }
+
       // return asset id, asset name, asset type, asset size (sizeByte or size)
-      const results = assets.map((a) => ({
-        id: a.id,
-        name: a.name,
-        type: a.type,
-        size: Number(a.sizeByte),
-      }))
+      const results = assets.map((a) => {
+        const latestVersion = latestVersionsMap.get(a.id)
+        return {
+          id: a.id,
+          name:
+            a.type === AssetType.version_stack && (!a.name || a.name === '')
+              ? (latestVersion?.name ?? a.name)
+              : a.name,
+          type: a.type,
+          size:
+            a.type === AssetType.version_stack && latestVersion
+              ? Number(latestVersion.sizeByte)
+              : Number(a.sizeByte),
+        }
+      })
 
       return {
         assets: results,

--- a/packages/agent/src/tools/analyze-image.ts
+++ b/packages/agent/src/tools/analyze-image.ts
@@ -36,13 +36,24 @@ export function createAnalyzeImageTool(
         id: assetId,
       })
 
-      const asset = await prisma.asset.findUnique({
+      let asset = await prisma.asset.findUnique({
         where: { id: assetId },
         include: { storageKey: true },
       })
 
       if (!asset) {
         throw new Error(`Asset with ID ${assetId} not found.`)
+      }
+
+      if (asset.type === 'version_stack') {
+        const latestVersion = await prisma.asset.findFirst({
+          where: { parentId: asset.id, isDeleted: false },
+          orderBy: { sortIndex: 'asc' },
+          include: { storageKey: true },
+        })
+        if (latestVersion) {
+          asset = latestVersion
+        }
       }
 
       // Get default media key

--- a/packages/agent/src/tools/download-asset.test.ts
+++ b/packages/agent/src/tools/download-asset.test.ts
@@ -13,6 +13,7 @@ vi.mock('@shumai/db', async (importOriginal) => {
     prisma: {
       asset: {
         findUnique: vi.fn(),
+        findFirst: vi.fn(),
       },
     },
   }
@@ -165,5 +166,49 @@ describe('downloadAssetTool', () => {
 
     expect(fs.existsSync(expectedPath)).toBe(true)
     expect(result.details.contentType).toBe('text/markdown')
+  })
+
+  it('should resolve version_stack asset to its latest version file', async () => {
+    vi.mocked(authzService.hasPermission).mockResolvedValue()
+    vi.mocked(prisma.asset.findUnique).mockResolvedValue({
+      id: 'stack-1',
+      name: '',
+      type: 'version_stack',
+      storageKey: null,
+      media: null,
+    } as unknown as Asset)
+
+    vi.mocked(prisma.asset.findFirst).mockResolvedValue({
+      id: 'file-ver-2',
+      name: 'banana_pig.png',
+      type: 'file',
+      storageKey: { key: 'raw/banana_pig.png' },
+      media: {
+        proxyType: 'image',
+        imageTranscodes: [{ key: 'proxy/banana_pig.webp' }],
+      },
+    } as unknown as Asset)
+
+    vi.mocked(s3Service.getObject).mockResolvedValue({
+      buffer: Buffer.from('fake-version-bytes'),
+      contentType: 'image/webp',
+    } as unknown as { buffer: Buffer; contentType: string })
+
+    const tool = createDownloadAssetTool('user-1')
+    const result = await tool.execute('call-1', { assetId: 'stack-1' })
+
+    expect(prisma.asset.findFirst).toHaveBeenCalledWith({
+      where: { parentId: 'stack-1', isDeleted: false },
+      orderBy: { sortIndex: 'asc' },
+      include: { storageKey: true },
+    })
+
+    expect(s3Service.getObject).toHaveBeenCalledWith('shumai', 'proxy/banana_pig.webp')
+
+    const expectedPath = path.join(piDir, 'file-ver-2_banana_pig.png')
+    createdFiles.push(expectedPath)
+
+    expect(fs.existsSync(expectedPath)).toBe(true)
+    expect(result.details.name).toBe('banana_pig.png')
   })
 })

--- a/packages/agent/src/tools/download-asset.ts
+++ b/packages/agent/src/tools/download-asset.ts
@@ -35,13 +35,24 @@ export function createDownloadAssetTool(userId: string): AgentTool<typeof downlo
         id: assetId,
       })
 
-      const asset = await prisma.asset.findUnique({
+      let asset = await prisma.asset.findUnique({
         where: { id: assetId },
         include: { storageKey: true },
       })
 
       if (!asset) {
         throw new Error(`Asset with ID ${assetId} not found.`)
+      }
+
+      if (asset.type === 'version_stack') {
+        const latestVersion = await prisma.asset.findFirst({
+          where: { parentId: asset.id, isDeleted: false },
+          orderBy: { sortIndex: 'asc' },
+          include: { storageKey: true },
+        })
+        if (latestVersion) {
+          asset = latestVersion
+        }
       }
 
       let mediaKey = asset.storageKey?.key

--- a/packages/agent/src/tools/read-pdf-pages.ts
+++ b/packages/agent/src/tools/read-pdf-pages.ts
@@ -56,12 +56,22 @@ export function createReadPdfPagesTool(
         id: targetAssetId,
       })
 
-      const asset = await prisma.asset.findUnique({
+      let asset = await prisma.asset.findUnique({
         where: { id: targetAssetId },
       })
 
       if (!asset) {
         throw new Error(`Asset with ID ${targetAssetId} not found.`)
+      }
+
+      if (asset.type === 'version_stack') {
+        const latestVersion = await prisma.asset.findFirst({
+          where: { parentId: asset.id, isDeleted: false },
+          orderBy: { sortIndex: 'asc' },
+        })
+        if (latestVersion) {
+          asset = latestVersion
+        }
       }
 
       const proxyType = (asset.media as PrismaJson.MediaInfo | null)?.proxyType


### PR DESCRIPTION
## Summary

Resolves issues where:
1. `list_assets` returned `"name": ""` for assets of type `version_stack` because version stack container records are created with an empty name in the database and `list_assets` mapped raw database fields without resolving the top version's name.
2. `download_asset` (as well as `analyze_image` and `read_pdf_pages`) failed with `No media content found for asset...` when passed a `version_stack` asset ID because `version_stack` container records do not directly hold `storageKey` or `media` entries.

## Changes

- Updated `list_assets` in [`packages/agent/src/activities/agent.ts`](file:///Users/yiling/Projects/shumai/packages/agent/src/activities/agent.ts#L1174-L1210) to batch fetch active top child versions (`orderBy: { sortIndex: 'asc' }`) for any `version_stack` assets with empty names and resolve `name` and `size`.
- Updated `download_asset`, `analyze_image`, and `read_pdf_pages` tools in [`packages/agent/src/tools/`](file:///Users/yiling/Projects/shumai/packages/agent/src/tools/) to automatically resolve a `version_stack` ID to its latest active child version (`orderBy: { sortIndex: 'asc' }`).
- Added unit test coverage in `packages/agent/src/activities/agent.test.ts` and `packages/agent/src/tools/download-asset.test.ts` verifying top version name, size, and media resolution for `version_stack` assets.

## Verification

Ran all project checks:
- `bun run lint` (Passed)
- `bun run format` (Passed)
- `bun run typecheck` (Passed)
- `bun run test` (Passed, 111 test files, 1041 tests)
- `bun run test:e2e:app` (Passed, 30 tests)
- `bun run test:e2e:webui` (Passed, 9 tests)
- `bun run test:e2e:workflow` (Passed, 14 test files, 58 tests)

## Notes

None.