### PR TITLE
feat(authz): enforce project-aware roles for agent/skill/mcp permissions

### DIFF
--- a/packages/agent/src/activities/agent.ts
+++ b/packages/agent/src/activities/agent.ts
@@ -5,7 +5,12 @@ import {
 } from '@earendil-works/pi-agent-core'
 import { type ImageContent } from '@earendil-works/pi-ai'
 import { assetService } from '@shumai/core/src/asset/asset'
-import { authzService, Permission, ResourceType } from '@shumai/core/src/authz/authz'
+import {
+  authzService,
+  Permission,
+  ResourceType,
+  resolveEffectiveRole,
+} from '@shumai/core/src/authz/authz'
 import { logger } from '@shumai/core/src/logger'
 import { mcpService } from '@shumai/core/src/mcp/mcp-service'
 import { metadataService } from '@shumai/core/src/metadata/metadata'
@@ -174,7 +179,12 @@ When creating a file or version, you may attach metadata (for example, the AI mo
   // sessions never receive MCP tools even if a server is assigned.
   const mcpTools =
     agent.type === 'chat'
-      ? await mcpService.buildAgentTools(params.agentId, params.teamId, params.userId)
+      ? await mcpService.buildAgentTools(
+          params.agentId,
+          params.teamId,
+          params.userId,
+          params.projectId,
+        )
       : []
 
   const { session, harness } = await createAgentSession({
@@ -888,6 +898,7 @@ export async function getAgentChatContextActivity(params: {
   teamId: string
   agentId: string
   userId?: string
+  projectId?: string
 }): Promise<AgentExecutionContext> {
   const team = await prisma.team.findUnique({
     where: { id: params.teamId },
@@ -916,16 +927,8 @@ export async function getAgentChatContextActivity(params: {
   }
 
   if (params.userId) {
-    const member = await prisma.teamMember.findUnique({
-      where: {
-        teamIdUserId: {
-          teamId: params.teamId,
-          userId: params.userId,
-        },
-      },
-      select: { role: true },
-    })
-    const userLevel = getRoleLevel(member?.role)
+    const effectiveRole = await resolveEffectiveRole(params.teamId, params.projectId, params.userId)
+    const userLevel = getRoleLevel(effectiveRole)
     const requiredLevel = getAgentRequiredLevel(agent.permission)
     if (userLevel < requiredLevel) {
       throw ApplicationFailure.create({
@@ -956,10 +959,22 @@ export async function getAgentChatContextActivity(params: {
     include: { models: true },
   })
 
-  // Only advertise skills that are explicitly enabled for this agent (agent_skills).
-  // Disabled skills must not be listed in the system prompt nor loadable via read_skill.
+  // Only advertise skills that are explicitly enabled for this agent (agent_skills)
+  // AND permitted for the requesting user's effective role. Disabled or
+  // un-permitted skills must not be listed in the system prompt nor loadable
+  // via read_skill (read_skill keeps its own permission check as a backstop).
   const enabledSkills = (agent.skills ?? []).map((as) => as.skill)
-  const enabledSkillIds = enabledSkills.map((s) => s.id)
+  let permittedSkills = enabledSkills
+  if (params.userId) {
+    const effectiveRole = await resolveEffectiveRole(params.teamId, params.projectId, params.userId)
+    if (!effectiveRole) {
+      permittedSkills = []
+    } else {
+      const userLevel = getRoleLevel(effectiveRole)
+      permittedSkills = enabledSkills.filter((s) => (getRoleLevel(s.permission) || 1) <= userLevel)
+    }
+  }
+  const enabledSkillIds = permittedSkills.map((s) => s.id)
 
   // Fetch the agent's assigned MCP servers
   const assignments = await prisma.agentMcpServer.findMany({
@@ -976,7 +991,7 @@ export async function getAgentChatContextActivity(params: {
   return {
     agent,
     dbProviders,
-    teamSkills: enabledSkills,
+    teamSkills: permittedSkills,
     mcpServers,
     enabledSkillIds,
     allowedDomains,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -325,6 +325,7 @@ export async function createAgentSession(params: CreateAgentSessionParams) {
     onEnvsAdded,
     restricted ? onSkillLoaded : undefined,
     enabledSkillIds,
+    projectId,
   )
 
   const systemTools: AgentTool[] = []

--- a/packages/agent/src/tools/read-skill.test.ts
+++ b/packages/agent/src/tools/read-skill.test.ts
@@ -307,6 +307,77 @@ describe('readSkillTool', () => {
         reviewerTool.execute('1', { skillId: ownerSkill.id }, undefined, undefined),
       ).rejects.toThrow('Permission denied')
     })
+
+    it('uses the effective project role for skill permission checks', async () => {
+      const team = await prisma.team.create({ data: { name: 'Project Skill Team' } })
+      const project = await prisma.project.create({ data: { name: 'Skill Proj', teamId: team.id } })
+      const editorSkill = await prisma.skill.create({
+        data: {
+          name: 'Editor Project Skill',
+          assetId: 'asset1',
+          hash: 'proj-editor-hash',
+          teamId: team.id,
+          permission: 'editor',
+        },
+      })
+
+      // Team editor demoted to project reviewer: denied inside the project
+      const demoted = await prisma.user.create({
+        data: { name: 'Demoted Skill', email: 'dem-skill@test.com' },
+      })
+      const demotedTm = await prisma.teamMember.create({
+        data: { teamId: team.id, userId: demoted.id, role: 'editor', scope: 'team' },
+      })
+      await prisma.projectMember.create({
+        data: { projectId: project.id, teamMemberId: demotedTm.id, role: 'reviewer' },
+      })
+
+      const demotedTool = createReadSkillTool(
+        demoted.id,
+        () => {},
+        undefined,
+        undefined,
+        project.id,
+      )
+      await expect(
+        demotedTool.execute('1', { skillId: editorSkill.id }, undefined, undefined),
+      ).rejects.toThrow('Permission denied')
+
+      // Project-scoped member invited as editor: allowed
+      const projEditor = await prisma.user.create({
+        data: { name: 'PE Skill', email: 'pe-skill@test.com' },
+      })
+      const projEditorTm = await prisma.teamMember.create({
+        data: { teamId: team.id, userId: projEditor.id, role: 'reviewer', scope: 'project' },
+      })
+      await prisma.projectMember.create({
+        data: { projectId: project.id, teamMemberId: projEditorTm.id, role: 'editor' },
+      })
+
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mocking node fs calls
+      vi.spyOn(fs, 'readFileSync').mockImplementation((path: any) => {
+        if (path.toString().endsWith('.hash')) return 'proj-editor-hash'
+        if (path.toString().endsWith('SKILL.md')) return '# Editor Project Skill Content'
+        return ''
+      })
+
+      const projEditorTool = createReadSkillTool(
+        projEditor.id,
+        () => {},
+        undefined,
+        undefined,
+        project.id,
+      )
+      const result = await projEditorTool.execute(
+        '1',
+        { skillId: editorSkill.id },
+        undefined,
+        undefined,
+      )
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((result.content[0] as any).text).toBe('# Editor Project Skill Content')
+    })
   })
 
   describe('onSkillLoaded callback', () => {

--- a/packages/agent/src/tools/read-skill.ts
+++ b/packages/agent/src/tools/read-skill.ts
@@ -2,6 +2,7 @@ import { prisma } from '@shumai/db'
 import { Type } from 'typebox'
 import { type AgentTool } from '@earendil-works/pi-agent-core'
 import { agentService } from '@shumai/core/src/agent/agent'
+import { resolveEffectiveRole } from '@shumai/core/src/authz/authz'
 
 const readSkillSchema = Type.Object({
   skillId: Type.String({ description: 'The ID of the skill to read' }),
@@ -18,6 +19,7 @@ export const createReadSkillTool = (
   onEnvsAdded: (envs: Record<string, string>) => void,
   onSkillLoaded?: () => Promise<void> | void,
   enabledSkillIds?: string[],
+  projectId?: string,
 ): AgentTool<typeof readSkillSchema, { skillId: string }> => ({
   name: 'read_skill',
   label: 'Read Agent Skill',
@@ -41,15 +43,10 @@ export const createReadSkillTool = (
     const requiredLevel = ROLE_HIERARCHY[skill.permission] || 1
 
     if (userId) {
-      const member = await prisma.teamMember.findUnique({
-        where: {
-          teamIdUserId: {
-            teamId: skill.teamId,
-            userId,
-          },
-        },
-      })
-      const userLevel = member ? ROLE_HIERARCHY[member.role] || 0 : 0
+      // Resolve the user's effective role for the project context (project
+      // override wins; project-scoped members without project access are denied).
+      const effectiveRole = await resolveEffectiveRole(skill.teamId, projectId, userId)
+      const userLevel = effectiveRole ? ROLE_HIERARCHY[effectiveRole] || 0 : 0
       if (userLevel < requiredLevel) {
         throw new Error(
           `Permission denied: Insufficient role to load skill "${skill.name}". Minimum required role is "${skill.permission}".`,

--- a/packages/agent/src/workflows/agent-chat.test.ts
+++ b/packages/agent/src/workflows/agent-chat.test.ts
@@ -118,6 +118,15 @@ describe('Agent Chat Workflow', () => {
     // Verify comment context fetched
     expect(mockActivities.getCommentActivity).toHaveBeenCalledWith('c1')
 
+    // Verify agent context fetched with the project context forwarded
+    // (required for project-aware role enforcement in the activity)
+    expect(mockActivities.getAgentChatContextActivity).toHaveBeenCalledWith({
+      teamId: 't1',
+      agentId: 'b1',
+      userId: undefined,
+      projectId: 'p1',
+    })
+
     // Verify placeholder comment created
     expect(mockActivities.createCommentActivity).toHaveBeenCalledWith({
       assetId: 'a1',

--- a/packages/agent/src/workflows/agent-chat.ts
+++ b/packages/agent/src/workflows/agent-chat.ts
@@ -115,6 +115,7 @@ export async function agentChat(task: WorkflowTask): Promise<void> {
       teamId,
       agentId: agentId,
       userId: payload.agent?.userId,
+      projectId: payload.projectId,
     })
 
     const pathContext = await executeActivity(

--- a/packages/api/src/agent.test.ts
+++ b/packages/api/src/agent.test.ts
@@ -3,6 +3,7 @@ import { HTTPException } from 'hono/http-exception'
 import { agentService } from '@shumai/core/src/agent/agent'
 import { authzService } from '@shumai/core/src/authz/authz'
 import { auditLogService } from '@shumai/core/src/auditLog/auditLog'
+import type { AgentInfo } from '@shumai/dtos'
 import app from './agent'
 
 vi.mock('@shumai/core/src/agent/agent')
@@ -13,6 +14,24 @@ vi.mock('@shumai/core/src/auditLog/auditLog', () => ({
   },
 }))
 
+/**
+ * Shape of the agent rows returned by the (mocked) service methods. Mirrors
+ * the real AgentInfoSource consumed by AgentService.toAgentInfo.
+ */
+interface MockAgentRow {
+  id: string
+  user: { name: string; image?: string | null }
+  type: string
+  enabled?: boolean
+  permission?: string
+  providerId?: string | null
+  modelId?: string | null
+  soul?: string | null
+  config?: { thinkingLevel?: string; systemPrompt?: string; deniedTools?: string[] }
+  skills?: Array<{ id: string; skillId: string; skill?: { id: string; name: string } }>
+  mcpServers?: Array<{ mcpServerId: string }>
+}
+
 describe('Agent API', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -21,6 +40,32 @@ describe('Agent API', () => {
       id: 'agent1',
       teamId: 'team1',
     } as unknown as Awaited<ReturnType<typeof agentService.getAgent>>)
+
+    // The route delegates AgentInfo mapping to the service; replicate the real
+    // mapping so response assertions keep working.
+    vi.mocked(agentService.toAgentInfo).mockImplementation(async (agent) => {
+      const config = agent.config as MockAgentRow['config']
+      return {
+        id: agent.id,
+        name: agent.user.name,
+        type: agent.type,
+        enabled: agent.enabled ?? true,
+        permission: agent.permission ?? 'reviewer',
+        avatar: agent.user.image || undefined,
+        providerId: agent.providerId || undefined,
+        modelId: agent.modelId || undefined,
+        thinkingLevel: config?.thinkingLevel || 'off',
+        systemPrompt: config?.systemPrompt,
+        soul: agent.soul || undefined,
+        skills: (agent.skills || []).map((s) => ({
+          id: s.id,
+          skillId: s.skillId,
+          skill: s.skill,
+        })),
+        mcpServerIds: (agent.mcpServers || []).map((m) => m.mcpServerId),
+        deniedTools: config?.deniedTools || [],
+      } as unknown as AgentInfo
+    })
   })
 
   describe('GET /teams/:teamId/agents', () => {
@@ -314,6 +359,55 @@ describe('Agent API', () => {
         type: 'team',
         id: 'team1',
       })
+    })
+  })
+
+  describe('GET /projects/:projectId/chat-agents', () => {
+    it('returns project-scoped chat agents for the user', async () => {
+      const mockAgents = [
+        {
+          id: 'agent1',
+          name: 'Chat Bot',
+          type: 'chat',
+          enabled: true,
+          permission: 'reviewer',
+          skills: [],
+          mcpServerIds: [],
+          deniedTools: [],
+        },
+      ]
+      vi.mocked(agentService.listProjectChatAgents).mockResolvedValue(
+        mockAgents as unknown as Awaited<ReturnType<typeof agentService.listProjectChatAgents>>,
+      )
+
+      const res = await app.request('/projects/project1/chat-agents', {
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      expect(res.status).toBe(200)
+      const data = await res.json()
+      expect(data).toHaveLength(1)
+      expect(data[0].name).toBe('Chat Bot')
+      expect(authzService.hasPermission).toHaveBeenCalledWith({
+        user: undefined,
+        permission: 'Read',
+        type: 'project',
+        id: 'project1',
+      })
+      expect(agentService.listProjectChatAgents).toHaveBeenCalledWith('project1', undefined)
+    })
+
+    it('denies access when the user has no project access', async () => {
+      vi.mocked(authzService.hasPermission).mockRejectedValue(
+        new HTTPException(403, { message: 'Forbidden' }),
+      )
+
+      const res = await app.request('/projects/project1/chat-agents', {
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      expect(res.status).toBe(403)
+      expect(agentService.listProjectChatAgents).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -2,14 +2,12 @@ import { Hono } from 'hono'
 import { zValidator } from '@hono/zod-validator'
 import { agentService } from '@shumai/core/src/agent/agent'
 import { authzService, Permission, ResourceType } from '@shumai/core/src/authz/authz'
-import { getAvatarUrl } from '@shumai/core/src/user/avatar'
 import {
   createAgentRequestSchema,
   updateAgentRequestSchema,
   updateAgentPermissionRequestSchema,
   paginationParamsSchema,
   AgentInfo,
-  AgentType,
   AuditAction,
 } from '@shumai/dtos'
 
@@ -33,32 +31,24 @@ const route = new Hono<{ Variables: { user: User } }>()
     const agents = await agentService.listAgents({ teamId, userId: userReq?.id })
 
     const res: AgentInfo[] = await Promise.all(
-      agents.map(async (agent) => {
-        const config = agent.config as unknown as PrismaJson.AgentConfig
-        return {
-          id: agent.id,
-          name: agent.user.name,
-          type: agent.type as AgentType,
-          enabled: agent.enabled,
-          permission: agent.permission,
-          avatar: (await getAvatarUrl(agent.user.image)) || undefined,
-          providerId: agent.providerId || undefined,
-          modelId: agent.modelId || undefined,
-          thinkingLevel: config.thinkingLevel || 'off',
-          systemPrompt: config.systemPrompt,
-          soul: agent.soul || undefined,
-          skills: agent.skills.map((s) => ({
-            id: s.id,
-            skillId: s.skillId,
-            skill: s.skill,
-          })),
-          mcpServerIds: (agent.mcpServers || []).map((m) => m.mcpServerId),
-          deniedTools: config.deniedTools || [],
-        }
-      }),
+      agents.map((agent) => agentService.toAgentInfo(agent)),
     )
 
     return c.json(res, 200)
+  })
+  .get('/projects/:projectId/chat-agents', async (c) => {
+    const projectId = c.req.param('projectId')
+    const userReq = c.get('user')
+
+    await authzService.hasPermission({
+      user: userReq,
+      permission: Permission.Read,
+      type: ResourceType.Project,
+      id: projectId,
+    })
+
+    const agents = await agentService.listProjectChatAgents(projectId, userReq?.id)
+    return c.json(agents, 200)
   })
   .post('/teams/:teamId/agents', zValidator('json', createAgentRequestSchema), async (c) => {
     const teamId = c.req.param('teamId')
@@ -79,27 +69,7 @@ const route = new Hono<{ Variables: { user: User } }>()
 
     if (!agent) throw new Error('failed to create agent')
 
-    const config = agent.config as unknown as PrismaJson.AgentConfig
-    const info: AgentInfo = {
-      id: agent.id,
-      name: agent.user.name,
-      type: agent.type as AgentType,
-      enabled: agent.enabled,
-      permission: agent.permission,
-      avatar: (await getAvatarUrl(agent.user.image)) || undefined,
-      providerId: agent.providerId || undefined,
-      modelId: agent.modelId || undefined,
-      thinkingLevel: config.thinkingLevel || 'off',
-      systemPrompt: config.systemPrompt,
-      soul: agent.soul || undefined,
-      skills: agent.skills.map((s) => ({
-        id: s.id,
-        skillId: s.skillId,
-        skill: s.skill,
-      })),
-      mcpServerIds: (agent.mcpServers || []).map((m) => m.mcpServerId),
-      deniedTools: config.deniedTools || [],
-    }
+    const info = await agentService.toAgentInfo(agent)
 
     await auditLogService.logAction({
       action: AuditAction.agent_create,
@@ -134,27 +104,7 @@ const route = new Hono<{ Variables: { user: User } }>()
       itemId: agent.id,
     })
 
-    const config = agent.config as unknown as PrismaJson.AgentConfig
-    const info: AgentInfo = {
-      id: agent.id,
-      name: agent.user.name,
-      type: agent.type as AgentType,
-      enabled: agent.enabled,
-      permission: agent.permission,
-      avatar: (await getAvatarUrl(agent.user.image)) || undefined,
-      providerId: agent.providerId || undefined,
-      modelId: agent.modelId || undefined,
-      thinkingLevel: config.thinkingLevel || 'off',
-      systemPrompt: config.systemPrompt,
-      soul: agent.soul || undefined,
-      skills: agent.skills.map((s) => ({
-        id: s.id,
-        skillId: s.skillId,
-        skill: s.skill,
-      })),
-      mcpServerIds: (agent.mcpServers || []).map((m) => m.mcpServerId),
-      deniedTools: config.deniedTools || [],
-    }
+    const info = await agentService.toAgentInfo(agent)
 
     return c.json(info, 200)
   })
@@ -182,27 +132,7 @@ const route = new Hono<{ Variables: { user: User } }>()
         itemId: agent.id,
       })
 
-      const config = agent.config as unknown as PrismaJson.AgentConfig
-      const info: AgentInfo = {
-        id: agent.id,
-        name: agent.user.name,
-        type: agent.type as AgentType,
-        enabled: agent.enabled,
-        permission: agent.permission,
-        avatar: (await getAvatarUrl(agent.user.image)) || undefined,
-        providerId: agent.providerId || undefined,
-        modelId: agent.modelId || undefined,
-        thinkingLevel: config.thinkingLevel || 'off',
-        systemPrompt: config.systemPrompt,
-        soul: agent.soul || undefined,
-        skills: agent.skills.map((s) => ({
-          id: s.id,
-          skillId: s.skillId,
-          skill: s.skill,
-        })),
-        mcpServerIds: (agent.mcpServers || []).map((m) => m.mcpServerId),
-        deniedTools: config.deniedTools || [],
-      }
+      const info = await agentService.toAgentInfo(agent)
 
       return c.json(info, 200)
     },

--- a/packages/api/src/project.ts
+++ b/packages/api/src/project.ts
@@ -241,6 +241,7 @@ const route = new Hono<{ Variables: { user: User } }>()
     const members = await projectService.listProjectMembers({
       projectId,
       includeAgents: includeAgents,
+      requesterUserId: user.id,
     })
     return c.json(members)
   })

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -539,5 +539,150 @@ describe('AgentService', () => {
       expect(ownerAgentIds).toContain(editorAgent!.id)
       expect(ownerAgentIds).toContain(ownerAgent!.id)
     })
+
+    test('listProjectChatAgents filters by effective project role and chat/enabled only', async () => {
+      const db = prisma
+      const svc = new AgentService()
+      const { team, provider, model } = await setupTestData(db)
+
+      const project = await db.project.create({
+        data: { name: 'Proj Agents', teamId: team.id },
+      })
+
+      // Two chat agents + one disabled chat agent + one embedding agent
+      const reviewerAgent = await svc.createAgent({
+        teamId: team.id,
+        name: 'Reviewer Chat',
+        type: 'chat',
+        enabled: true,
+        thinkingLevel: 'off',
+        permission: 'reviewer',
+        providerId: provider.id,
+        modelId: model.id,
+      })
+      const editorAgent = await svc.createAgent({
+        teamId: team.id,
+        name: 'Editor Chat',
+        type: 'chat',
+        enabled: true,
+        thinkingLevel: 'off',
+        permission: 'editor',
+        providerId: provider.id,
+        modelId: model.id,
+      })
+      const disabledAgent = await svc.createAgent({
+        teamId: team.id,
+        name: 'Disabled Chat',
+        type: 'chat',
+        enabled: false,
+        thinkingLevel: 'off',
+        permission: 'reviewer',
+        providerId: provider.id,
+        modelId: model.id,
+      })
+
+      // Team reviewer, promoted to project owner in this project
+      const projectOwner = await db.user.create({
+        data: { name: 'Proj Owner', email: 'projowner@shumai.ai' },
+      })
+      const projectOwnerTm = await db.teamMember.create({
+        data: { teamId: team.id, userId: projectOwner.id, role: 'reviewer', scope: 'team' },
+      })
+      await db.projectMember.create({
+        data: { projectId: project.id, teamMemberId: projectOwnerTm.id, role: 'owner' },
+      })
+
+      const list = await svc.listProjectChatAgents(project.id, projectOwner.id)
+      const ids = list.map((a) => a.id)
+      expect(ids).toContain(reviewerAgent!.id)
+      expect(ids).toContain(editorAgent!.id)
+      expect(ids).not.toContain(disabledAgent!.id)
+      expect(list.every((a) => a.type === 'chat')).toBe(true)
+      expect(list.every((a) => a.enabled)).toBe(true)
+    })
+
+    test('listProjectChatAgents restricts project-scoped members to their project role', async () => {
+      const db = prisma
+      const svc = new AgentService()
+      const { team, provider, model } = await setupTestData(db)
+
+      const project = await db.project.create({
+        data: { name: 'Proj Guest', teamId: team.id },
+      })
+
+      const reviewerAgent = await svc.createAgent({
+        teamId: team.id,
+        name: 'Reviewer Chat',
+        type: 'chat',
+        enabled: true,
+        thinkingLevel: 'off',
+        permission: 'reviewer',
+        providerId: provider.id,
+        modelId: model.id,
+      })
+      const editorAgent = await svc.createAgent({
+        teamId: team.id,
+        name: 'Editor Chat',
+        type: 'chat',
+        enabled: true,
+        thinkingLevel: 'off',
+        permission: 'editor',
+        providerId: provider.id,
+        modelId: model.id,
+      })
+
+      // Project-scoped member invited as reviewer in this project
+      const guest = await db.user.create({
+        data: { name: 'Guest', email: 'guest@shumai.ai' },
+      })
+      const guestTm = await db.teamMember.create({
+        data: { teamId: team.id, userId: guest.id, role: 'reviewer', scope: 'project' },
+      })
+      await db.projectMember.create({
+        data: { projectId: project.id, teamMemberId: guestTm.id, role: 'reviewer' },
+      })
+
+      const ids = (await svc.listProjectChatAgents(project.id, guest.id)).map((a) => a.id)
+      expect(ids).toContain(reviewerAgent!.id)
+      expect(ids).not.toContain(editorAgent!.id)
+    })
+
+    test('listProjectChatAgents returns empty for users outside the project', async () => {
+      const db = prisma
+      const svc = new AgentService()
+      const { team, provider, model } = await setupTestData(db)
+
+      const project = await db.project.create({
+        data: { name: 'Proj Closed', teamId: team.id },
+      })
+      const projectB = await db.project.create({
+        data: { name: 'Proj Other', teamId: team.id },
+      })
+
+      await svc.createAgent({
+        teamId: team.id,
+        name: 'Reviewer Chat',
+        type: 'chat',
+        enabled: true,
+        thinkingLevel: 'off',
+        permission: 'reviewer',
+        providerId: provider.id,
+        modelId: model.id,
+      })
+
+      // Project-scoped member of projectB only
+      const guest = await db.user.create({
+        data: { name: 'Guest B', email: 'guestb@shumai.ai' },
+      })
+      const guestTm = await db.teamMember.create({
+        data: { teamId: team.id, userId: guest.id, role: 'reviewer', scope: 'project' },
+      })
+      await db.projectMember.create({
+        data: { projectId: projectB.id, teamMemberId: guestTm.id, role: 'reviewer' },
+      })
+
+      const ids = (await svc.listProjectChatAgents(project.id, guest.id)).map((a) => a.id)
+      expect(ids).toHaveLength(0)
+    })
   })
 })

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1,10 +1,12 @@
-import { prisma, type Prisma } from '@shumai/db'
+import { prisma, type Prisma, type TeamMemberRole } from '@shumai/db'
 import {
   CreateAgentParams,
   DeleteAgentParams,
   ListAgentsParams,
   UpdateAgentParams,
   AgentSessionInfo,
+  AgentInfo,
+  AgentType,
 } from '@shumai/dtos'
 import {
   paginateQuery,
@@ -14,10 +16,34 @@ import {
 import '@shumai/db/src/prisma-json-types'
 import { s3Service } from '@shumai/core/src/s3/s3'
 import { getAvatarUrl } from '@shumai/core/src/user/avatar'
+import { resolveEffectiveRole } from '@shumai/core/src/authz/authz'
 import { getAllowedAgentRoles } from './permissions'
 import AdmZip from 'adm-zip'
 import * as fs from 'fs'
 import * as path from 'path'
+
+const agentInclude = {
+  user: true,
+  provider: true,
+  modelRef: true,
+  skills: { include: { skill: true } },
+  mcpServers: true,
+} satisfies Prisma.AgentInclude
+
+/** Structural shape consumed by `toAgentInfo` (works with any standard include). */
+interface AgentInfoSource {
+  id: string
+  type: AgentType
+  enabled: boolean
+  permission: TeamMemberRole
+  providerId: string | null
+  modelId: string | null
+  config: unknown
+  soul: string | null
+  user: { name: string; image: string | null }
+  skills: Array<{ id: string; skillId: string; skill: { id: string; name: string } }>
+  mcpServers: Array<{ mcpServerId: string }>
+}
 
 function extractS3Key(urlOrKey?: string | null): string | null | undefined {
   if (!urlOrKey) return urlOrKey
@@ -374,6 +400,65 @@ export class AgentService {
     await this.prismaClient.user.delete({
       where: { id: agentId },
     })
+  }
+
+  /**
+   * Map an agent (with the standard relations include) to the AgentInfo DTO.
+   * Shared by the team-level agent list and the project-scoped chat-agent list.
+   */
+  async toAgentInfo(agent: AgentInfoSource): Promise<AgentInfo> {
+    const config = agent.config as unknown as PrismaJson.AgentConfig
+    return {
+      id: agent.id,
+      name: agent.user.name,
+      type: agent.type as AgentType,
+      enabled: agent.enabled,
+      permission: agent.permission,
+      avatar: (await getAvatarUrl(agent.user.image)) || undefined,
+      providerId: agent.providerId || undefined,
+      modelId: agent.modelId || undefined,
+      thinkingLevel: config.thinkingLevel || 'off',
+      systemPrompt: config.systemPrompt,
+      soul: agent.soul || undefined,
+      skills: agent.skills.map((s) => ({
+        id: s.id,
+        skillId: s.skillId,
+        skill: s.skill,
+      })),
+      mcpServerIds: (agent.mcpServers || []).map((m) => m.mcpServerId),
+      deniedTools: config.deniedTools || [],
+    }
+  }
+
+  /**
+   * List the chat agents available to a user inside a specific project,
+   * resolved against the user's effective project role (project override wins;
+   * restricted users get an empty list). Used by the one-to-one chat selector.
+   */
+  async listProjectChatAgents(projectId: string, userId: string): Promise<AgentInfo[]> {
+    const project = await this.prismaClient.project.findUnique({
+      where: { id: projectId },
+      select: { teamId: true },
+    })
+    if (!project) return []
+
+    const effectiveRole = await resolveEffectiveRole(project.teamId, projectId, userId)
+    if (!effectiveRole) return []
+
+    const allowedRoles = getAllowedAgentRoles(effectiveRole)
+
+    const agents = await this.prismaClient.agent.findMany({
+      where: {
+        teamId: project.teamId,
+        type: 'chat',
+        enabled: true,
+        permission: { in: allowedRoles },
+      },
+      orderBy: { id: 'desc' },
+      include: agentInclude,
+    })
+
+    return Promise.all(agents.map((agent) => this.toAgentInfo(agent)))
   }
 
   async listAgents(params: ListAgentsParams) {

--- a/packages/core/src/asset/asset.test.ts
+++ b/packages/core/src/asset/asset.test.ts
@@ -1296,6 +1296,90 @@ describe('AssetService', () => {
     expect(tasks.length).toBe(0)
   })
 
+  it('uses the effective project role for bot mention permission checks', async () => {
+    const { project } = await setupBasicAssets()
+    const file = await prisma.asset.create({
+      data: {
+        name: 'perm-file-2',
+        type: AssetType.file,
+        projectId: project.id,
+        status: 'uploaded',
+      },
+    })
+
+    // Editor-permission chat agent
+    const editorBotUser = await prisma.user.create({
+      data: {
+        name: 'Editor Bot Agent',
+        type: 'agent',
+        email: `editor-bot-${Date.now()}@shumai.ai`,
+      },
+    })
+    const editorAgent = await prisma.agent.create({
+      data: {
+        id: editorBotUser.id,
+        teamId: project.teamId,
+        type: 'chat',
+        permission: 'editor',
+        config: { provider: 'p', model: 'm' },
+      },
+    })
+
+    // Team editor, demoted to project reviewer in this project
+    const demoted = await prisma.user.create({
+      data: { name: 'Demoted Member', email: `dem-${Date.now()}@shumai.ai`, password: 'pw' },
+    })
+    const demotedTm = await prisma.teamMember.create({
+      data: { teamId: project.teamId, userId: demoted.id, role: 'editor', scope: 'team' },
+    })
+    await prisma.projectMember.create({
+      data: { projectId: project.id, teamMemberId: demotedTm.id, role: 'reviewer' },
+    })
+
+    // Project-scoped member invited as editor
+    const projEditor = await prisma.user.create({
+      data: { name: 'Proj Editor', email: `pe-${Date.now()}@shumai.ai`, password: 'pw' },
+    })
+    const projEditorTm = await prisma.teamMember.create({
+      data: { teamId: project.teamId, userId: projEditor.id, role: 'reviewer', scope: 'project' },
+    })
+    await prisma.projectMember.create({
+      data: { projectId: project.id, teamMemberId: projEditorTm.id, role: 'editor' },
+    })
+
+    // Demoted team editor (project reviewer) mentioning the editor agent: no workflow
+    const demotedComment = await assetService.createComment({
+      assetId: file.id,
+      userId: demoted.id,
+      message: `Hello <@${editorAgent.id}>`,
+      attachmentIds: [],
+    })
+    const demotedTasks = await prisma.workflowTask.findMany({
+      where: {
+        assetId: file.id,
+        payload: { path: ['agent', 'userCommentId'], equals: demotedComment.id },
+      },
+    })
+    expect(demotedTasks.length).toBe(0)
+
+    // Project-scoped editor mentioning the editor agent: workflow created
+    const peComment = await assetService.createComment({
+      assetId: file.id,
+      userId: projEditor.id,
+      message: `Hello <@${editorAgent.id}>`,
+      attachmentIds: [],
+    })
+    const peTasks = await prisma.workflowTask.findMany({
+      where: {
+        assetId: file.id,
+        payload: { path: ['agent', 'userCommentId'], equals: peComment.id },
+      },
+    })
+    expect(peTasks.length).toBe(1)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((peTasks[0].payload as any)?.agent?.userId).toBe(projEditor.id)
+  })
+
   it('updates asset order correctly', async () => {
     const { user, project } = await setupBasicAssets()
 

--- a/packages/core/src/asset/asset.ts
+++ b/packages/core/src/asset/asset.ts
@@ -27,6 +27,7 @@ import { watermarkService } from '@shumai/core/src/watermark/watermark'
 import { generateKeyBetween } from 'jittered-fractional-indexing'
 import { getAvatarUrl } from '@shumai/core/src/user/avatar'
 import { getAgentRequiredLevel, getRoleLevel } from '@shumai/core/src/agent/permissions'
+import { resolveEffectiveRole } from '@shumai/core/src/authz/authz'
 
 type AssetWithIncludes = Prisma.AssetGetPayload<{
   include: {
@@ -1378,19 +1379,13 @@ export class AssetService {
       const mentionedAgentIds = new Set(botMentionMatches.map((match) => match[1]))
       const handledAgentIds = new Set<string>()
 
-      const member = a.project?.team
-        ? await tx.teamMember.findUnique({
-            where: {
-              teamIdUserId: {
-                teamId: a.project.team.id,
-                userId: req.userId,
-              },
-            },
-            select: { role: true },
-          })
+      // Effective role for the project context (project override wins; project-
+      // scoped members without project access resolve to null and are denied).
+      const effectiveRole = a.project?.team
+        ? await resolveEffectiveRole(a.project.team.id, a.project.id, req.userId, tx)
         : null
 
-      const userLevel = getRoleLevel(member?.role)
+      const userLevel = getRoleLevel(effectiveRole)
 
       if (parentComment && a.project) {
         const rootSessionId = parentComment.sessionId

--- a/packages/core/src/authz/authz.ts
+++ b/packages/core/src/authz/authz.ts
@@ -1,4 +1,4 @@
-import { prisma } from '@shumai/db'
+import { prisma, type TeamMemberRole } from '@shumai/db'
 import type { Prisma } from '@shumai/db'
 import { HTTPException } from 'hono/http-exception'
 
@@ -33,13 +33,70 @@ export interface AuthzRequest {
   id: string
 }
 
+type RoleDb = typeof prisma | Prisma.TransactionClient
+
+/**
+ * Resolve a user's effective role for a team/project context, mirroring the
+ * precedence rules enforced by `AuthzService.hasPermission`:
+ *
+ * 1. Project membership (`projectMember.role`) takes precedence inside a project.
+ * 2. Team-scoped members fall back to their team role when no project override exists.
+ * 3. Project-scoped members without a matching project record (or without a
+ *    project context) are restricted (`null`).
+ *
+ * Returns `null` for non-members as well, so callers can fail closed.
+ */
+export async function resolveEffectiveRole(
+  teamId: string,
+  projectId: string | undefined,
+  userId: string,
+  db: RoleDb = prisma,
+): Promise<TeamMemberRole | null> {
+  const member = await db.teamMember.findUnique({
+    where: {
+      teamIdUserId: {
+        teamId,
+        userId,
+      },
+    },
+  })
+  if (!member) return null
+
+  // Project membership takes precedence when operating inside a project.
+  if (projectId) {
+    const pm = await db.projectMember.findUnique({
+      where: {
+        projectIdTeamMemberId: {
+          projectId,
+          teamMemberId: member.id,
+        },
+      },
+    })
+    if (pm) return pm.role
+  }
+
+  // Team-scoped members fall back to their team role.
+  if (member.scope === 'team') return member.role
+
+  // Project-scoped members without a matching project record are restricted.
+  return null
+}
+
 export class AuthzService {
   async hasPermission(req: AuthzRequest): Promise<void> {
     if (!req.user) throw new HTTPException(401, { message: 'User is required' })
 
     const { teamId, projectId } = await this.resolveContext(req.type, req.id)
 
-    // 1. Check Team Membership
+    // Resolve the user's effective role using the shared precedence rules
+    // (project override -> team role for team-scoped members -> restricted).
+    const role = await resolveEffectiveRole(teamId, projectId, req.user.id)
+    if (role) {
+      return this.checkRole(role, req.permission)
+    }
+
+    // No effective role: either not a team member, or a project-scoped member
+    // without access to the resolved project context.
     const member = await prisma.teamMember.findUnique({
       where: {
         teamIdUserId: {
@@ -48,36 +105,12 @@ export class AuthzService {
         },
       },
     })
-
     if (!member) throw new HTTPException(403, { message: 'User is not a member of the team' })
 
-    // 2. Check Project Membership first if project context is available
-    if (projectId) {
-      const pm = await prisma.projectMember.findUnique({
-        where: {
-          projectIdTeamMemberId: {
-            projectId: projectId,
-            teamMemberId: member.id,
-          },
-        },
-      })
-      if (pm) {
-        return this.checkRole(pm.role, req.permission)
-      }
-    }
-
-    // 3. Fall back to Team scope checks
-    if (member.scope === 'team') {
-      return this.checkRole(member.role, req.permission)
-    }
-
-    // 4. Scope is Project, and no project-level record exists (or no project context was provided)
-    if (!projectId) {
-      // User has project scope but no project context provided (e.g. Team-level resource)
-      // If it's a team-level resource, project-scoped users can access Read (like ListProjects).
-      if (req.permission === Permission.Read) {
-        return
-      }
+    // Project-scoped member on a team-level resource (no project context):
+    // allow Read (e.g. listing), deny Edit/Admin.
+    if (!projectId && req.permission === Permission.Read) {
+      return
     }
     throw new HTTPException(403, { message: 'User has only project scope' })
   }

--- a/packages/core/src/authz/effective-role.test.ts
+++ b/packages/core/src/authz/effective-role.test.ts
@@ -1,0 +1,93 @@
+import { setupTestDbHooks } from '@shumai/db/test'
+import { describe, expect, it } from 'vitest'
+
+import { prisma } from '@shumai/db'
+import { resolveEffectiveRole } from '@shumai/core/src/authz/authz'
+
+describe('resolveEffectiveRole', () => {
+  setupTestDbHooks()
+
+  async function setupData() {
+    const team = await prisma.team.create({ data: { name: 'Role Team' } })
+    const projectA = await prisma.project.create({
+      data: { name: 'Project A', teamId: team.id },
+    })
+    const projectB = await prisma.project.create({
+      data: { name: 'Project B', teamId: team.id },
+    })
+
+    // Team-scoped owner
+    const owner = await prisma.user.create({ data: { name: 'Owner', email: 'o@x.com' } })
+    await prisma.teamMember.create({
+      data: { teamId: team.id, userId: owner.id, role: 'owner', scope: 'team' },
+    })
+
+    // Team-scoped reviewer, promoted to project owner in Project A
+    const promoted = await prisma.user.create({ data: { name: 'Promoted', email: 'p@x.com' } })
+    const promotedTm = await prisma.teamMember.create({
+      data: { teamId: team.id, userId: promoted.id, role: 'reviewer', scope: 'team' },
+    })
+    await prisma.projectMember.create({
+      data: { projectId: projectA.id, teamMemberId: promotedTm.id, role: 'owner' },
+    })
+
+    // Team-scoped editor, demoted to project reviewer in Project A
+    const demoted = await prisma.user.create({ data: { name: 'Demoted', email: 'd@x.com' } })
+    const demotedTm = await prisma.teamMember.create({
+      data: { teamId: team.id, userId: demoted.id, role: 'editor', scope: 'team' },
+    })
+    await prisma.projectMember.create({
+      data: { projectId: projectA.id, teamMemberId: demotedTm.id, role: 'reviewer' },
+    })
+
+    // Project-scoped member (invited to Project A only, as editor)
+    const guest = await prisma.user.create({ data: { name: 'Guest', email: 'g@x.com' } })
+    const guestTm = await prisma.teamMember.create({
+      data: { teamId: team.id, userId: guest.id, role: 'reviewer', scope: 'project' },
+    })
+    await prisma.projectMember.create({
+      data: { projectId: projectA.id, teamMemberId: guestTm.id, role: 'editor' },
+    })
+
+    // Non-member
+    const outsider = await prisma.user.create({ data: { name: 'Outsider', email: 'x@x.com' } })
+
+    return { team, projectA, projectB, owner, promoted, demoted, guest, outsider }
+  }
+
+  it('returns the team role for team-scoped members without a project override', async () => {
+    const { team, projectA, owner } = await setupData()
+    await expect(resolveEffectiveRole(team.id, projectA.id, owner.id)).resolves.toBe('owner')
+    await expect(resolveEffectiveRole(team.id, undefined, owner.id)).resolves.toBe('owner')
+  })
+
+  it('prefers the project override over the team role', async () => {
+    const { team, projectA, projectB, promoted, demoted } = await setupData()
+
+    // Promoted: team reviewer -> project owner
+    await expect(resolveEffectiveRole(team.id, projectA.id, promoted.id)).resolves.toBe('owner')
+    // Outside the overridden project, the team role applies
+    await expect(resolveEffectiveRole(team.id, projectB.id, promoted.id)).resolves.toBe('reviewer')
+
+    // Demoted: team editor -> project reviewer
+    await expect(resolveEffectiveRole(team.id, projectA.id, demoted.id)).resolves.toBe('reviewer')
+    await expect(resolveEffectiveRole(team.id, projectB.id, demoted.id)).resolves.toBe('editor')
+  })
+
+  it('resolves the project role for project-scoped members inside their project', async () => {
+    const { team, projectA, guest } = await setupData()
+    await expect(resolveEffectiveRole(team.id, projectA.id, guest.id)).resolves.toBe('editor')
+  })
+
+  it('restricts project-scoped members without a matching project record', async () => {
+    const { team, projectB, guest } = await setupData()
+    await expect(resolveEffectiveRole(team.id, projectB.id, guest.id)).resolves.toBeNull()
+    await expect(resolveEffectiveRole(team.id, undefined, guest.id)).resolves.toBeNull()
+  })
+
+  it('returns null for non-members', async () => {
+    const { team, projectA, outsider } = await setupData()
+    await expect(resolveEffectiveRole(team.id, projectA.id, outsider.id)).resolves.toBeNull()
+    await expect(resolveEffectiveRole(team.id, undefined, outsider.id)).resolves.toBeNull()
+  })
+})

--- a/packages/core/src/chat/chat.test.ts
+++ b/packages/core/src/chat/chat.test.ts
@@ -776,4 +776,129 @@ describe('ChatService', () => {
       )
     })
   })
+
+  describe('project-aware agent permission checks', () => {
+    async function setupProjectRoles() {
+      const team = await prisma.team.create({
+        data: {
+          name: 'Team Roles',
+          settings: { transcode: { videoStrategy: 'best_match' }, chatbotAgentId: 'test-agent-id' },
+          sandbox: { create: {} },
+        },
+      })
+      const project = await prisma.project.create({
+        data: { name: 'Proj Roles', teamId: team.id },
+      })
+      const rootFolder = await prisma.asset.create({
+        data: { name: 'root', type: 'root', status: 'processed', projectId: project.id },
+      })
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { rootFolderId: rootFolder.id },
+      })
+
+      const createAgent = async (name: string, permission: 'owner' | 'editor' | 'reviewer') => {
+        const agentUser = await prisma.user.create({
+          data: { name, email: `${name}-${Date.now()}@shumai.ai`, type: 'agent' },
+        })
+        return prisma.agent.create({
+          data: {
+            id: agentUser.id,
+            teamId: team.id,
+            type: 'chat',
+            permission,
+            config: { provider: 'openai', model: 'gpt-4' },
+          },
+        })
+      }
+
+      const editorAgent = await createAgent('Editor Agent', 'editor')
+      const ownerAgent = await createAgent('Owner Agent', 'owner')
+
+      // Team editor demoted to project reviewer
+      const demoted = await prisma.user.create({
+        data: { name: 'Demoted', email: `dem-${Date.now()}@x.com`, password: 'pw' },
+      })
+      const demotedTm = await prisma.teamMember.create({
+        data: { teamId: team.id, userId: demoted.id, role: 'editor', scope: 'team' },
+      })
+      await prisma.projectMember.create({
+        data: { projectId: project.id, teamMemberId: demotedTm.id, role: 'reviewer' },
+      })
+
+      // Project-scoped member invited as editor
+      const projEditor = await prisma.user.create({
+        data: { name: 'Proj Editor', email: `pe-${Date.now()}@x.com`, password: 'pw' },
+      })
+      const projEditorTm = await prisma.teamMember.create({
+        data: { teamId: team.id, userId: projEditor.id, role: 'reviewer', scope: 'project' },
+      })
+      await prisma.projectMember.create({
+        data: { projectId: project.id, teamMemberId: projEditorTm.id, role: 'editor' },
+      })
+
+      // Team reviewer promoted to project owner
+      const promoted = await prisma.user.create({
+        data: { name: 'Promoted', email: `pro-${Date.now()}@x.com`, password: 'pw' },
+      })
+      const promotedTm = await prisma.teamMember.create({
+        data: { teamId: team.id, userId: promoted.id, role: 'reviewer', scope: 'team' },
+      })
+      await prisma.projectMember.create({
+        data: { projectId: project.id, teamMemberId: promotedTm.id, role: 'owner' },
+      })
+
+      // Plain team reviewer (no project override)
+      const reviewer = await prisma.user.create({
+        data: { name: 'Reviewer', email: `rev-${Date.now()}@x.com`, password: 'pw' },
+      })
+      await prisma.teamMember.create({
+        data: { teamId: team.id, userId: reviewer.id, role: 'reviewer', scope: 'team' },
+      })
+
+      return { team, project, editorAgent, ownerAgent, demoted, projEditor, promoted, reviewer }
+    }
+
+    it('denies an editor agent to a team editor demoted to project reviewer', async () => {
+      const { team, project, editorAgent, demoted } = await setupProjectRoles()
+      await expect(
+        chatService.startOrContinueChat(demoted, team.id, {
+          agentId: editorAgent.id,
+          textPrompt: 'hello',
+          projectId: project.id,
+        }),
+      ).rejects.toThrow(/Insufficient role/)
+    })
+
+    it('allows an editor agent to a project-scoped member invited as editor', async () => {
+      const { team, project, editorAgent, projEditor } = await setupProjectRoles()
+      const { sessionId } = await chatService.startOrContinueChat(projEditor, team.id, {
+        agentId: editorAgent.id,
+        textPrompt: 'hello',
+        projectId: project.id,
+      })
+      expect(sessionId).toBeDefined()
+    })
+
+    it('allows an owner agent to a team reviewer promoted to project owner', async () => {
+      const { team, project, ownerAgent, promoted } = await setupProjectRoles()
+      const { sessionId } = await chatService.startOrContinueChat(promoted, team.id, {
+        agentId: ownerAgent.id,
+        textPrompt: 'hello',
+        projectId: project.id,
+      })
+      expect(sessionId).toBeDefined()
+    })
+
+    it('denies an editor agent to a plain team reviewer', async () => {
+      const { team, project, editorAgent, reviewer } = await setupProjectRoles()
+      await expect(
+        chatService.startOrContinueChat(reviewer, team.id, {
+          agentId: editorAgent.id,
+          textPrompt: 'hello',
+          projectId: project.id,
+        }),
+      ).rejects.toThrow(/Insufficient role/)
+    })
+  })
 })

--- a/packages/core/src/chat/chat.ts
+++ b/packages/core/src/chat/chat.ts
@@ -1,6 +1,11 @@
 import { prisma } from '@shumai/db'
 import type { Prisma } from '@shumai/db'
-import { authzService, Permission, ResourceType } from '@shumai/core/src/authz/authz'
+import {
+  authzService,
+  Permission,
+  ResourceType,
+  resolveEffectiveRole,
+} from '@shumai/core/src/authz/authz'
 import { paginateQuery, type PaginatedData } from '@shumai/core/src/pagination'
 import type { ChatRequest, ChatSessionInfo, ChatMessage } from '@shumai/dtos'
 import type { SessionTreeEntry } from '@earendil-works/pi-agent-core'
@@ -293,7 +298,9 @@ export class ChatService {
         throw new Error(`Agent does not belong to the specified team`)
       }
 
-      // Check user's permission to use this agent
+      // Check user's permission to use this agent, resolving the effective
+      // role for the project context (projectMember.role takes precedence over
+      // the team role; project-scoped members without project access are denied).
       const member = await tx.teamMember.findUnique({
         where: {
           teamIdUserId: {
@@ -306,7 +313,14 @@ export class ChatService {
         throw new Error('User is not a member of the team')
       }
 
-      const userLevel = getRoleLevel(member.role)
+      const effectiveRole = await resolveEffectiveRole(teamId, projectId, user.id, tx)
+      if (!effectiveRole) {
+        throw new Error(
+          `Permission denied: Insufficient role to use agent "${agent.user.name}". Minimum required role is "${agent.permission}".`,
+        )
+      }
+
+      const userLevel = getRoleLevel(effectiveRole)
       const requiredLevel = getAgentRequiredLevel(agent.permission)
       if (userLevel < requiredLevel) {
         throw new Error(

--- a/packages/core/src/mcp/mcp-service.test.ts
+++ b/packages/core/src/mcp/mcp-service.test.ts
@@ -536,6 +536,109 @@ describe('McpService', () => {
     expect(allowed.ok).toBe(true)
   })
 
+  it('uses the effective project role for MCP permission checks', async () => {
+    const server = await service.createServer(teamId, {
+      url: srv.url,
+      permission: 'editor',
+    })
+    const project = await prisma.project.create({
+      data: { name: 'MCP Proj', teamId },
+    })
+
+    // Team editor demoted to project reviewer: denied inside the project
+    const demoted = await prisma.user.create({
+      data: { name: 'Demoted MCP', email: `dem-mcp-${Date.now()}@shumai.ai`, type: 'human' },
+    })
+    const demotedTm = await prisma.teamMember.create({
+      data: { teamId, userId: demoted.id, role: 'editor', scope: 'team' },
+    })
+    await prisma.projectMember.create({
+      data: { projectId: project.id, teamMemberId: demotedTm.id, role: 'reviewer' },
+    })
+
+    const denied = await service.callMcpTool(
+      server.id,
+      'echo',
+      { text: 'x' },
+      { teamId, userId: demoted.id, projectId: project.id },
+    )
+    expect(denied.ok).toBe(false)
+    expect((denied.content[0] as { text?: string }).text).toContain('Permission denied')
+
+    // Project-scoped member invited as editor: allowed
+    const projEditor = await prisma.user.create({
+      data: { name: 'PE MCP', email: `pe-mcp-${Date.now()}@shumai.ai`, type: 'human' },
+    })
+    const peTm = await prisma.teamMember.create({
+      data: { teamId, userId: projEditor.id, role: 'reviewer', scope: 'project' },
+    })
+    await prisma.projectMember.create({
+      data: { projectId: project.id, teamMemberId: peTm.id, role: 'editor' },
+    })
+
+    const allowed = await service.callMcpTool(
+      server.id,
+      'echo',
+      { text: 'ok' },
+      { teamId, userId: projEditor.id, projectId: project.id },
+    )
+    expect(allowed.ok).toBe(true)
+  })
+
+  it('filters assigned MCP servers by the user effective role when building agent tools', async () => {
+    const agent = await seedAgentAndUser(teamId, 'Filtered MCP Agent')
+    const project = await prisma.project.create({
+      data: { name: 'MCP Filter Proj', teamId },
+    })
+
+    const reviewerSrv = await startTestMcpServer({
+      tools: standardTestTools(),
+      serverInfo: { name: 'reviewer-only-mcp' },
+    })
+    const editorSrv = await startTestMcpServer({
+      tools: standardTestTools(),
+      serverInfo: { name: 'editor-only-mcp' },
+    })
+    const reviewerServer = await service.createServer(teamId, {
+      url: reviewerSrv.url,
+      permission: 'reviewer',
+    })
+    const editorServer = await service.createServer(teamId, {
+      url: editorSrv.url,
+      permission: 'editor',
+    })
+    await service.refreshServer(reviewerServer.id)
+    await service.refreshServer(editorServer.id)
+    await prisma.agentMcpServer.create({
+      data: { agentId: agent.id, mcpServerId: reviewerServer.id },
+    })
+    await prisma.agentMcpServer.create({
+      data: { agentId: agent.id, mcpServerId: editorServer.id },
+    })
+
+    // Project-scoped member invited as reviewer: only the reviewer server's
+    // tools are attached; the editor server's tools are not even registered.
+    const reviewer = await prisma.user.create({
+      data: { name: 'Filter Reviewer', email: `fr-${Date.now()}@shumai.ai`, type: 'human' },
+    })
+    const reviewerTm = await prisma.teamMember.create({
+      data: { teamId, userId: reviewer.id, role: 'reviewer', scope: 'project' },
+    })
+    await prisma.projectMember.create({
+      data: { projectId: project.id, teamMemberId: reviewerTm.id, role: 'reviewer' },
+    })
+
+    const tools = await service.buildAgentTools(agent.id, teamId, reviewer.id, project.id)
+    const descriptions = tools
+      .map((t) => (t.description ?? '') + (t.name === 'mcp' ? JSON.stringify(t.parameters) : ''))
+      .join('\n')
+    expect(descriptions).toContain('reviewer-only-mcp')
+    expect(descriptions).not.toContain('editor-only-mcp')
+
+    await reviewerSrv.stop()
+    await editorSrv.stop()
+  })
+
   // --------------------------------------------------------------------------
   // Per-agent assignment (D6)
   // --------------------------------------------------------------------------

--- a/packages/core/src/mcp/mcp-service.ts
+++ b/packages/core/src/mcp/mcp-service.ts
@@ -13,6 +13,7 @@ import type {
   UpdateMcpServerRequest,
 } from '@shumai/dtos'
 import { logger } from '@shumai/core/src/logger'
+import { resolveEffectiveRole } from '@shumai/core/src/authz/authz'
 import { mcpDbStore, type PendingAuth } from './mcp-db-store'
 import { buildDirectTools, isDirectTool } from './mcp-direct-tools'
 import { McpOauthProvider, type McpOauthConfig } from './mcp-oauth-provider'
@@ -34,6 +35,7 @@ const ROLE_HIERARCHY: Record<string, number> = {
 export interface McpToolCallContext {
   teamId: string
   userId?: string
+  projectId?: string
 }
 
 export type McpToolCallContent = AgentToolResult<Record<string, unknown>>['content']
@@ -468,16 +470,10 @@ export class McpService {
     const requiredLevel = ROLE_HIERARCHY[server.permission] || 1
 
     if (ctx?.userId) {
-      const member = await prisma.teamMember.findUnique({
-        where: {
-          teamIdUserId: {
-            teamId: server.teamId,
-            userId: ctx.userId,
-          },
-        },
-        select: { role: true },
-      })
-      const userLevel = member ? ROLE_HIERARCHY[member.role] || 0 : 0
+      // Resolve the user's effective role for the project context (project
+      // override wins; project-scoped members without project access are denied).
+      const effectiveRole = await resolveEffectiveRole(server.teamId, ctx.projectId, ctx.userId)
+      const userLevel = effectiveRole ? ROLE_HIERARCHY[effectiveRole] || 0 : 0
       if (userLevel < requiredLevel) {
         return `Permission denied: Insufficient role to use MCP server "${server.name}". Minimum required role is "${server.permission}".`
       }
@@ -791,13 +787,33 @@ export class McpService {
    * Build the agent's MCP AgentTools: the single `mcp` proxy tool plus direct
    * tools for assigned servers in direct-tools mode. Returns [] when the agent
    * has no assigned servers (no proxy tool — don't waste LLM context).
+   *
+   * When a user context is provided, servers whose `permission` exceeds the
+   * user's effective project role are filtered out up front, so the model never
+   * sees tools it is not allowed to call (call-time checks remain as a backstop).
    */
-  async buildAgentTools(agentId: string, teamId: string, userId?: string): Promise<AgentTool[]> {
+  async buildAgentTools(
+    agentId: string,
+    teamId: string,
+    userId?: string,
+    projectId?: string,
+  ): Promise<AgentTool[]> {
     const assignments = await prisma.agentMcpServer.findMany({
       where: { agentId },
       include: { mcpServer: true },
     })
     if (assignments.length === 0) return []
+
+    let assignedServers = assignments.map((a) => a.mcpServer)
+    if (userId) {
+      const effectiveRole = await resolveEffectiveRole(teamId, projectId, userId)
+      if (!effectiveRole) return []
+      const userLevel = ROLE_HIERARCHY[effectiveRole] || 0
+      assignedServers = assignedServers.filter(
+        (s) => (ROLE_HIERARCHY[s.permission] || 1) <= userLevel,
+      )
+    }
+    if (assignedServers.length === 0) return []
 
     // Per-agent tool registry: built fresh for this agent from the persisted
     // discovery cache (McpServer.tools). It only ever contains the agent's
@@ -805,33 +821,31 @@ export class McpService {
     // nor called — no global mutable state to leak through.
     const registry = new McpToolRegistry()
 
-    const servers = assignments
-      .map((a) => a.mcpServer)
-      .map((s) => {
-        const storedTools = (s.tools ?? []) as PrismaJson.McpToolInfo[]
-        if (storedTools.length > 0) {
-          registry.setTools(
-            s.id,
-            s.name,
-            storedTools.map((t) => ({
-              name: t.name,
-              description: t.description ?? '',
-              ...(t.inputSchema !== undefined ? { inputSchema: t.inputSchema } : {}),
-            })),
-            { excludeTools: s.config?.excludeTools },
-          )
-        }
-        return {
-          id: s.id,
-          name: s.name,
-          instructions: s.instructions ?? null,
-          url: s.url,
-          transport: s.transport,
-          authConfig: (s.authConfig ?? {}) as PrismaJson.McpServerAuthConfig,
-          config: (s.config ?? {}) as PrismaJson.McpServerConfig,
-          status: s.status,
-        }
-      })
+    const servers = assignedServers.map((s) => {
+      const storedTools = (s.tools ?? []) as PrismaJson.McpToolInfo[]
+      if (storedTools.length > 0) {
+        registry.setTools(
+          s.id,
+          s.name,
+          storedTools.map((t) => ({
+            name: t.name,
+            description: t.description ?? '',
+            ...(t.inputSchema !== undefined ? { inputSchema: t.inputSchema } : {}),
+          })),
+          { excludeTools: s.config?.excludeTools },
+        )
+      }
+      return {
+        id: s.id,
+        name: s.name,
+        instructions: s.instructions ?? null,
+        url: s.url,
+        transport: s.transport,
+        authConfig: (s.authConfig ?? {}) as PrismaJson.McpServerAuthConfig,
+        config: (s.config ?? {}) as PrismaJson.McpServerConfig,
+        status: s.status,
+      }
+    })
 
     const serverNameById = new Map<string, string>()
     const serverIdByName = new Map<string, string>()
@@ -880,7 +894,7 @@ export class McpService {
       },
       ensureConnected: (serverId) => this.ensureConnected(serverId, registry),
       callTool: (serverId, toolName, args) =>
-        this.callMcpTool(serverId, toolName, args, { teamId, userId }),
+        this.callMcpTool(serverId, toolName, args, { teamId, userId, projectId }),
       authStatus: (serverId) => this.getAuthStatus(serverId),
       startAuth: (serverId) => this.startAuth(serverId),
       getInstructions: (serverId) => this.getServerInstructions(serverId),
@@ -898,7 +912,7 @@ export class McpService {
           serverId: server.id,
           serverName: server.name,
           callTool: (serverId, toolName, args) =>
-            this.callMcpTool(serverId, toolName, args, { teamId, userId }),
+            this.callMcpTool(serverId, toolName, args, { teamId, userId, projectId }),
         }),
       )
     }

--- a/packages/core/src/project/project.test.ts
+++ b/packages/core/src/project/project.test.ts
@@ -196,6 +196,53 @@ describe('ProjectService', () => {
       expect(allMembers).toHaveLength(2)
     })
 
+    it('filters agent bots by the requester effective project role', async () => {
+      const team = await prisma.team.create({ data: { name: 'Team Bot Filter' } })
+      const project = await prisma.project.create({ data: { name: 'P2', teamId: team.id } })
+
+      const createChatAgent = async (name: string, permission: 'owner' | 'editor' | 'reviewer') => {
+        const bot = await prisma.user.create({
+          data: { name, email: `${name}-${Date.now()}@example.com`, password: 'pw', type: 'agent' },
+        })
+        await prisma.teamMember.create({
+          data: { teamId: team.id, userId: bot.id, role: 'editor', scope: 'team' },
+        })
+        await prisma.agent.create({
+          data: {
+            id: bot.id,
+            teamId: team.id,
+            type: 'chat',
+            enabled: true,
+            permission,
+            config: { provider: 'google', model: 'gemini' },
+          },
+        })
+      }
+
+      await createChatAgent('Reviewer Bot', 'reviewer')
+      await createChatAgent('Editor Bot', 'editor')
+
+      // Project-scoped requester invited as reviewer: sees only reviewer bots
+      const requester = await prisma.user.create({
+        data: { name: 'Req', email: `req-${Date.now()}@example.com`, password: 'pw' },
+      })
+      const requesterTm = await prisma.teamMember.create({
+        data: { teamId: team.id, userId: requester.id, role: 'reviewer', scope: 'project' },
+      })
+      await prisma.projectMember.create({
+        data: { projectId: project.id, teamMemberId: requesterTm.id, role: 'reviewer' },
+      })
+
+      const members = await projectService.listProjectMembers({
+        projectId: project.id,
+        includeAgents: true,
+        requesterUserId: requester.id,
+      })
+      const agentNames = members.filter((m) => m.id !== requester.id).map((m) => m.name)
+      expect(agentNames).toContain('Reviewer Bot')
+      expect(agentNames).not.toContain('Editor Bot')
+    })
+
     it('should allow upserting custom role override for team-scoped members via updateMemberRole', async () => {
       const team = await prisma.team.create({ data: { name: 'Team Scope Test' } })
       const project = await prisma.project.create({ data: { name: 'Project A', teamId: team.id } })

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -3,6 +3,8 @@ import { Prisma } from '@shumai/db'
 import { s3Service } from '@shumai/core/src/s3/s3'
 import { paginateQuery, PaginatedData } from '@shumai/core/src/pagination'
 import { getAvatarUrl } from '@shumai/core/src/user/avatar'
+import { getAllowedAgentRoles } from '@shumai/core/src/agent/permissions'
+import { resolveEffectiveRole } from '@shumai/core/src/authz/authz'
 import {
   ServiceCreateProjectRequest,
   ServiceUpdateProjectRequest,
@@ -226,17 +228,35 @@ export class ProjectService {
     })
     if (!project) throw new Error('Project not found')
 
+    // When agents are requested, only include the chat agents the requester's
+    // effective project role permits (project override wins; restricted
+    // requesters see no agents at all). Without a requester context, fall back
+    // to including all enabled chat agents (legacy behavior).
+    let agentFilter: Prisma.AgentWhereInput | undefined
+    if (req.includeAgents) {
+      if (req.requesterUserId) {
+        const effectiveRole = await resolveEffectiveRole(
+          project.teamId,
+          req.projectId,
+          req.requesterUserId,
+        )
+        if (effectiveRole) {
+          agentFilter = {
+            type: 'chat' as const,
+            enabled: true,
+            permission: { in: getAllowedAgentRoles(effectiveRole) },
+          }
+        }
+      } else {
+        agentFilter = { type: 'chat' as const, enabled: true }
+      }
+    }
+
     const userTypeFilter = req.includeAgents
       ? {
           OR: [
             { type: 'human' as const },
-            {
-              type: 'agent' as const,
-              agent: {
-                type: 'chat' as const,
-                enabled: true,
-              },
-            },
+            ...(agentFilter ? [{ type: 'agent' as const, agent: agentFilter }] : []),
           ],
         }
       : { type: { not: 'agent' as const } }

--- a/packages/dtos/src/project.ts
+++ b/packages/dtos/src/project.ts
@@ -105,6 +105,7 @@ export interface ServiceAddProjectMemberRequest {
 export interface ServiceListProjectMembersRequest {
   projectId: string
   includeAgents?: boolean
+  requesterUserId?: string
 }
 
 export interface ServiceUpdateProjectMemberRoleRequest {

--- a/packages/webui/components/chatbot-sidebar.tsx
+++ b/packages/webui/components/chatbot-sidebar.tsx
@@ -66,16 +66,16 @@ export function ChatbotSidebar({ projectId, contextAssetId }: ChatbotSidebarProp
   }, [projectId, ensureTeamIdForProject])
 
   const { data: agents = [] } = useQuery({
-    queryKey: ['agents', teamId],
+    queryKey: ['chat-agents', projectId],
     queryFn: async () => {
-      if (!teamId) return []
-      const res = await client.api.teams[':teamId'].agents.$get({
-        param: { teamId },
+      if (!projectId) return []
+      const res = await client.api.projects[':projectId']['chat-agents'].$get({
+        param: { projectId },
       })
       if (!res.ok) throw new Error('failed to fetch agents')
       return res.json()
     },
-    enabled: !!teamId,
+    enabled: !!projectId,
   })
 
   const chatAgents = agents.filter((a) => a.type === 'chat' && a.enabled)


### PR DESCRIPTION
## Summary

Fixes the gaps found in the agent/skill/mcp permission model review. The runtime permission checks for agents, skills, and MCP servers previously used only the raw `teamMember.role`, which (a) let project-only members execute team-level agents/skills/MCP tools (contradicting the authzService 'project scope = Read only on team resources' model) and (b) ignored per-project role overrides (`projectMember.role`).

Introduces a single shared `resolveEffectiveRole(teamId, projectId, userId)` helper mirroring `AuthzService.hasPermission` precedence rules and routes every agent/skill/mcp gate through it, so the visible selector list and the runtime enforcement can never diverge.

Also adds a new project-scoped `GET /projects/:projectId/chat-agents` API for the one-to-one chat selector (settings keeps the team-level API, unchanged by design).

## Changes

- **authz**: new `resolveEffectiveRole` helper; `hasPermission` refactored to use it (behavior-preserving)
- **Agent usage gates**: `chat.ts` (start chat), `asset.ts` (bot mentions), `getAgentChatContextActivity` (workflow runtime) now resolve the effective project role
- **Skill gate**: `read_skill` enforces via effective role; `projectId` threaded from the agent session; agent sessions only advertise skills the user's effective role permits (Gap 4)
- **MCP**: `checkPermission` uses effective role; `buildAgentTools` filters out servers above the user's role so their tools are never advertised (Gap 4)
- **Project members**: `listProjectMembers` with `includeAgents` now filters agent bots by the requester's effective project role
- **New API**: `GET /projects/:projectId/chat-agents` (Read on Project) returns chat+enabled agents filtered by the user's effective project role; WebUI `chatbot-sidebar` switched to it
- **Refactor**: shared `AgentService.toAgentInfo` mapper replaces duplicated inline mapping in the agent API routes

## Verification

- `bun run lint` ✓
- `bun run format` ✓
- `bun run typecheck` ✓
- `bun run test` — 1147 passed
- `bun run test:e2e:app` — 34 passed
- `bun run test:e2e:webui` — 9 passed
- `bun run test:e2e:workflow` — 58 passed

New tests cover: `resolveEffectiveRole` precedence rules, project-role matrices for chat start / bot mentions / MCP tool calls / skill loading, `listProjectChatAgents`, `listProjectMembers` filtering, and the new API route (incl. 403).

## Notes

- Bash privilege (`resolveTeamMemberRole` in the agent package) intentionally stays team-owner-based — it is the sandbox/code-execution safety boundary. Project owners gain agent selection rights but not full bash.
- The chat @mention picker still uses the team members endpoint (team-role filter); its enforcement gate is fixed. Switching the picker itself to project-scoped members is left as follow-up.
- Per plan, no new workflow/web E2E tests were added; existing E2E suites remain green.