### PR TITLE
fix(webui): content-only pinch-zoom and two-finger pan in media viewers

### DIFF
--- a/packages/webui/components/drawing-canvas.tsx
+++ b/packages/webui/components/drawing-canvas.tsx
@@ -225,6 +225,15 @@ const DrawingCanvas = ({
         y: clientY - rect.top,
       }
 
+      // Multi-touch gestures (pinch / two-finger pan) are handled by the
+      // viewer's gesture layer. Don't apply single-pointer pan/draw while they
+      // are active, but keep lastPos in sync so a resumed single-finger pan
+      // doesn't jump.
+      if ('touches' in e && e.touches.length > 1) {
+        lastPos.current = stagePos
+        return
+      }
+
       const {
         isDrawing: activeDrawing,
         currentTool: tool,
@@ -269,7 +278,10 @@ const DrawingCanvas = ({
       }
     }
 
-    const handleGlobalUp = () => {
+    const handleGlobalUp = (e: MouseEvent | TouchEvent) => {
+      // Keep dragging while fingers remain down (e.g. a pinch releasing one
+      // finger); only finalize once every pointer is up.
+      if ('touches' in e && e.touches.length > 0) return
       finalizeDrawing()
     }
 

--- a/packages/webui/components/viewers/image/image-viewer.tsx
+++ b/packages/webui/components/viewers/image/image-viewer.tsx
@@ -1,11 +1,13 @@
 import { useScreenSize } from '@/ui/hooks/useScreenSize'
 import { client } from '@/ui/api/client'
 import { getBestTranscode } from '@/ui/lib/media'
-import React, { useCallback, useEffect, useRef, useState, useImperativeHandle } from 'react'
+import React, { useEffect, useRef, useState, useImperativeHandle } from 'react'
 import DrawingCanvas from '@/ui/components/drawing-canvas'
 import { ImageControlBar } from './image-control-bar'
 import { useAnnotationStore } from '@/ui/stores/annotation-store'
 import { FileViewerProps, MediaController } from '../types'
+import { centeredPan, fitScale, isZoomed, zoomAtPoint } from '../pan-zoom'
+import { usePanZoomGestures } from '../use-pan-zoom'
 
 export const ImageViewer = React.forwardRef<MediaController, FileViewerProps>(
   ({ file, annotations, shareId, children, allowDownload }, ref) => {
@@ -28,29 +30,25 @@ export const ImageViewer = React.forwardRef<MediaController, FileViewerProps>(
     const [containerSize, setContainerSize] = useState({ width: 0, height: 0 })
     const [zoom, setZoom] = useState(1)
     const [pan, setPan] = useState({ x: 0, y: 0 })
+    const [hasManuallyZoomed, setHasManuallyZoomed] = useState(false)
     const [copied, setCopied] = useState(false)
 
-    const observerRef = useRef<ResizeObserver | null>(null)
+    const containerRef = useRef<HTMLDivElement | null>(null)
 
-    const containerRef = useCallback((node: HTMLDivElement | null) => {
-      if (observerRef.current) {
-        observerRef.current.disconnect()
-        observerRef.current = null
-      }
-
-      if (node !== null) {
-        const observer = new ResizeObserver((entries) => {
-          const entry = entries[0]
-          if (entry) {
-            setContainerSize({
-              width: entry.contentRect.width,
-              height: entry.contentRect.height,
-            })
-          }
-        })
-        observer.observe(node)
-        observerRef.current = observer
-      }
+    useEffect(() => {
+      const node = containerRef.current
+      if (!node) return
+      const observer = new ResizeObserver((entries) => {
+        const entry = entries[0]
+        if (entry) {
+          setContainerSize({
+            width: entry.contentRect.width,
+            height: entry.contentRect.height,
+          })
+        }
+      })
+      observer.observe(node)
+      return () => observer.disconnect()
     }, [])
 
     const imgW = file.media?.metadata?.originalWidth ?? 1920
@@ -58,43 +56,42 @@ export const ImageViewer = React.forwardRef<MediaController, FileViewerProps>(
     const conW = containerSize.width
     const conH = containerSize.height
 
-    let baseScale = 1
+    const baseScale = fitScale(conW, conH, imgW, imgH)
 
-    if (conW > 0 && conH > 0) {
-      baseScale = Math.min(conW / imgW, conH / imgH)
-    }
-
-    // Reset/Fit logic
+    // Auto-fit when the container size changes, unless the user has manually
+    // zoomed (their view is preserved across resizes, e.g. sidebar toggles).
     useEffect(() => {
-      if (conW > 0 && conH > 0) {
-        setZoom(baseScale)
-        // Center
-        const x = (conW - imgW * baseScale) / 2
-        const y = (conH - imgH * baseScale) / 2
-        setPan({ x, y })
-      }
-    }, [file.id, conW, conH, baseScale, imgW, imgH])
+      if (conW <= 0 || conH <= 0) return
+      if (hasManuallyZoomed) return
+      setZoom(baseScale)
+      setPan(centeredPan(conW, conH, imgW, imgH, baseScale))
+    }, [conW, conH, baseScale, imgW, imgH, hasManuallyZoomed])
 
     const handleZoom = (factor: number) => {
-      const cx = conW / 2
-      const cy = conH / 2
-
-      const newZoom = zoom * factor
-      if (newZoom < 0.01 || newZoom > 50) return
-
-      const newPanX = cx - (cx - pan.x) * (newZoom / zoom)
-      const newPanY = cy - (cy - pan.y) * (newZoom / zoom)
-
-      setZoom(newZoom)
-      setPan({ x: newPanX, y: newPanY })
+      setHasManuallyZoomed(true)
+      const next = zoomAtPoint(zoom, pan, factor, conW / 2, conH / 2)
+      setZoom(next.zoom)
+      setPan(next.pan)
     }
 
     const handleFit = () => {
+      setHasManuallyZoomed(false)
       setZoom(baseScale)
-      const x = (conW - imgW * baseScale) / 2
-      const y = (conH - imgH * baseScale) / 2
-      setPan({ x, y })
+      setPan(centeredPan(conW, conH, imgW, imgH, baseScale))
     }
+
+    usePanZoomGestures({
+      containerRef,
+      zoom,
+      pan,
+      baseScale,
+      onZoomChange: (next) => {
+        setHasManuallyZoomed(true)
+        setZoom(next.zoom)
+        setPan(next.pan)
+      },
+      onPanChange: setPan,
+    })
 
     const bestUrl = getBestTranscode(file.media?.imageTranscodes, screenWidth)?.url ?? ''
 
@@ -178,7 +175,7 @@ export const ImageViewer = React.forwardRef<MediaController, FileViewerProps>(
       <div className="flex flex-col flex-1 h-full overflow-hidden bg-gray-100 dark:bg-gray-950 relative">
         <div className="flex-1 flex flex-col-reverse md:flex-row min-h-0 relative">
           {children}
-          <div ref={containerRef} className="flex-1 relative overflow-hidden">
+          <div ref={containerRef} className="flex-1 relative overflow-hidden touch-none">
             {bestUrl ? (
               <DrawingCanvas
                 width={conW}
@@ -191,7 +188,7 @@ export const ImageViewer = React.forwardRef<MediaController, FileViewerProps>(
                 annotations={displayAnnotations}
                 scale={zoom}
                 offset={pan}
-                onPan={setPan}
+                onPan={isZoomed(zoom, baseScale) ? setPan : undefined}
                 className="absolute inset-0 z-0"
                 isDrawing={isDrawing}
                 currentTool={currentTool}

--- a/packages/webui/components/viewers/pan-zoom.test.ts
+++ b/packages/webui/components/viewers/pan-zoom.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_ZOOM,
+  MIN_ZOOM,
+  centeredPan,
+  clampZoom,
+  fitScale,
+  isZoomed,
+  wheelZoomFactor,
+  zoomAtPoint,
+} from './pan-zoom'
+
+describe('fitScale', () => {
+  it('fits a wide media into a narrower container by width', () => {
+    expect(fitScale(100, 100, 200, 100)).toBe(0.5)
+  })
+
+  it('fits a tall media into a shorter container by height', () => {
+    expect(fitScale(100, 100, 100, 200)).toBe(0.5)
+  })
+
+  it('keeps aspect ratio (min of both axes)', () => {
+    expect(fitScale(100, 50, 200, 200)).toBe(0.25)
+  })
+
+  it('returns 1 for empty container or media dimensions', () => {
+    expect(fitScale(0, 100, 100, 100)).toBe(1)
+    expect(fitScale(100, 0, 100, 100)).toBe(1)
+    expect(fitScale(100, 100, 0, 100)).toBe(1)
+    expect(fitScale(100, 100, 100, 0)).toBe(1)
+  })
+})
+
+describe('centeredPan', () => {
+  it('centers a smaller-than-container media', () => {
+    expect(centeredPan(1000, 1000, 500, 500, 1)).toEqual({ x: 250, y: 250 })
+  })
+
+  it('centers a scaled media', () => {
+    expect(centeredPan(1000, 800, 200, 100, 2)).toEqual({ x: 300, y: 300 })
+  })
+})
+
+describe('isZoomed', () => {
+  it('is false at or below fit scale', () => {
+    expect(isZoomed(1, 1)).toBe(false)
+    expect(isZoomed(0.5, 1)).toBe(false)
+  })
+
+  it('is true above the fit scale plus epsilon', () => {
+    expect(isZoomed(1.2, 1)).toBe(true)
+    expect(isZoomed(1.01, 1)).toBe(false)
+  })
+})
+
+describe('clampZoom', () => {
+  it('clamps to the configured bounds', () => {
+    expect(clampZoom(0.001)).toBe(MIN_ZOOM)
+    expect(clampZoom(1000)).toBe(MAX_ZOOM)
+    expect(clampZoom(2)).toBe(2)
+  })
+})
+
+describe('zoomAtPoint', () => {
+  it('keeps the anchor point fixed while zooming', () => {
+    const result = zoomAtPoint(1, { x: 0, y: 0 }, 2, 100, 50)
+    expect(result.zoom).toBe(2)
+    // Anchor (100, 50) must map to itself: pan' = px - (px - pan) * ratio
+    expect(result.pan).toEqual({ x: -100, y: -50 })
+  })
+
+  it('zooms about the container center like the old center-zoom behavior', () => {
+    // With pan (0,0) and anchor at center (50, 50), doubling zoom pushes pan
+    // to (-50, -50).
+    const result = zoomAtPoint(1, { x: 0, y: 0 }, 2, 50, 50)
+    expect(result.pan).toEqual({ x: -50, y: -50 })
+  })
+
+  it('zooming out keeps the anchor fixed', () => {
+    const result = zoomAtPoint(2, { x: -100, y: -50 }, 0.5, 100, 50)
+    expect(result.zoom).toBe(1)
+    expect(result.pan).toEqual({ x: 0, y: 0 })
+  })
+
+  it('clamps zoom while still keeping the anchor fixed', () => {
+    const result = zoomAtPoint(40, { x: 10, y: 20 }, 2, 5, 5)
+    expect(result.zoom).toBe(MAX_ZOOM)
+    // ratio is 50/40 = 1.25 once clamped; the anchor (5, 5) stays fixed
+    expect(result.pan).toEqual({ x: 11.25, y: 23.75 })
+  })
+
+  it('keeps pan untouched when already at the bound (ratio 1)', () => {
+    const result = zoomAtPoint(MAX_ZOOM, { x: 10, y: 20 }, 2, 5, 5)
+    expect(result.zoom).toBe(MAX_ZOOM)
+    expect(result.pan).toEqual({ x: 10, y: 20 })
+  })
+
+  it('clamps at the minimum zoom', () => {
+    const result = zoomAtPoint(0.05, { x: 10, y: 20 }, 0.1, 5, 5)
+    expect(result.zoom).toBe(MIN_ZOOM)
+  })
+})
+
+describe('wheelZoomFactor', () => {
+  it('zooms in for negative delta (scroll up / pinch out)', () => {
+    expect(wheelZoomFactor(-100)).toBeGreaterThan(1)
+  })
+
+  it('zooms out for positive delta (scroll down / pinch in)', () => {
+    expect(wheelZoomFactor(100)).toBeLessThan(1)
+  })
+
+  it('normalizes line and page delta modes to pixel-like scales', () => {
+    // deltaMode 1 = lines: multiply by 16
+    expect(wheelZoomFactor(-6.25, 1)).toBe(wheelZoomFactor(-100, 0))
+    // deltaMode 2 = pages: multiply by 100
+    expect(wheelZoomFactor(-1, 2)).toBe(wheelZoomFactor(-100, 0))
+  })
+
+  it('clamps extreme deltas to avoid jumps', () => {
+    expect(wheelZoomFactor(-1_000_000)).toBe(2)
+    expect(wheelZoomFactor(1_000_000)).toBe(0.5)
+  })
+})

--- a/packages/webui/components/viewers/pan-zoom.ts
+++ b/packages/webui/components/viewers/pan-zoom.ts
@@ -1,0 +1,71 @@
+export interface PanZoomState {
+  zoom: number
+  pan: { x: number; y: number }
+}
+
+export const MIN_ZOOM = 0.01
+export const MAX_ZOOM = 50
+
+/** Scale that fits `media` inside `container` while preserving aspect ratio. */
+export function fitScale(conW: number, conH: number, mediaW: number, mediaH: number): number {
+  if (conW <= 0 || conH <= 0 || mediaW <= 0 || mediaH <= 0) return 1
+  return Math.min(conW / mediaW, conH / mediaH)
+}
+
+/** Pan that centers media of `mediaW` x `mediaH` at the given zoom. */
+export function centeredPan(
+  conW: number,
+  conH: number,
+  mediaW: number,
+  mediaH: number,
+  zoom: number,
+): { x: number; y: number } {
+  return { x: (conW - mediaW * zoom) / 2, y: (conH - mediaH * zoom) / 2 }
+}
+
+/**
+ * Whether the user has zoomed in far enough that panning is meaningful.
+ * A small epsilon avoids float noise around the fit scale.
+ */
+export function isZoomed(zoom: number, baseScale: number, epsilon = 0.02): boolean {
+  return zoom > baseScale * (1 + epsilon)
+}
+
+export function clampZoom(zoom: number, min = MIN_ZOOM, max = MAX_ZOOM): number {
+  return Math.min(max, Math.max(min, zoom))
+}
+
+/**
+ * Zoom by `factor` about container point `(px, py)`, keeping the content
+ * under that point fixed (used for cursor/pinch-midpoint anchored zoom).
+ */
+export function zoomAtPoint(
+  zoom: number,
+  pan: { x: number; y: number },
+  factor: number,
+  px: number,
+  py: number,
+  min = MIN_ZOOM,
+  max = MAX_ZOOM,
+): PanZoomState {
+  const newZoom = clampZoom(zoom * factor, min, max)
+  const ratio = newZoom / zoom
+  return {
+    zoom: newZoom,
+    pan: {
+      x: px - (px - pan.x) * ratio,
+      y: py - (py - pan.y) * ratio,
+    },
+  }
+}
+
+/**
+ * Per-event zoom factor for a ctrl+wheel (trackpad pinch / ctrl+scroll).
+ * Normalizes line/page delta modes to pixel-like values, then clamps so a
+ * single event can't cause a jarring jump.
+ */
+export function wheelZoomFactor(deltaY: number, deltaMode?: number): number {
+  const normalized = deltaMode === 1 ? deltaY * 16 : deltaMode === 2 ? deltaY * 100 : deltaY
+  const factor = Math.exp(-normalized * 0.01)
+  return Math.min(2, Math.max(0.5, factor))
+}

--- a/packages/webui/components/viewers/pdf/pdf-viewer.tsx
+++ b/packages/webui/components/viewers/pdf/pdf-viewer.tsx
@@ -2,9 +2,11 @@ import { client } from '@/ui/api/client'
 import DrawingCanvas from '@/ui/components/drawing-canvas'
 import { useAnnotationStore } from '@/ui/stores/annotation-store'
 import * as pdfjsLib from 'pdfjs-dist'
-import React, { useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import React, { useEffect, useImperativeHandle, useRef, useState } from 'react'
 import { FileViewerProps, MediaController } from '../types'
 import { PdfControlBar } from './pdf-control-bar'
+import { centeredPan, fitScale, isZoomed, zoomAtPoint } from '../pan-zoom'
+import { usePanZoomGestures } from '../use-pan-zoom'
 
 import pdfworker from '@/ui/public/pdf.worker.min.mjs' with { type: 'file' }
 
@@ -121,28 +123,24 @@ export const PdfViewer = React.forwardRef<MediaController, FileViewerProps>(
     const [containerSize, setContainerSize] = useState({ width: 0, height: 0 })
     const [zoom, setZoom] = useState(1)
     const [pan, setPan] = useState({ x: 0, y: 0 })
+    const [hasManuallyZoomed, setHasManuallyZoomed] = useState(false)
 
-    const observerRef = useRef<ResizeObserver | null>(null)
+    const containerRef = useRef<HTMLDivElement | null>(null)
 
-    const containerRef = useCallback((node: HTMLDivElement | null) => {
-      if (observerRef.current) {
-        observerRef.current.disconnect()
-        observerRef.current = null
-      }
-
-      if (node !== null) {
-        const observer = new ResizeObserver((entries) => {
-          const entry = entries[0]
-          if (entry) {
-            setContainerSize({
-              width: entry.contentRect.width,
-              height: entry.contentRect.height,
-            })
-          }
-        })
-        observer.observe(node)
-        observerRef.current = observer
-      }
+    useEffect(() => {
+      const node = containerRef.current
+      if (!node) return
+      const observer = new ResizeObserver((entries) => {
+        const entry = entries[0]
+        if (entry) {
+          setContainerSize({
+            width: entry.contentRect.width,
+            height: entry.contentRect.height,
+          })
+        }
+      })
+      observer.observe(node)
+      return () => observer.disconnect()
     }, [])
 
     const fileUrl = file.media?.pdfTranscode?.url
@@ -253,40 +251,42 @@ export const PdfViewer = React.forwardRef<MediaController, FileViewerProps>(
     const pdfW = pageDimensions.width
     const pdfH = pageDimensions.height
 
-    let baseScale = 1
-    if (conW > 0 && conH > 0 && pdfW > 0 && pdfH > 0) {
-      baseScale = Math.min(conW / pdfW, conH / pdfH)
-    }
+    const baseScale = fitScale(conW, conH, pdfW, pdfH)
 
+    // Auto-fit when the container or page changes, unless the user has
+    // manually zoomed (their view is preserved across resizes / page flips).
     useEffect(() => {
-      if (conW > 0 && conH > 0 && pdfW > 0 && pdfH > 0) {
-        setZoom(baseScale)
-        const x = (conW - pdfW * baseScale) / 2
-        const y = (conH - pdfH * baseScale) / 2
-        setPan({ x, y })
-      }
-    }, [file.id, currentPage, conW, conH, baseScale, pdfW, pdfH])
+      if (conW <= 0 || conH <= 0 || pdfW <= 0 || pdfH <= 0) return
+      if (hasManuallyZoomed) return
+      setZoom(baseScale)
+      setPan(centeredPan(conW, conH, pdfW, pdfH, baseScale))
+    }, [conW, conH, baseScale, pdfW, pdfH, hasManuallyZoomed])
 
     const handleZoom = (factor: number) => {
-      const cx = conW / 2
-      const cy = conH / 2
-
-      const newZoom = zoom * factor
-      if (newZoom < 0.01 || newZoom > 50) return
-
-      const newPanX = cx - (cx - pan.x) * (newZoom / zoom)
-      const newPanY = cy - (cy - pan.y) * (newZoom / zoom)
-
-      setZoom(newZoom)
-      setPan({ x: newPanX, y: newPanY })
+      setHasManuallyZoomed(true)
+      const next = zoomAtPoint(zoom, pan, factor, conW / 2, conH / 2)
+      setZoom(next.zoom)
+      setPan(next.pan)
     }
 
     const handleFit = () => {
+      setHasManuallyZoomed(false)
       setZoom(baseScale)
-      const x = (conW - pdfW * baseScale) / 2
-      const y = (conH - pdfH * baseScale) / 2
-      setPan({ x, y })
+      setPan(centeredPan(conW, conH, pdfW, pdfH, baseScale))
     }
+
+    usePanZoomGestures({
+      containerRef,
+      zoom,
+      pan,
+      baseScale,
+      onZoomChange: (next) => {
+        setHasManuallyZoomed(true)
+        setZoom(next.zoom)
+        setPan(next.pan)
+      },
+      onPanChange: setPan,
+    })
 
     const handleDownload = async () => {
       const key = file.media?.original?.key
@@ -319,7 +319,7 @@ export const PdfViewer = React.forwardRef<MediaController, FileViewerProps>(
       <div className="flex flex-col flex-1 h-full overflow-hidden bg-gray-100 dark:bg-gray-950 relative">
         <div className="flex-1 flex flex-col-reverse md:flex-row min-h-0 relative">
           {children}
-          <div ref={containerRef} className="flex-1 relative overflow-hidden">
+          <div ref={containerRef} className="flex-1 relative overflow-hidden touch-none">
             {loading ? (
               <div className="absolute inset-0 flex items-center justify-center bg-black/40 z-20">
                 <div className="w-8 h-8 border-4 border-white/30 border-t-white rounded-full animate-spin" />
@@ -337,7 +337,7 @@ export const PdfViewer = React.forwardRef<MediaController, FileViewerProps>(
                 annotations={displayAnnotations}
                 scale={zoom}
                 offset={pan}
-                onPan={setPan}
+                onPan={isZoomed(zoom, baseScale) ? setPan : undefined}
                 className="absolute inset-0 z-0"
                 isDrawing={isDrawing}
                 currentTool={currentTool}

--- a/packages/webui/components/viewers/pdf/pdf-viewer.tsx
+++ b/packages/webui/components/viewers/pdf/pdf-viewer.tsx
@@ -5,7 +5,7 @@ import * as pdfjsLib from 'pdfjs-dist'
 import React, { useEffect, useImperativeHandle, useRef, useState } from 'react'
 import { FileViewerProps, MediaController } from '../types'
 import { PdfControlBar } from './pdf-control-bar'
-import { centeredPan, fitScale, isZoomed, zoomAtPoint } from '../pan-zoom'
+import { centeredPan, fitScale, zoomAtPoint } from '../pan-zoom'
 import { usePanZoomGestures } from '../use-pan-zoom'
 
 import pdfworker from '@/ui/public/pdf.worker.min.mjs' with { type: 'file' }
@@ -337,7 +337,6 @@ export const PdfViewer = React.forwardRef<MediaController, FileViewerProps>(
                 annotations={displayAnnotations}
                 scale={zoom}
                 offset={pan}
-                onPan={isZoomed(zoom, baseScale) ? setPan : undefined}
                 className="absolute inset-0 z-0"
                 isDrawing={isDrawing}
                 currentTool={currentTool}

--- a/packages/webui/components/viewers/use-pan-zoom.ts
+++ b/packages/webui/components/viewers/use-pan-zoom.ts
@@ -1,0 +1,144 @@
+import { useEffect, useRef } from 'react'
+import { isZoomed, type PanZoomState, wheelZoomFactor, zoomAtPoint } from './pan-zoom'
+
+interface UsePanZoomGesturesOptions {
+  containerRef: { current: HTMLElement | null }
+  zoom: number
+  pan: { x: number; y: number }
+  /** The "fit" scale for the current container — zoom above this allows panning. */
+  baseScale: number
+  /** Called when a gesture changes zoom (and possibly pan). */
+  onZoomChange: (next: PanZoomState) => void
+  /** Called when a two-finger move / wheel scroll pans the content. */
+  onPanChange: (next: { x: number; y: number }) => void
+}
+
+interface PinchState {
+  lastDist: number
+  lastMid: { x: number; y: number }
+}
+
+/**
+ * Adds trackpad/touchscreen pan-zoom gestures to a media container:
+ * - ctrl+wheel (trackpad pinch) → zoom the content about the cursor,
+ *   suppressing the browser's native page zoom.
+ * - plain wheel (two-finger scroll / mouse wheel) → pan the content, but only
+ *   once the user has zoomed in.
+ * - two-finger touch pinch/move → zoom about the pinch midpoint and pan by the
+ *   midpoint delta (pan only while zoomed in).
+ *
+ * The container must be styled with `touch-action: none` so the browser does
+ * not scroll/zoom the page from within it. Native, non-passive listeners are
+ * used so `preventDefault()` reliably suppresses browser gestures.
+ */
+export function usePanZoomGestures({
+  containerRef,
+  zoom,
+  pan,
+  baseScale,
+  onZoomChange,
+  onPanChange,
+}: UsePanZoomGesturesOptions) {
+  const stateRef = useRef({ zoom, pan, baseScale, onZoomChange, onPanChange })
+  stateRef.current = { zoom, pan, baseScale, onZoomChange, onPanChange }
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+
+    const activeTouches = new Map<number, { x: number; y: number }>()
+    let pinch: PinchState | null = null
+
+    const handleWheel = (e: WheelEvent) => {
+      const s = stateRef.current
+      if (e.ctrlKey) {
+        // Trackpad pinch / ctrl+scroll → zoom the media about the cursor.
+        e.preventDefault()
+        const rect = el.getBoundingClientRect()
+        const px = e.clientX - rect.left
+        const py = e.clientY - rect.top
+        s.onZoomChange(zoomAtPoint(s.zoom, s.pan, wheelZoomFactor(e.deltaY, e.deltaMode), px, py))
+        return
+      }
+      // Plain wheel / two-finger scroll → pan, but only once zoomed in.
+      if (isZoomed(s.zoom, s.baseScale)) {
+        e.preventDefault()
+        s.onPanChange({ x: s.pan.x - e.deltaX, y: s.pan.y - e.deltaY })
+      }
+    }
+
+    const dist = (a: { x: number; y: number }, b: { x: number; y: number }) =>
+      Math.hypot(b.x - a.x, b.y - a.y)
+
+    const mid = (a: { x: number; y: number }, b: { x: number; y: number }, rect: DOMRect) => ({
+      x: (a.x + b.x) / 2 - rect.left,
+      y: (a.y + b.y) / 2 - rect.top,
+    })
+
+    const handleTouchStart = (e: TouchEvent) => {
+      for (const t of Array.from(e.touches)) {
+        activeTouches.set(t.identifier, { x: t.clientX, y: t.clientY })
+      }
+      if (activeTouches.size === 2) {
+        e.preventDefault()
+        const rect = el.getBoundingClientRect()
+        const [a, b] = Array.from(activeTouches.values())
+        pinch = { lastDist: dist(a, b), lastMid: mid(a, b, rect) }
+      }
+    }
+
+    const handleTouchMove = (e: TouchEvent) => {
+      for (const t of Array.from(e.touches)) {
+        activeTouches.set(t.identifier, { x: t.clientX, y: t.clientY })
+      }
+      if (!pinch || activeTouches.size < 2) return
+      e.preventDefault()
+
+      const rect = el.getBoundingClientRect()
+      const [a, b] = Array.from(activeTouches.values())
+      const currentMid = mid(a, b, rect)
+      const currentDist = dist(a, b)
+      const s = stateRef.current
+
+      // Zoom by the pinch distance ratio (incremental about the midpoint).
+      const factor = pinch.lastDist > 0 ? currentDist / pinch.lastDist : 1
+      const next = zoomAtPoint(s.zoom, s.pan, factor, currentMid.x, currentMid.y)
+
+      // Two-finger move pans the content, but only once zoomed in.
+      let nextPan = next.pan
+      if (isZoomed(next.zoom, s.baseScale)) {
+        nextPan = {
+          x: nextPan.x + (currentMid.x - pinch.lastMid.x),
+          y: nextPan.y + (currentMid.y - pinch.lastMid.y),
+        }
+      }
+      s.onZoomChange({ zoom: next.zoom, pan: nextPan })
+
+      pinch.lastDist = currentDist
+      pinch.lastMid = currentMid
+    }
+
+    const handleTouchEnd = (e: TouchEvent) => {
+      for (const t of Array.from(e.changedTouches)) {
+        activeTouches.delete(t.identifier)
+      }
+      if (activeTouches.size < 2) {
+        pinch = null
+      }
+    }
+
+    el.addEventListener('wheel', handleWheel, { passive: false })
+    el.addEventListener('touchstart', handleTouchStart, { passive: false })
+    el.addEventListener('touchmove', handleTouchMove, { passive: false })
+    el.addEventListener('touchend', handleTouchEnd, { passive: false })
+    el.addEventListener('touchcancel', handleTouchEnd, { passive: false })
+
+    return () => {
+      el.removeEventListener('wheel', handleWheel)
+      el.removeEventListener('touchstart', handleTouchStart)
+      el.removeEventListener('touchmove', handleTouchMove)
+      el.removeEventListener('touchend', handleTouchEnd)
+      el.removeEventListener('touchcancel', handleTouchEnd)
+    }
+  }, [containerRef])
+}

--- a/packages/webui/components/viewers/video/video-viewer.tsx
+++ b/packages/webui/components/viewers/video/video-viewer.tsx
@@ -10,6 +10,8 @@ import { VideoControlBar, type PlayerState, type DisplayTranscode } from './vide
 import DrawingCanvas from '@/ui/components/drawing-canvas'
 import { useAnnotationStore } from '@/ui/stores/annotation-store'
 import { FileViewerProps, MediaController } from '../types'
+import { centeredPan, fitScale, isZoomed, zoomAtPoint } from '../pan-zoom'
+import { usePanZoomGestures } from '../use-pan-zoom'
 
 const VideoViewer = React.forwardRef<MediaController, FileViewerProps>(
   (
@@ -121,16 +123,34 @@ const VideoViewer = React.forwardRef<MediaController, FileViewerProps>(
     const [videoHtmlEl, setVideoHtmlEl] = useState<HTMLVideoElement | undefined>(undefined)
     const videoRef = useRef<HTMLVideoElement | null>(null)
     const [zoom, setZoom] = useState(1)
+    const [pan, setPan] = useState({ x: 0, y: 0 })
     const [hasManuallyZoomed, setHasManuallyZoomed] = useState(false)
     const [containerSize, setContainerSize] = useState({ width: 0, height: 0 })
 
+    const vidW = data.media?.metadata?.originalWidth || 1920
+    const vidH = data.media?.metadata?.originalHeight || 1080
+    const baseScale = fitScale(containerSize.width, containerSize.height, vidW, vidH)
+
     const handleZoomChange = (newZoom: number) => {
-      setZoom(newZoom)
       setHasManuallyZoomed(true)
+      const next = zoomAtPoint(
+        zoom,
+        pan,
+        newZoom / zoom,
+        containerSize.width / 2,
+        containerSize.height / 2,
+      )
+      setZoom(next.zoom)
+      setPan(next.pan)
     }
 
     const handleZoomReset = () => {
       setHasManuallyZoomed(false)
+      if (containerSize.width > 0 && containerSize.height > 0) {
+        const scale = fitScale(containerSize.width, containerSize.height, vidW, vidH)
+        setZoom(scale)
+        setPan(centeredPan(containerSize.width, containerSize.height, vidW, vidH, scale))
+      }
     }
 
     // Store
@@ -161,17 +181,27 @@ const VideoViewer = React.forwardRef<MediaController, FileViewerProps>(
       return () => observer.disconnect()
     }, [])
 
-    // Fit to screen initial / responsive resize
+    // Fit to screen initial / responsive resize (preserves manual zoom)
     useEffect(() => {
-      if (containerSize.width > 0 && containerSize.height > 0) {
-        const vidW = data.media?.metadata?.originalWidth || 1920
-        const vidH = data.media?.metadata?.originalHeight || 1080
-        const scale = Math.min(containerSize.width / vidW, containerSize.height / vidH)
-        if (!hasManuallyZoomed) {
-          setZoom(scale)
-        }
-      }
-    }, [containerSize.width, containerSize.height, data.media?.metadata, hasManuallyZoomed])
+      if (containerSize.width <= 0 || containerSize.height <= 0) return
+      if (hasManuallyZoomed) return
+      const scale = fitScale(containerSize.width, containerSize.height, vidW, vidH)
+      setZoom(scale)
+      setPan(centeredPan(containerSize.width, containerSize.height, vidW, vidH, scale))
+    }, [containerSize.width, containerSize.height, vidW, vidH, hasManuallyZoomed])
+
+    usePanZoomGestures({
+      containerRef,
+      zoom,
+      pan,
+      baseScale,
+      onZoomChange: (next) => {
+        setHasManuallyZoomed(true)
+        setZoom(next.zoom)
+        setPan(next.pan)
+      },
+      onPanChange: setPan,
+    })
 
     // Cleanup ref when player is disposed
     useEffect(() => {
@@ -580,13 +610,8 @@ const VideoViewer = React.forwardRef<MediaController, FileViewerProps>(
       return () => document.removeEventListener('fullscreenchange', onFsChange)
     }, [])
 
-    // Calculate center pan
-    const vidW = data.media?.metadata?.originalWidth || 1920
-    const vidH = data.media?.metadata?.originalHeight || 1080
-
+    // Center pan is owned by `pan` state (set by auto-fit / gestures).
     const scale = zoom
-    const panX = (containerSize.width - vidW * scale) / 2
-    const panY = (containerSize.height - vidH * scale) / 2
 
     if (!hasMedia) {
       return (
@@ -615,7 +640,7 @@ const VideoViewer = React.forwardRef<MediaController, FileViewerProps>(
           <div
             ref={containerRef}
             className={cn(
-              'flex-1 bg-black cursor-pointer relative flex items-center justify-center overflow-hidden min-h-0',
+              'flex-1 bg-black cursor-pointer relative flex items-center justify-center overflow-hidden min-h-0 touch-none',
             )}
             onClick={togglePlay}
             data-vjs-player
@@ -647,9 +672,12 @@ const VideoViewer = React.forwardRef<MediaController, FileViewerProps>(
                   videoElement={videoHtmlEl}
                   annotations={displayAnnotations}
                   scale={scale}
-                  offset={{ x: panX, y: panY }}
+                  offset={pan}
+                  onPan={isZoomed(zoom, baseScale) ? setPan : undefined}
                   className="absolute inset-0"
-                  onClick={togglePlay}
+                  // Play/pause is handled by the video-area div's onClick; a
+                  // Konva-level onClick would double-toggle once the overlay
+                  // becomes interactive (zoomed).
                   // Drawing Props
                   isDrawing={isDrawing}
                   currentTool={currentTool}

--- a/packages/webui/components/viewers/video/video-viewer.tsx
+++ b/packages/webui/components/viewers/video/video-viewer.tsx
@@ -10,7 +10,7 @@ import { VideoControlBar, type PlayerState, type DisplayTranscode } from './vide
 import DrawingCanvas from '@/ui/components/drawing-canvas'
 import { useAnnotationStore } from '@/ui/stores/annotation-store'
 import { FileViewerProps, MediaController } from '../types'
-import { centeredPan, fitScale, isZoomed, zoomAtPoint } from '../pan-zoom'
+import { centeredPan, fitScale, zoomAtPoint } from '../pan-zoom'
 import { usePanZoomGestures } from '../use-pan-zoom'
 
 const VideoViewer = React.forwardRef<MediaController, FileViewerProps>(
@@ -673,7 +673,6 @@ const VideoViewer = React.forwardRef<MediaController, FileViewerProps>(
                   annotations={displayAnnotations}
                   scale={scale}
                   offset={pan}
-                  onPan={isZoomed(zoom, baseScale) ? setPan : undefined}
                   className="absolute inset-0"
                   // Play/pause is handled by the video-area div's onClick; a
                   // Konva-level onClick would double-toggle once the overlay


### PR DESCRIPTION
## Summary

On the file detail page, pinch-zooming with two fingers (trackpad or touchscreen) zoomed the **whole browser page** instead of the media, because the image/video/PDF viewers had no gesture handling — only control-bar button zoom. Two-finger move did nothing to the content. This makes the viewers behave like Frame.io: pinch zooms only the content area, and two-finger move pans the content (only once zoomed in).

## Changes

- **New `viewers/pan-zoom.ts`**: shared pure math — `zoomAtPoint` (zoom about an arbitrary container point), `fitScale`, `centeredPan`, `isZoomed` (pan gating threshold), `wheelZoomFactor`. Replaces the duplicated center-zoom logic in the image/PDF viewers.
- **New `viewers/use-pan-zoom.ts`**: gesture hook using native, **non-passive** `wheel`/`touch` listeners + `touch-action: none` so `preventDefault()` reliably suppresses browser page zoom.
  - ctrl+wheel (trackpad pinch) → zoom about the cursor
  - plain wheel / two-finger scroll → pan, gated to zoomed state
  - two-finger touch pinch/move → zoom about midpoint + midpoint pan
- **Image / PDF viewers**: wired the hook, gated drag-pan on `isZoomed`, and **no longer reset zoom to fit on container resize** while the user has manually zoomed (adopted the video viewer's `hasManuallyZoomed` pattern).
- **Video viewer**: added a `pan` state (previously derived/centered, no panning at all), wired the hook, enabled drag-pan when zoomed. Play/pause stays on the container div (a Konva-level `onClick` would double-toggle once the overlay becomes interactive).
- **`drawing-canvas.tsx`**: single-pointer pan/draw now ignores multi-touch moves so it can't fight the pinch handler; pan keeps dragging until every finger lifts.
- **Follow-up (this PR, 2nd commit)**: **disabled click-drag pan for PDF and video** — when zoomed, left-button/single-finger drag no longer pans (it conflicted with PDF text-selection intent and video click-to-play). Panning there is now via mouse wheel + two-finger gestures only; the Konva overlay stays `pointer-events: none` when not drawing, so video click-to-play works cleanly at any zoom. Image keeps drag-pan.
- **Tests**: `pan-zoom.test.ts` covering zoom-about-point math, clamping, fit scale, and wheel factor.

## Verification

- `bun run lint` ✅
- `bun run format` ✅
- `bun run typecheck` ✅
- `bun run test` ✅ (1061 passed, incl. new pan-zoom tests)
- `bun run test:e2e:app` ✅ (30 passed)
- `bun run test:e2e:webui` ✅ (9 passed — incl. the two click-to-play video specs)
- `bun run test:e2e:workflow` ✅ (58 passed)

## Notes

- Compare (side-by-side) panes still use button zoom + drag pan; adding gestures there is follow-up (phase 2).
- Zooming out below fit is still allowed (existing behavior); panning only activates once zoomed in above fit.
- Native PDF text selection is a separate follow-up task; disabling drag-pan unblocks it.