### PR TITLE
feat(webui): improve AGENTS.md editor placeholder and read-only notice

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -43,6 +43,7 @@
         "pages": [
           "using-shumai/agent-providers",
           "using-shumai/agents",
+          "using-shumai/agents-md",
           "using-shumai/agent-skills",
           "using-shumai/agent-tools",
           "using-shumai/mcp-servers",

--- a/docs/using-shumai/agents-md.mdx
+++ b/docs/using-shumai/agents-md.mdx
@@ -1,0 +1,53 @@
+---
+title: AGENTS.md Context & Instructions
+description: Provide hierarchical, folder-specific instructions and context to AI agents.
+---
+
+In addition to global agent system prompts and skills, Shumai allows you to define project-level and folder-level instructions using **`AGENTS.md`**.
+
+When an AI agent (such as a Chat Agent or Autofill Agent) operates within a project or folder, Shumai automatically loads the corresponding `AGENTS.md` files to provide context, operational rules, and project-specific knowledge.
+
+---
+
+## Hierarchical Traversal & Inheritance
+
+Shumai uses a hierarchical context model for `AGENTS.md`:
+
+- **Upward Traversal**: When an agent works on a file or folder, Shumai traverses the folder tree upwards from the current folder all the way to the **project root level**.
+- **Combined Context**: All `AGENTS.md` files found along this path are loaded into the agent's context in order (from the project root down to the current folder).
+- **Layered Rules**: This lets you define broad, project-wide rules and guidelines at the project root `AGENTS.md`, while adding specific rules, vocabulary, or autofill hints in nested subfolder `AGENTS.md` files.
+
+---
+
+## What to Include in AGENTS.md
+
+You can use `AGENTS.md` to define any instructions you want the agent to follow when working in that folder or project:
+
+- **Project & Folder Overview**: Describe what assets are stored in the folder and how they relate to the broader project.
+- **Agent Behavioral Rules**: Specify guardrails, tone, required formats, or things the agent should and shouldn't do when answering queries or leaving comments.
+- **Terminology & Domain Knowledge**: Define specialized vocabulary, acronyms, brand naming conventions, or project-specific jargon.
+- **Metadata & Autofill Instructions**: Guide the **Autofill Agent** on how to summarize assets, generate tags, or populate specific custom metadata fields for files in this folder.
+
+---
+
+## Accessing and Editing AGENTS.md
+
+### Opening the Editor
+
+To view or edit `AGENTS.md`:
+
+1. Open any project or folder in the Shumai web application.
+2. Click the **`AGENTS.md`** button in the top navigation toolbar, or right-click any folder in the file browser and choose **AGENTS.md**.
+3. A dedicated WYSIWYG Markdown editor opens with full formatting support (headings, lists, code blocks, bold/italics, and links).
+
+### Auto-Save
+
+As you make changes in the editor, Shumai automatically saves your edits in the background with visual save status indicators (`Saving...`, `Saved`).
+
+---
+
+## Permissions & Read-Only Mode
+
+- **Viewing**: All team members who have read access to the project can view `AGENTS.md`.
+- **Editing**: **Only Team Owners** are permitted to create, edit, or delete `AGENTS.md` files.
+- **Read-Only State**: Non-owner members will see a clear read-only indicator in the toolbar explaining that only team owners can edit instructions for the file.

--- a/packages/webui/components/agents-md/agents-md-editor.test.tsx
+++ b/packages/webui/components/agents-md/agents-md-editor.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { AgentsMdEditor } from './agents-md-editor'
+import { m } from '@/ui/paraglide/messages.js'
+
+// Mock API client
+vi.mock('@/ui/api/client', () => ({
+  client: {
+    api: {
+      folders: {
+        ':folderId': {
+          agentsmd: {
+            $get: vi.fn(),
+            $patch: vi.fn(),
+          },
+        },
+      },
+    },
+  },
+}))
+
+// Mock usePermissions
+const mockUsePermissions = vi.fn()
+vi.mock('@/ui/hooks/use-permissions', () => ({
+  usePermissions: () => mockUsePermissions(),
+}))
+
+// Mock useNavigate
+const mockNavigate = vi.fn()
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+}))
+
+describe('AgentsMdEditor Component', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+    mockUsePermissions.mockReturnValue({
+      role: 'owner',
+      canEdit: true,
+      canAdmin: true,
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('renders loading state initially', async () => {
+    const { client } = await import('@/ui/api/client')
+    const getMock = client.api.folders[':folderId'].agentsmd.$get as unknown as ReturnType<
+      typeof vi.fn
+    >
+    getMock.mockImplementation(() => new Promise(() => {}))
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AgentsMdEditor projectId="proj-1" assetId="folder-1" rootFolderId="folder-1" isRoot />
+      </QueryClientProvider>,
+    )
+
+    expect(screen.getByText(m.agents_md_loading())).toBeDefined()
+  })
+
+  it('renders editable editor for team owner', async () => {
+    const { client } = await import('@/ui/api/client')
+    const getMock = client.api.folders[':folderId'].agentsmd.$get as unknown as ReturnType<
+      typeof vi.fn
+    >
+    getMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: '# Instructions' }),
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AgentsMdEditor projectId="proj-1" assetId="folder-1" rootFolderId="folder-1" isRoot />
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toBeDefined()
+    })
+    expect(screen.queryByText(m.agents_md_readonly_hint())).toBeNull()
+  })
+
+  it('renders read-only notice and restricts editing for non-owner', async () => {
+    mockUsePermissions.mockReturnValue({
+      role: 'editor',
+      canEdit: true,
+      canAdmin: false,
+    })
+
+    const { client } = await import('@/ui/api/client')
+    const getMock = client.api.folders[':folderId'].agentsmd.$get as unknown as ReturnType<
+      typeof vi.fn
+    >
+    getMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: '# Instructions' }),
+    })
+
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <AgentsMdEditor projectId="proj-1" assetId="folder-1" rootFolderId="folder-1" isRoot />
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(m.agents_md_readonly_hint())).toBeDefined()
+    })
+
+    expect(container.querySelector('.read-only')).toBeDefined()
+  })
+
+  it('displays the friendly multiline placeholder when content is empty', async () => {
+    const { client } = await import('@/ui/api/client')
+    const getMock = client.api.folders[':folderId'].agentsmd.$get as unknown as ReturnType<
+      typeof vi.fn
+    >
+    getMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: null }),
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AgentsMdEditor projectId="proj-1" assetId="folder-1" rootFolderId="folder-1" isRoot />
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/parent folders up to the project level/)).toBeDefined()
+    })
+  })
+})

--- a/packages/webui/components/agents-md/agents-md-editor.tsx
+++ b/packages/webui/components/agents-md/agents-md-editor.tsx
@@ -168,7 +168,7 @@ export function AgentsMdEditor({ projectId, assetId, rootFolderId, isRoot }: Age
   }
 
   const rightToolbarContent = (
-    <div className="flex items-center gap-2 shrink-0">
+    <div className="flex items-center justify-between w-full gap-2 shrink-0">
       {canAdmin ? (
         <div className="flex items-center gap-1.5 text-xs shrink-0">
           {(saveStatus === 'saving' || isClosing) && (
@@ -192,27 +192,29 @@ export function AgentsMdEditor({ projectId, assetId, rootFolderId, isRoot }: Age
         </div>
       ) : (
         <div
-          className="inline-flex items-center gap-1 text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded-md shrink-0"
+          className="inline-flex items-center gap-1.5 text-xs text-muted-foreground bg-muted/60 px-2.5 py-1 rounded-md shrink-0"
           title={m.agents_md_readonly_hint()}
         >
-          <Lock className="h-3 w-3 shrink-0" />
-          <span>{m.read_only()}</span>
+          <Lock className="h-3.5 w-3.5 shrink-0" />
+          <span>{m.agents_md_readonly_hint()}</span>
         </div>
       )}
 
-      <Separator orientation="vertical" className="h-4 shrink-0" />
+      <div className="flex items-center gap-2 shrink-0">
+        {canAdmin && <Separator orientation="vertical" className="h-4 shrink-0" />}
 
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={handleClose}
-        disabled={isClosing}
-        className="h-7 px-2.5 hover:bg-muted text-muted-foreground hover:text-foreground shrink-0"
-        title={m.close()}
-      >
-        <X className="h-4 w-4 mr-1 shrink-0" />
-        <span>{m.close()}</span>
-      </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleClose}
+          disabled={isClosing}
+          className="h-7 px-2.5 hover:bg-muted text-muted-foreground hover:text-foreground shrink-0"
+          title={m.close()}
+        >
+          <X className="h-4 w-4 mr-1 shrink-0" />
+          <span>{m.close()}</span>
+        </Button>
+      </div>
     </div>
   )
 

--- a/packages/webui/components/markdown-editor/markdown-editor.css
+++ b/packages/webui/components/markdown-editor/markdown-editor.css
@@ -97,10 +97,13 @@
   position: absolute;
   top: 16px;
   left: 16px;
+  right: 16px;
   color: var(--muted-foreground, #94a3b8);
   pointer-events: none;
   user-select: none;
   font-size: 15px;
+  line-height: 1.7;
+  white-space: pre-wrap;
 }
 
 /* Typography styles in WYSIWYG mode */

--- a/packages/webui/components/markdown-editor/markdown-editor.tsx
+++ b/packages/webui/components/markdown-editor/markdown-editor.tsx
@@ -132,7 +132,7 @@ export function MarkdownEditor({
         {!readOnly && !hideToolbar ? (
           <ToolbarPlugin rightContent={rightToolbarContent} />
         ) : rightToolbarContent ? (
-          <div className="shumai-editor-toolbar flex items-center justify-end px-3 py-1.5 border-b">
+          <div className="shumai-editor-toolbar flex items-center justify-between px-3 py-1.5 border-b">
             {rightToolbarContent}
           </div>
         ) : null}

--- a/packages/webui/messages/en.json
+++ b/packages/webui/messages/en.json
@@ -1039,8 +1039,8 @@
   "saved": "Saved",
   "read_only": "Read-only",
   "agents_md": "AGENTS.md",
-  "agents_md_placeholder": "Write guidelines and instructions for AI agents here...",
-  "agents_md_readonly_hint": "Only project owners can edit AGENTS.md instructions.",
+  "agents_md_placeholder": "Give AI agents instructions and context for this project or folder.\n\nShumai automatically loads this file, along with AGENTS.md files from parent folders up to the project level, whenever an agent works here.\n\nUse it to define things like:\n- What this project or folder contains\n- Rules the agent should follow\n- Terminology, style, or workflow\n- How metadata and autofill should be generated",
+  "agents_md_readonly_hint": "Only team owners can edit this file.",
   "agents_md_save_failed": "Failed to save",
   "agents_md_loading": "Loading AGENTS.md..."
 }

--- a/packages/webui/messages/zh.json
+++ b/packages/webui/messages/zh.json
@@ -1039,8 +1039,8 @@
   "saved": "已保存",
   "read_only": "只读",
   "agents_md": "AGENTS.md",
-  "agents_md_placeholder": "在此处为 AI Agent 编写项目或文件夹指引...",
-  "agents_md_readonly_hint": "只有项目所有者可以编辑 AGENTS.md 指引。",
+  "agents_md_placeholder": "为在此项目或文件夹中工作的 AI Agent 提供指引和上下文。\n\n当 Agent 在此处工作时，Shumai 会自动加载此文件以及向上追溯至项目根目录各级父文件夹中的 AGENTS.md 文件。\n\n您可以用它来定义：\n- 此项目或文件夹包含的内容\n- Agent 应当遵守的规则\n- 术语、风格或工作流规范\n- 元数据和自动填充的生成方式",
+  "agents_md_readonly_hint": "只有团队所有者可以修改此文件。",
   "agents_md_save_failed": "保存失败",
   "agents_md_loading": "正在加载 AGENTS.md..."
 }

--- a/packages/webui/paraglide/messages/agents_md_placeholder.d.ts
+++ b/packages/webui/paraglide/messages/agents_md_placeholder.d.ts
@@ -1,7 +1,7 @@
 /**
 * | output |
 * | --- |
-* | "Write guidelines and instructions for AI agents here..." |
+* | "Give AI agents instructions and context for this project or folder. Shumai automatically loads this file, along with AGENTS.md files from parent folders up t..." |
 *
 * @param {Agents_Md_PlaceholderInputs} inputs
 * @param {{ locale?: "en" | "zh" }} options

--- a/packages/webui/paraglide/messages/agents_md_placeholder.js
+++ b/packages/webui/paraglide/messages/agents_md_placeholder.js
@@ -6,17 +6,33 @@ import { getLocale, experimentalStaticLocale } from '../runtime.js';
 /** @typedef {{}} Agents_Md_PlaceholderInputs */
 
 const en_agents_md_placeholder = /** @type {(inputs: Agents_Md_PlaceholderInputs) => LocalizedString} */ () => {
-	return /** @type {LocalizedString} */ (`Write guidelines and instructions for AI agents here...`)
+	return /** @type {LocalizedString} */ (`Give AI agents instructions and context for this project or folder.
+
+Shumai automatically loads this file, along with AGENTS.md files from parent folders up to the project level, whenever an agent works here.
+
+Use it to define things like:
+- What this project or folder contains
+- Rules the agent should follow
+- Terminology, style, or workflow
+- How metadata and autofill should be generated`)
 };
 
 const zh_agents_md_placeholder = /** @type {(inputs: Agents_Md_PlaceholderInputs) => LocalizedString} */ () => {
-	return /** @type {LocalizedString} */ (`在此处为 AI Agent 编写项目或文件夹指引...`)
+	return /** @type {LocalizedString} */ (`为在此项目或文件夹中工作的 AI Agent 提供指引和上下文。
+
+当 Agent 在此处工作时，Shumai 会自动加载此文件以及向上追溯至项目根目录各级父文件夹中的 AGENTS.md 文件。
+
+您可以用它来定义：
+- 此项目或文件夹包含的内容
+- Agent 应当遵守的规则
+- 术语、风格或工作流规范
+- 元数据和自动填充的生成方式`)
 };
 
 /**
 * | output |
 * | --- |
-* | "Write guidelines and instructions for AI agents here..." |
+* | "Give AI agents instructions and context for this project or folder. Shumai automatically loads this file, along with AGENTS.md files from parent folders up t..." |
 *
 * @param {Agents_Md_PlaceholderInputs} inputs
 * @param {{ locale?: "en" | "zh" }} options

--- a/packages/webui/paraglide/messages/agents_md_readonly_hint.d.ts
+++ b/packages/webui/paraglide/messages/agents_md_readonly_hint.d.ts
@@ -1,7 +1,7 @@
 /**
 * | output |
 * | --- |
-* | "Only project owners can edit AGENTS.md instructions." |
+* | "Only team owners can edit this file." |
 *
 * @param {Agents_Md_Readonly_HintInputs} inputs
 * @param {{ locale?: "en" | "zh" }} options

--- a/packages/webui/paraglide/messages/agents_md_readonly_hint.js
+++ b/packages/webui/paraglide/messages/agents_md_readonly_hint.js
@@ -6,17 +6,17 @@ import { getLocale, experimentalStaticLocale } from '../runtime.js';
 /** @typedef {{}} Agents_Md_Readonly_HintInputs */
 
 const en_agents_md_readonly_hint = /** @type {(inputs: Agents_Md_Readonly_HintInputs) => LocalizedString} */ () => {
-	return /** @type {LocalizedString} */ (`Only project owners can edit AGENTS.md instructions.`)
+	return /** @type {LocalizedString} */ (`Only team owners can edit this file.`)
 };
 
 const zh_agents_md_readonly_hint = /** @type {(inputs: Agents_Md_Readonly_HintInputs) => LocalizedString} */ () => {
-	return /** @type {LocalizedString} */ (`只有项目所有者可以编辑 AGENTS.md 指引。`)
+	return /** @type {LocalizedString} */ (`只有团队所有者可以修改此文件。`)
 };
 
 /**
 * | output |
 * | --- |
-* | "Only project owners can edit AGENTS.md instructions." |
+* | "Only team owners can edit this file." |
 *
 * @param {Agents_Md_Readonly_HintInputs} inputs
 * @param {{ locale?: "en" | "zh" }} options


### PR DESCRIPTION
## Summary

Enhance the AGENTS.md editor UX with an informative multi-line placeholder explaining AGENTS.md inheritance (traversing up to the project level) and usage, clarify in read-only mode that only team owners can edit this file, and add documentation under "Shumai Agent Settings".

## Changes

- Updated `agents_md_placeholder` in `en.json` and `zh.json` to clearly describe the role of `AGENTS.md`, hierarchy traversal up to the project root, and key guidelines to define.
- Updated `agents_md_readonly_hint` to specify that only team owners can edit the file.
- Updated `.editor-placeholder` CSS in `markdown-editor.css` to enable `white-space: pre-wrap;` and consistent line height for multi-line formatted placeholders.
- Updated `AgentsMdEditor` read-only toolbar layout to prominently display the read-only notice with the lock icon.
- Added unit tests in `agents-md-editor.test.tsx`.
- Added documentation page `docs/using-shumai/agents-md.mdx` and registered it in `docs/docs.json` under the "Shumai Agent Settings" group.

## Verification

- `bun run lint` (passed)
- `bun run format` (passed)
- `bun run typecheck` (passed)
- `bun run test` (1101 passed)
- `bun run test:e2e:app` (30 passed)
- `bun run test:e2e:webui` (9 passed)
- `bun run test:e2e:workflow` (58 passed)

## Notes

None.