### PR TITLE
fix(i18n): update Chinese translation for dashboard to 仪表板

### DIFF
--- a/packages/webui/messages/zh.json
+++ b/packages/webui/messages/zh.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-  "dashboard": "控制台",
+  "dashboard": "仪表板",
   "notifications": "通知",
   "uploads": "上传管理",
   "language": "语言",

--- a/packages/webui/paraglide/messages/dashboard.js
+++ b/packages/webui/paraglide/messages/dashboard.js
@@ -10,7 +10,7 @@ const en_dashboard = /** @type {(inputs: DashboardInputs) => LocalizedString} */
 };
 
 const zh_dashboard = /** @type {(inputs: DashboardInputs) => LocalizedString} */ () => {
-	return /** @type {LocalizedString} */ (`控制台`)
+	return /** @type {LocalizedString} */ (`仪表板`)
 };
 
 /**


### PR DESCRIPTION
## Summary

Update the Chinese translation for "dashboard" from "控制台" to "仪表板" in `packages/webui/messages/zh.json` and recompile i18n messages.

## Changes

- Updated `"dashboard": "仪表板"` in `packages/webui/messages/zh.json`.
- Recompiled Paraglide i18n messages (`bun run i18n:compile`).

## Verification

Ran all required checks:
- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test`
- `bun run test:e2e:app`
- `bun run test:e2e:webui`
- `bun run test:e2e:workflow`

All passed simultaneously.

## Notes

Per project contribution rules (`AGENTS.md`), changes are submitted via Pull Request.