### PR TITLE
fix(core): rename latest version child record on version stack rename

### DIFF
--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -1245,9 +1245,7 @@ export async function executeAgentToolActivity(params: ExecuteAgentToolParams): 
         { first: limit, after },
       )
 
-      const stackIds = assets
-        .filter((a) => a.type === AssetType.version_stack && (!a.name || a.name === ''))
-        .map((a) => a.id)
+      const stackIds = assets.filter((a) => a.type === AssetType.version_stack).map((a) => a.id)
 
       const latestVersionsMap = new Map<string, Prisma.AssetGetPayload<Record<string, never>>>()
 
@@ -1268,10 +1266,7 @@ export async function executeAgentToolActivity(params: ExecuteAgentToolParams): 
         const latestVersion = latestVersionsMap.get(a.id)
         return {
           id: a.id,
-          name:
-            a.type === AssetType.version_stack && (!a.name || a.name === '')
-              ? (latestVersion?.name ?? a.name)
-              : a.name,
+          name: a.type === AssetType.version_stack ? (latestVersion?.name ?? a.name) : a.name,
           type: a.type,
           size:
             a.type === AssetType.version_stack && latestVersion

--- a/packages/core/src/asset/asset.test.ts
+++ b/packages/core/src/asset/asset.test.ts
@@ -3244,4 +3244,201 @@ describe('AssetService — natural sort by name', () => {
       expect(result.data[0].name).toBe(fileB.name) // fileB is the latest version
     })
   })
+
+  describe('updateAssetName', () => {
+    it('renames the latest version child file and returns updated AssetInfo when given a version stack ID', async () => {
+      const team = await prisma.team.create({ data: { name: 'Test Team ' + Date.now() } })
+      const project = await prisma.project.create({
+        data: { name: 'Test Project', teamId: team.id },
+      })
+      const rootFolder = await prisma.asset.create({
+        data: {
+          name: 'Root',
+          type: AssetType.folder,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+        },
+      })
+
+      const stack = await prisma.asset.create({
+        data: {
+          name: '',
+          type: AssetType.version_stack,
+          parentId: rootFolder.id,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+          fileCount: 2,
+          sizeByte: 300,
+        },
+      })
+
+      const fileV1 = await prisma.asset.create({
+        data: {
+          name: 'v1.mp4',
+          type: AssetType.file,
+          parentId: stack.id,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+          sizeByte: 100,
+          sortIndex: 'b0',
+        },
+      })
+
+      const fileV2 = await prisma.asset.create({
+        data: {
+          name: 'v2.mp4',
+          type: AssetType.file,
+          parentId: stack.id,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+          sizeByte: 200,
+          sortIndex: 'a0', // latest version
+        },
+      })
+
+      const updated = await assetService.updateAssetName({
+        id: stack.id,
+        name: 'v2-renamed.mp4',
+      })
+
+      expect(updated.id).toBe(stack.id)
+      expect(updated.name).toBe('v2-renamed.mp4')
+      expect(updated.versionStack?.versions[0]?.name).toBe('v2-renamed.mp4')
+
+      const dbFileV2 = await prisma.asset.findUnique({ where: { id: fileV2.id } })
+      expect(dbFileV2?.name).toBe('v2-renamed.mp4')
+
+      const dbFileV1 = await prisma.asset.findUnique({ where: { id: fileV1.id } })
+      expect(dbFileV1?.name).toBe('v1.mp4')
+
+      const dbStack = await prisma.asset.findUnique({ where: { id: stack.id } })
+      expect(dbStack?.name).toBe('')
+    })
+
+    it('preserves the renamed filename when a version stack dissolves', async () => {
+      const team = await prisma.team.create({ data: { name: 'Test Team ' + Date.now() } })
+      const project = await prisma.project.create({
+        data: { name: 'Test Project', teamId: team.id },
+      })
+      const rootFolder = await prisma.asset.create({
+        data: {
+          name: 'Root',
+          type: AssetType.folder,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+        },
+      })
+
+      const stack = await prisma.asset.create({
+        data: {
+          name: '',
+          type: AssetType.version_stack,
+          parentId: rootFolder.id,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+          fileCount: 2,
+          sizeByte: 300,
+          sortIndex: 's0',
+        },
+      })
+
+      const fileV1 = await prisma.asset.create({
+        data: {
+          name: 'v1.mp4',
+          type: AssetType.file,
+          parentId: stack.id,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+          sizeByte: 100,
+          sortIndex: 'b0',
+        },
+      })
+
+      const fileV2 = await prisma.asset.create({
+        data: {
+          name: 'v2.mp4',
+          type: AssetType.file,
+          parentId: stack.id,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+          sizeByte: 200,
+          sortIndex: 'a0',
+        },
+      })
+
+      await assetService.updateAssetName({
+        id: stack.id,
+        name: 'v2-renamed.mp4',
+      })
+
+      // Remove v1 from stack -> stack dissolves and v2 becomes standalone file
+      const { versionStackService } = await import('../versionStack/versionStack')
+      await versionStackService.removeVersionFromStack({
+        stackId: stack.id,
+        fileId: fileV1.id,
+      })
+
+      const remainingFile = await prisma.asset.findUnique({ where: { id: fileV2.id } })
+      expect(remainingFile?.parentId).toBe(rootFolder.id)
+      expect(remainingFile?.name).toBe('v2-renamed.mp4')
+    })
+
+    it('throws an error if version stack has no active versions to rename', async () => {
+      const team = await prisma.team.create({ data: { name: 'Test Team ' + Date.now() } })
+      const project = await prisma.project.create({
+        data: { name: 'Test Project', teamId: team.id },
+      })
+      const emptyStack = await prisma.asset.create({
+        data: {
+          name: '',
+          type: AssetType.version_stack,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+        },
+      })
+
+      await expect(
+        assetService.updateAssetName({
+          id: emptyStack.id,
+          name: 'new-name.mp4',
+        }),
+      ).rejects.toThrow('No active version found in stack to rename')
+    })
+
+    it('renames a regular file and folder correctly', async () => {
+      const team = await prisma.team.create({ data: { name: 'Test Team ' + Date.now() } })
+      const project = await prisma.project.create({
+        data: { name: 'Test Project', teamId: team.id },
+      })
+      const folder = await prisma.asset.create({
+        data: {
+          name: 'Original Folder',
+          type: AssetType.folder,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+        },
+      })
+      const file = await prisma.asset.create({
+        data: {
+          name: 'original.png',
+          type: AssetType.file,
+          parentId: folder.id,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+        },
+      })
+
+      const updatedFolder = await assetService.updateAssetName({
+        id: folder.id,
+        name: 'Renamed Folder',
+      })
+      expect(updatedFolder.name).toBe('Renamed Folder')
+
+      const updatedFile = await assetService.updateAssetName({
+        id: file.id,
+        name: 'renamed.png',
+      })
+      expect(updatedFile.name).toBe('renamed.png')
+    })
+  })
 })

--- a/packages/core/src/asset/asset.ts
+++ b/packages/core/src/asset/asset.ts
@@ -955,9 +955,42 @@ export class AssetService {
   }
 
   async updateAssetName(req: UpdateAssetNameRequest): Promise<AssetInfo> {
-    const asset = await this.prismaClient.asset.update({
+    const existing = await this.prismaClient.asset.findUnique({
       where: { id: req.id },
-      data: { name: req.name },
+      include: { target: true },
+    })
+    if (!existing) throw new Error('Asset not found')
+
+    let targetType = existing.type
+    let targetId = existing.id
+
+    if (existing.type === AssetType.symlink && existing.target) {
+      targetType = existing.target.type
+      targetId = existing.target.id
+    }
+
+    if (targetType === AssetType.version_stack) {
+      const latestChild = await this.prismaClient.asset.findFirst({
+        where: { parentId: targetId, isDeleted: false },
+        orderBy: { sortIndex: 'asc' },
+        select: { id: true },
+      })
+      if (!latestChild) {
+        throw new Error('No active version found in stack to rename')
+      }
+      await this.prismaClient.asset.update({
+        where: { id: latestChild.id },
+        data: { name: req.name },
+      })
+    } else {
+      await this.prismaClient.asset.update({
+        where: { id: req.id },
+        data: { name: req.name },
+      })
+    }
+
+    const asset = await this.prismaClient.asset.findUnique({
+      where: { id: req.id },
       include: {
         creator: true,
         metadataValues: true,
@@ -983,6 +1016,8 @@ export class AssetService {
         storageKey: true,
       },
     })
+    if (!asset) throw new Error('Asset not found')
+
     const infos = await this.toAssetInfos([asset as unknown as AssetWithIncludes])
     return infos[0]
   }


### PR DESCRIPTION
## Summary

Fixes an issue where renaming a version stack updated the container `version_stack` row rather than the active latest version child file asset record.

## Changes

- In `assetService.updateAssetName` (`packages/core/src/asset/asset.ts`), resolve the latest active child file record when renaming a version stack (or symlink to a version stack) and update the child's `name`.
- Throw a descriptive error if attempting to rename an empty version stack with zero active versions.
- Return the full `AssetInfo` of the requested version stack ID with updated name and version list.
- Clean up `packages/agent/src/activities/agent.ts` to uniformly resolve name and size from `latestVersion` for all version stacks.
- Add reproduction and regression tests in `packages/core/src/asset/asset.test.ts` verifying stack renaming, older version retention, container name invariance, and dissolved stack name preservation.

## Verification

All checks ran and passed simultaneously:
- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test` (118 files, 1115 tests passed)
- `bun run test:e2e:app` (34 tests passed)
- `bun run test:e2e:webui` (9 tests passed)
- `bun run test:e2e:workflow` (14 files, 58 tests passed)

## Notes

None.