### PR TITLE
fix(webui): fix select field height and multi-select overflow/interaction issues

### DIFF
--- a/packages/webui/components/fields/select-field.test.tsx
+++ b/packages/webui/components/fields/select-field.test.tsx
@@ -45,8 +45,21 @@ describe('SelectField Component', () => {
   }
 
   it('renders selected option badge correctly', () => {
-    render(<SelectField value="foo" config={sampleConfig} onSave={vi.fn()} />)
-    expect(screen.getByText('Foo')).toBeTruthy()
+    const { container } = render(<SelectField value="foo" config={sampleConfig} onSave={vi.fn()} />)
+    const badge = screen.getByText('Foo')
+    expect(badge).toBeTruthy()
+    expect(badge.className).toContain('h-[22px]')
+    const trigger = container.querySelector('div[class*="h-[28px]"]')
+    expect(trigger).toBeTruthy()
+  })
+
+  it('renders placeholder with text-sm styling', () => {
+    const { container } = render(<SelectField value="" config={sampleConfig} onSave={vi.fn()} />)
+    const placeholder = screen.getByText('Select an option')
+    expect(placeholder).toBeTruthy()
+    expect(placeholder.className).toContain('text-sm')
+    const trigger = container.querySelector('div[class*="h-[28px]"]')
+    expect(trigger).toBeTruthy()
   })
 
   it('filters options based on search query', () => {

--- a/packages/webui/components/fields/select-field.tsx
+++ b/packages/webui/components/fields/select-field.tsx
@@ -99,10 +99,11 @@ const SelectField: React.FC<FieldProps<string>> = ({
   }
 
   const renderOptionBadge = (option: SelectOption | undefined) => {
-    if (!option) return <span className="text-muted-foreground italic">Select an option</span>
+    if (!option)
+      return <span className="text-muted-foreground italic text-sm">Select an option</span>
     return (
       <span
-        className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+        className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium h-[22px]"
         style={getOptionStyle(option.color)}
       >
         {option.displayName}
@@ -116,7 +117,7 @@ const SelectField: React.FC<FieldProps<string>> = ({
         <PopoverTrigger asChild>
           <div
             onClick={handleStartEdit}
-            className={`flex items-center justify-between w-full min-h-[28px] px-2 py-1 rounded border border-transparent transition-colors ${
+            className={`flex items-center justify-between w-full h-[28px] px-2 rounded border border-transparent transition-colors ${
               !readOnly ? 'cursor-pointer hover:bg-accent hover:border-border group' : ''
             }`}
           >

--- a/packages/webui/components/fields/select-multi-field.test.tsx
+++ b/packages/webui/components/fields/select-multi-field.test.tsx
@@ -121,4 +121,15 @@ describe('SelectMultiField Component', () => {
       expect(onSave).toHaveBeenCalledWith(['foo', 'new-multi-option'])
     })
   })
+
+  it('opens search input directly on first click even when multiple items are selected', () => {
+    render(<SelectMultiField value={['foo', 'bar']} config={sampleConfig} onSave={vi.fn()} />)
+
+    const trigger = screen.getByText('Foo')
+    fireEvent.click(trigger)
+
+    const searchInput = screen.getByPlaceholderText('Search options...')
+    expect(searchInput).toBeTruthy()
+    expect(screen.getByText('abc')).toBeTruthy()
+  })
 })

--- a/packages/webui/components/fields/select-multi-field.tsx
+++ b/packages/webui/components/fields/select-multi-field.tsx
@@ -20,7 +20,6 @@ const SelectMultiField: React.FC<FieldProps<string[]>> = ({
   const options: SelectOption[] = selectConfig?.options || []
   const containerRef = useRef<HTMLDivElement>(null)
   const [isEditing, setIsEditing] = useState(false)
-  const [expanded, setExpanded] = useState(false)
   const [visibleCount, setVisibleCount] = useState(value.length)
   const [searchQuery, setSearchQuery] = useState('')
 
@@ -39,44 +38,44 @@ const SelectMultiField: React.FC<FieldProps<string[]>> = ({
 
   // Dynamic calculation for how many items fit in one line
   useLayoutEffect(() => {
-    if (isEditing || expanded) {
+    if (isEditing) {
       setVisibleCount(selectedOptions.length)
       return
     }
 
     if (containerRef.current) {
-      const containerWidth = containerRef.current.offsetWidth
+      const innerWidth = containerRef.current.clientWidth - 8 // account for px-1 (8px padding)
       const canvas = document.createElement('canvas')
       const context = canvas.getContext('2d')
-      if (context) {
-        context.font = '12px ui-sans-serif, system-ui, sans-serif'
+      if (context && innerWidth > 0) {
+        context.font = '500 12px ui-sans-serif, system-ui, sans-serif'
+        const gap = 4
+        const badgeWidths = selectedOptions.map(
+          (opt) => Math.ceil(context.measureText(opt.displayName).width) + 18,
+        )
+        const totalAllWidth =
+          badgeWidths.reduce((a, b) => a + b, 0) + Math.max(0, badgeWidths.length - 1) * gap
 
+        if (totalAllWidth <= innerWidth) {
+          setVisibleCount(selectedOptions.length)
+          return
+        }
+
+        const moreBadgeWidth = 32
+        const maxAvailableWidth = innerWidth - moreBadgeWidth - gap
         let currentWidth = 0
         let count = 0
-        const moreBadgeWidth = 28
-        const maxAvailableWidth = containerWidth - moreBadgeWidth
 
-        for (let i = 0; i < selectedOptions.length; i++) {
-          const textWidth = context.measureText(selectedOptions[i].displayName).width
-          const badgeWidth = textWidth + 16 + 4
-
-          if (currentWidth + badgeWidth > maxAvailableWidth && i < selectedOptions.length - 1) {
-            break
-          }
-          if (i === selectedOptions.length - 1) {
-            if (currentWidth + badgeWidth <= containerWidth) {
-              count++
-            }
-            break
-          }
-
-          currentWidth += badgeWidth
+        for (let i = 0; i < badgeWidths.length; i++) {
+          const widthWithGap = count > 0 ? currentWidth + gap + badgeWidths[i] : badgeWidths[i]
+          if (widthWithGap > maxAvailableWidth) break
+          currentWidth = widthWithGap
           count++
         }
         setVisibleCount(count)
       }
     }
-  }, [selectedOptions, isEditing, expanded, value])
+  }, [selectedOptions, isEditing, value])
 
   const toggleOption = (optionId: string) => {
     const currentVal = value || []
@@ -135,40 +134,24 @@ const SelectMultiField: React.FC<FieldProps<string[]>> = ({
 
   const handlePlaceholderClick = (e: React.MouseEvent) => {
     e.stopPropagation()
-    if (isEditing) return
-
-    const hiddenCount = selectedOptions.length - visibleCount
-    if (!expanded && hiddenCount > 0) {
-      setExpanded(true)
-    } else {
-      if (!readOnly) {
-        setIsEditing(true)
-      }
-    }
-  }
-
-  const handleOverlayClick = (e: React.MouseEvent) => {
-    e.stopPropagation()
     if (!readOnly) {
       setIsEditing(true)
     }
   }
 
   const hiddenCount = selectedOptions.length - visibleCount
-  const isOpen = (expanded && !isEditing) || isEditing
 
   const handleOpenChange = (open: boolean) => {
     if (readOnly) return
+    setIsEditing(open)
     if (!open) {
-      setExpanded(false)
-      setIsEditing(false)
       setSearchQuery('')
     }
   }
 
   return (
     <div className="relative w-full" onClick={(e) => e.stopPropagation()}>
-      <Popover open={!readOnly && isOpen} onOpenChange={handleOpenChange}>
+      <Popover open={!readOnly && isEditing} onOpenChange={handleOpenChange}>
         <PopoverTrigger asChild>
           {/* Placeholder Display Mode */}
           <div
@@ -207,87 +190,61 @@ const SelectMultiField: React.FC<FieldProps<string[]>> = ({
           side="bottom"
           align="start"
           sideOffset={4}
-          className={`p-1.5 bg-popover border rounded-lg shadow-xl max-h-72 flex flex-col ${
-            expanded && !isEditing
-              ? 'w-[--radix-popover-trigger-width] min-w-[200px] flex flex-wrap gap-1 border-ring min-h-[32px] h-auto cursor-pointer overflow-auto'
-              : 'w-64 border-border'
-          }`}
-          onClick={expanded && !isEditing ? handleOverlayClick : undefined}
+          className="p-1.5 w-64 max-h-72 flex flex-col bg-popover border border-border rounded-lg shadow-lg"
         >
-          {expanded && !isEditing ? (
-            <>
-              {selectedOptions.length === 0 && (
-                <span className="text-muted-foreground text-sm italic px-1 pt-0.5">Empty</span>
-              )}
-              {selectedOptions.map((option: SelectOption) => (
-                <span
+          <div
+            className="relative pb-1.5 border-b border-border mb-1"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Search className="w-3.5 h-3.5 absolute left-2 top-2 text-muted-foreground" />
+            <input
+              type="text"
+              className="w-full pl-7 pr-2 py-1 text-xs bg-muted/50 border border-input rounded-md focus:outline-none focus:ring-1 focus:ring-ring text-foreground"
+              placeholder={m.search_options_placeholder()}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              autoFocus
+            />
+          </div>
+
+          <div className="overflow-y-auto max-h-48 min-h-[120px] space-y-0.5">
+            {filteredOptions.map((option: SelectOption) => {
+              const isSelected = (value || []).includes(option.id)
+              return (
+                <div
                   key={option.id}
-                  className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border border-transparent whitespace-nowrap h-[22px]"
-                  style={getOptionStyle(option.color)}
+                  onClick={() => toggleOption(option.id)}
+                  className={`px-2.5 py-1.5 hover:bg-accent rounded cursor-pointer flex items-center justify-between text-xs ${
+                    isSelected ? 'bg-accent/30 font-medium' : ''
+                  }`}
                 >
-                  {option.displayName}
-                </span>
-              ))}
-            </>
-          ) : (
-            <>
-              <div
-                className="relative pb-1.5 border-b border-border mb-1"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Search className="w-3.5 h-3.5 absolute left-2 top-2 text-muted-foreground" />
-                <input
-                  type="text"
-                  className="w-full pl-7 pr-2 py-1 text-xs bg-muted/50 border border-input rounded-md focus:outline-none focus:ring-1 focus:ring-ring text-foreground"
-                  placeholder={m.search_options_placeholder()}
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  autoFocus
-                />
-              </div>
-
-              <div className="overflow-y-auto max-h-48 min-h-[120px] space-y-0.5">
-                {filteredOptions.map((option: SelectOption) => {
-                  const isSelected = (value || []).includes(option.id)
-                  return (
-                    <div
-                      key={option.id}
-                      onClick={() => toggleOption(option.id)}
-                      className={`px-2.5 py-1.5 hover:bg-accent rounded cursor-pointer flex items-center justify-between text-xs ${
-                        isSelected ? 'bg-accent/30 font-medium' : ''
-                      }`}
-                    >
-                      <span
-                        className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
-                        style={getOptionStyle(option.color)}
-                      >
-                        {option.displayName}
-                      </span>
-                      {isSelected && <Check className="w-3.5 h-3.5 text-primary" />}
-                    </div>
-                  )
-                })}
-
-                {filteredOptions.length === 0 && !trimmedSearch && (
-                  <div className="px-2.5 py-2 text-xs text-muted-foreground italic text-center">
-                    {m.no_options_found()}
-                  </div>
-                )}
-
-                {trimmedSearch !== '' && !hasExactMatch && (
-                  <div
-                    onClick={handleAddOption}
-                    className="px-2.5 py-1.5 text-xs text-primary hover:bg-accent rounded cursor-pointer flex items-center gap-1.5 font-medium border-t border-border mt-1 pt-1.5"
+                  <span
+                    className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+                    style={getOptionStyle(option.color)}
                   >
-                    <Plus className="w-3.5 h-3.5 shrink-0" />
-                    <span className="truncate">
-                      {m.add_option_with_name({ name: trimmedSearch })}
-                    </span>
-                  </div>
-                )}
+                    {option.displayName}
+                  </span>
+                  {isSelected && <Check className="w-3.5 h-3.5 text-primary" />}
+                </div>
+              )
+            })}
+
+            {filteredOptions.length === 0 && !trimmedSearch && (
+              <div className="px-2.5 py-2 text-xs text-muted-foreground italic text-center">
+                {m.no_options_found()}
               </div>
-            </>
-          )}
+            )}
+
+            {trimmedSearch !== '' && !hasExactMatch && (
+              <div
+                onClick={handleAddOption}
+                className="px-2.5 py-1.5 text-xs text-primary hover:bg-accent rounded cursor-pointer flex items-center gap-1.5 font-medium border-t border-border mt-1 pt-1.5"
+              >
+                <Plus className="w-3.5 h-3.5 shrink-0" />
+                <span className="truncate">{m.add_option_with_name({ name: trimmedSearch })}</span>
+              </div>
+            )}
+          </div>
         </PopoverContent>
       </Popover>
     </div>

--- a/packages/webui/components/fields/user-multi-field.tsx
+++ b/packages/webui/components/fields/user-multi-field.tsx
@@ -12,7 +12,6 @@ const UserMultiField: React.FC<FieldProps<string[]>> = ({ value = [], onSave, re
   const { members, fetchMembers } = useMemberStore()
   const containerRef = useRef<HTMLDivElement>(null)
   const [isEditing, setIsEditing] = useState(false)
-  const [expanded, setExpanded] = useState(false)
   const [visibleCount, setVisibleCount] = useState(value.length)
 
   useEffect(() => {
@@ -34,45 +33,46 @@ const UserMultiField: React.FC<FieldProps<string[]>> = ({ value = [], onSave, re
 
   // Dynamic calculation for how many items fit in one line
   useLayoutEffect(() => {
-    if (isEditing || expanded) {
+    if (isEditing) {
       setVisibleCount(selectedUsers.length)
       return
     }
 
     if (containerRef.current) {
-      const containerWidth = containerRef.current.offsetWidth
+      const innerWidth = containerRef.current.clientWidth - 8 // account for px-1 (8px padding)
       const canvas = document.createElement('canvas')
       const context = canvas.getContext('2d')
-      if (context) {
-        context.font = '12px ui-sans-serif, system-ui, sans-serif'
+      if (context && innerWidth > 0) {
+        context.font = '500 12px ui-sans-serif, system-ui, sans-serif'
+        const gap = 4
+        const badgeWidths = selectedUsers.map((user) => {
+          const textWidth = Math.min(100, Math.ceil(context.measureText(user.name).width))
+          // 16px padding + 2px border + 16px avatar + 6px gap = 40px
+          return textWidth + 40
+        })
+        const totalAllWidth =
+          badgeWidths.reduce((a, b) => a + b, 0) + Math.max(0, badgeWidths.length - 1) * gap
 
+        if (totalAllWidth <= innerWidth) {
+          setVisibleCount(selectedUsers.length)
+          return
+        }
+
+        const moreBadgeWidth = 32
+        const maxAvailableWidth = innerWidth - moreBadgeWidth - gap
         let currentWidth = 0
         let count = 0
-        const moreBadgeWidth = 28
-        const maxAvailableWidth = containerWidth - moreBadgeWidth
 
-        for (let i = 0; i < selectedUsers.length; i++) {
-          const textWidth = context.measureText(selectedUsers[i].name).width
-          // 16px padding + 16px avatar + 6px gap + 4px extra gap
-          const badgeWidth = textWidth + 42
-
-          if (currentWidth + badgeWidth > maxAvailableWidth && i < selectedUsers.length - 1) {
-            break
-          }
-          if (i === selectedUsers.length - 1) {
-            if (currentWidth + badgeWidth <= containerWidth) {
-              count++
-            }
-            break
-          }
-
-          currentWidth += badgeWidth
+        for (let i = 0; i < badgeWidths.length; i++) {
+          const widthWithGap = count > 0 ? currentWidth + gap + badgeWidths[i] : badgeWidths[i]
+          if (widthWithGap > maxAvailableWidth) break
+          currentWidth = widthWithGap
           count++
         }
         setVisibleCount(count)
       }
     }
-  }, [selectedUsers, isEditing, expanded, value])
+  }, [selectedUsers, isEditing, value])
 
   const toggleUser = (userId: string) => {
     const currentVal = value || []
@@ -87,34 +87,16 @@ const UserMultiField: React.FC<FieldProps<string[]>> = ({ value = [], onSave, re
 
   const handlePlaceholderClick = (e: React.MouseEvent) => {
     e.stopPropagation()
-    if (isEditing) return
-
-    const hiddenCount = selectedUsers.length - visibleCount
-    if (!expanded && hiddenCount > 0) {
-      setExpanded(true)
-    } else {
-      if (!readOnly) {
-        setIsEditing(true)
-      }
-    }
-  }
-
-  const handleOverlayClick = (e: React.MouseEvent) => {
-    e.stopPropagation()
     if (!readOnly) {
       setIsEditing(true)
     }
   }
 
   const hiddenCount = selectedUsers.length - visibleCount
-  const isOpen = (expanded && !isEditing) || isEditing
 
   const handleOpenChange = (open: boolean) => {
     if (readOnly) return
-    if (!open) {
-      setExpanded(false)
-      setIsEditing(false)
-    }
+    setIsEditing(open)
   }
 
   const renderUserBadge = (user: UserInfo) => {
@@ -136,7 +118,7 @@ const UserMultiField: React.FC<FieldProps<string[]>> = ({ value = [], onSave, re
 
   return (
     <div className="relative w-full" onClick={(e) => e.stopPropagation()}>
-      <Popover open={!readOnly && isOpen} onOpenChange={handleOpenChange}>
+      <Popover open={!readOnly && isEditing} onOpenChange={handleOpenChange}>
         <PopoverTrigger asChild>
           <div
             ref={containerRef}
@@ -162,44 +144,30 @@ const UserMultiField: React.FC<FieldProps<string[]>> = ({ value = [], onSave, re
         </PopoverTrigger>
 
         <PopoverContent
-          className={`p-1 bg-popover border rounded-lg shadow-xl max-h-60 overflow-auto ${
-            expanded && !isEditing
-              ? 'w-[--radix-popover-trigger-width] min-w-[200px] flex flex-wrap gap-1 border-ring min-h-[32px] h-auto cursor-pointer'
-              : 'w-64 border-border'
-          }`}
+          className="p-1 w-[--radix-popover-trigger-width] min-w-[200px] max-h-60 overflow-auto bg-popover border border-border rounded-lg shadow-lg"
           align="start"
-          onClick={expanded && !isEditing ? handleOverlayClick : undefined}
         >
-          {expanded && !isEditing ? (
-            <>
-              {selectedUsers.length === 0 && (
-                <span className="text-muted-foreground text-sm italic px-1 pt-0.5">Empty</span>
-              )}
-              {selectedUsers.map(renderUserBadge)}
-            </>
-          ) : (
-            members.map((user) => {
-              const isSelected = (value || []).includes(user.id)
-              return (
-                <div
-                  key={user.id}
-                  onClick={() => toggleUser(user.id)}
-                  className="px-3 py-2 hover:bg-accent cursor-pointer flex items-center justify-between rounded-sm"
-                >
-                  <div className="flex items-center gap-2">
-                    <Avatar className="w-5 h-5">
-                      <AvatarImage src={user.image} alt={user.name} className="object-cover" />
-                      <AvatarFallback className="text-[10px] bg-rose-400 text-black font-semibold">
-                        {getInitials(user.name)}
-                      </AvatarFallback>
-                    </Avatar>
-                    <span className="text-sm font-medium text-foreground">{user.name}</span>
-                  </div>
-                  {isSelected && <Check className="w-4 h-4 text-primary" />}
+          {members.map((user) => {
+            const isSelected = (value || []).includes(user.id)
+            return (
+              <div
+                key={user.id}
+                onClick={() => toggleUser(user.id)}
+                className="px-3 py-2 hover:bg-accent cursor-pointer flex items-center justify-between rounded-sm"
+              >
+                <div className="flex items-center gap-2">
+                  <Avatar className="w-5 h-5">
+                    <AvatarImage src={user.image} alt={user.name} className="object-cover" />
+                    <AvatarFallback className="text-[10px] bg-rose-400 text-black font-semibold">
+                      {getInitials(user.name)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className="text-sm font-medium text-foreground">{user.name}</span>
                 </div>
-              )
-            })
-          )}
+                {isSelected && <Check className="w-4 h-4 text-primary" />}
+              </div>
+            )
+          })}
         </PopoverContent>
       </Popover>
     </div>


### PR DESCRIPTION
## Summary

Fix custom field select issues in WebUI:
1. Standardize single-select trigger container height, placeholder font size, and option badge height to eliminate empty-vs-selected height jumps.
2. Fix multi-select `+n` badge disappearance caused by missing flex gap and padding accounting in `useLayoutEffect` badge width calculations.
3. Remove redundant intermediate `expanded` read-only popover state in multi-select widgets so clicking directly opens the full searchable selection dropdown.

## Changes

- [`packages/webui/components/fields/select-field.tsx`](file:///Users/yiling/Projects/shumai/packages/webui/components/fields/select-field.tsx):
  - Updated container trigger from `min-h-[28px] px-2 py-1` to fixed `h-[28px] px-2`.
  - Added `text-sm` to placeholder and `h-[22px]` to badge.
- [`packages/webui/components/fields/select-multi-field.tsx`](file:///Users/yiling/Projects/shumai/packages/webui/components/fields/select-multi-field.tsx) & [`packages/webui/components/fields/user-multi-field.tsx`](file:///Users/yiling/Projects/shumai/packages/webui/components/fields/user-multi-field.tsx):
  - Fixed `useLayoutEffect` badge overflow calculation to factor in flexbox `gap-1` (`4px`), container padding (`px-1` / `8px`), and borders so `+n` never wraps onto line 2.
  - Removed `expanded` state and intermediate read-only preview popover, allowing 1-click access to search and options.
- [`packages/webui/components/fields/select-field.test.tsx`](file:///Users/yiling/Projects/shumai/packages/webui/components/fields/select-field.test.tsx) & [`packages/webui/components/fields/select-multi-field.test.tsx`](file:///Users/yiling/Projects/shumai/packages/webui/components/fields/select-multi-field.test.tsx):
  - Added tests verifying trigger classes, badge heights, and direct edit popover on click.

## Verification

- `bun run lint` (passed)
- `bun run format` (passed)
- `bun run typecheck` (passed)
- `bun run test` (115 passed, 1086 tests)
- `bun run test:e2e:webui` (9 passed)
- `bun run test:e2e:workflow` (14 passed, 58 tests)
- `bun run test:e2e:app` (30 passed)

## Notes

None.