### PR TITLE
fix(quota): serialize initial records, validate merged updates, and reset on dimension changes

### DIFF
--- a/packages/core/src/quota/quota-service.test.ts
+++ b/packages/core/src/quota/quota-service.test.ts
@@ -269,9 +269,15 @@ describe('QuotaService', () => {
     const userSelected = await prisma.user.create({
       data: { name: 'Selected User', email: 'sel@example.com', password: 'pw' },
     })
+    await prisma.teamMember.create({
+      data: { teamId: team.id, userId: userSelected.id, role: 'editor' },
+    })
 
     const userOther = await prisma.user.create({
       data: { name: 'Other User', email: 'other@example.com', password: 'pw' },
+    })
+    await prisma.teamMember.create({
+      data: { teamId: team.id, userId: userOther.id, role: 'editor' },
     })
 
     await quotaService.createRule(team.id, {
@@ -541,6 +547,9 @@ describe('QuotaService', () => {
     const user = await prisma.user.create({
       data: { name: 'Charlie', email: 'charlie@example.com', password: 'pw' },
     })
+    await prisma.teamMember.create({
+      data: { teamId: team.id, userId: user.id, role: 'editor' },
+    })
 
     // Rule 1: Team overall token limit 10,000 (all_members)
     await quotaService.createRule(team.id, {
@@ -598,5 +607,148 @@ describe('QuotaService', () => {
         1000,
       ),
     ).resolves.toEqual(expect.objectContaining({ allowed: true }))
+  })
+
+  it('rejects selected_members if user is not a member of the team on create', async () => {
+    const team1 = await prisma.team.create({ data: { name: 'Team 1' } })
+    const team2 = await prisma.team.create({ data: { name: 'Team 2' } })
+
+    const userInTeam1 = await prisma.user.create({
+      data: { name: 'Member 1', email: 'm1@example.com', password: 'pw' },
+    })
+    await prisma.teamMember.create({
+      data: { teamId: team1.id, userId: userInTeam1.id, role: 'editor' },
+    })
+
+    const userInTeam2 = await prisma.user.create({
+      data: { name: 'Member 2', email: 'm2@example.com', password: 'pw' },
+    })
+    await prisma.teamMember.create({
+      data: { teamId: team2.id, userId: userInTeam2.id, role: 'editor' },
+    })
+
+    // Creating rule on Team 1 with user from Team 2 should throw 400
+    await expect(
+      quotaService.createRule(team1.id, {
+        scopeMode: 'selected_members',
+        userIds: [userInTeam2.id],
+        resource: 'agent_cost',
+        limit: 10,
+        period: '1day',
+      }),
+    ).rejects.toThrow('One or more selected users are not members of the team')
+  })
+
+  it('validates merged rule and rejects invalid partial updates', async () => {
+    const team = await prisma.team.create({ data: { name: 'Validation Team' } })
+    const user = await prisma.user.create({
+      data: { name: 'User 1', email: 'u1@example.com', password: 'pw' },
+    })
+    await prisma.teamMember.create({
+      data: { teamId: team.id, userId: user.id, role: 'editor' },
+    })
+
+    const rule = await quotaService.createRule(team.id, {
+      scopeMode: 'each_member',
+      resource: 'agent_total_tokens',
+      limit: 10000,
+      period: '1hour',
+    })
+
+    // Updating resource to agent_skill_call_count without resourceData.id should fail validation
+    await expect(
+      quotaService.updateRule(team.id, rule.id, {
+        resource: 'agent_skill_call_count',
+      }),
+    ).rejects.toThrow()
+
+    // Updating scopeMode to selected_members without userIds should fail validation
+    await expect(
+      quotaService.updateRule(team.id, rule.id, {
+        scopeMode: 'selected_members',
+      }),
+    ).rejects.toThrow()
+
+    // Updating userIds with a user from outside the team should fail validation
+    const otherUser = await prisma.user.create({
+      data: { name: 'Other User', email: 'other_team@example.com', password: 'pw' },
+    })
+    await expect(
+      quotaService.updateRule(team.id, rule.id, {
+        scopeMode: 'selected_members',
+        userIds: [otherUser.id],
+      }),
+    ).rejects.toThrow('One or more selected users are not members of the team')
+  })
+
+  it('resets existing quota records when accounting dimensions change', async () => {
+    const team = await prisma.team.create({ data: { name: 'Reset Records Team' } })
+
+    const rule = await quotaService.createRule(team.id, {
+      scopeMode: 'all_members',
+      resource: 'agent_total_tokens',
+      limit: 1000,
+      period: '1hour',
+    })
+
+    // Consume 500 tokens
+    await quotaService.consumeQuota(
+      {
+        teamId: team.id,
+        resource: 'agent_total_tokens',
+      },
+      500,
+    )
+
+    let records = await prisma.quotaRecord.findMany({ where: { ruleId: rule.id } })
+    expect(records).toHaveLength(1)
+    expect(records[0].consumed).toBe(500)
+
+    // Update resource to agent_cost (limit 10)
+    await quotaService.updateRule(team.id, rule.id, {
+      resource: 'agent_cost',
+      limit: 10,
+    })
+
+    // Records should be reset
+    records = await prisma.quotaRecord.findMany({ where: { ruleId: rule.id } })
+    expect(records).toHaveLength(0)
+
+    // Consume $2 under the new resource
+    await quotaService.consumeQuota(
+      {
+        teamId: team.id,
+        resource: 'agent_cost',
+      },
+      2,
+    )
+
+    records = await prisma.quotaRecord.findMany({ where: { ruleId: rule.id } })
+    expect(records).toHaveLength(1)
+    expect(records[0].consumed).toBe(2)
+  })
+
+  it('handles concurrent first consumption for all_members without creating duplicate records', async () => {
+    const team = await prisma.team.create({ data: { name: 'Concurrent Quota Team' } })
+
+    const rule = await quotaService.createRule(team.id, {
+      scopeMode: 'all_members',
+      resource: 'agent_total_tokens',
+      limit: 10000,
+      period: '1hour',
+    })
+
+    // Concurrently trigger 5 quota consumption calls for the first time
+    await Promise.all([
+      quotaService.consumeQuota({ teamId: team.id, resource: 'agent_total_tokens' }, 10),
+      quotaService.consumeQuota({ teamId: team.id, resource: 'agent_total_tokens' }, 20),
+      quotaService.consumeQuota({ teamId: team.id, resource: 'agent_total_tokens' }, 30),
+      quotaService.consumeQuota({ teamId: team.id, resource: 'agent_total_tokens' }, 40),
+      quotaService.consumeQuota({ teamId: team.id, resource: 'agent_total_tokens' }, 50),
+    ])
+
+    const records = await prisma.quotaRecord.findMany({ where: { ruleId: rule.id } })
+    expect(records).toHaveLength(1)
+    expect(records[0].consumed).toBe(150)
   })
 })

--- a/packages/core/src/quota/quota-service.ts
+++ b/packages/core/src/quota/quota-service.ts
@@ -8,6 +8,10 @@ import {
   type UpdateQuotaRuleRequest,
   normalizeQuotaPeriod,
   formatQuotaPeriod,
+  skillResourceDataSchema,
+  mcpResourceDataSchema,
+  bashResourceDataSchema,
+  networkResourceDataSchema,
 } from '@shumai/dtos'
 import { HTTPException } from 'hono/http-exception'
 import { quotaRuleCache, type CachedQuotaRule, type QuotaEvent } from './quota-cache'
@@ -77,14 +81,22 @@ export class QuotaService {
   }
 
   async createRule(teamId: string, req: CreateQuotaRuleRequest): Promise<QuotaRuleResponse> {
-    if (req.scopeMode === 'selected_members' && req.userIds && req.userIds.length > 0) {
-      const users = await this.prismaClient.user.findMany({
-        where: { id: { in: req.userIds } },
-        select: { id: true },
-      })
-      if (users.length !== req.userIds.length) {
+    if (req.scopeMode === 'selected_members') {
+      if (!req.userIds || req.userIds.length === 0) {
         throw new HTTPException(400, {
-          message: 'One or more selected users were not found',
+          message: 'userIds must contain at least one user when scopeMode is "selected_members"',
+        })
+      }
+      const members = await this.prismaClient.teamMember.findMany({
+        where: {
+          teamId,
+          userId: { in: req.userIds },
+        },
+        select: { userId: true },
+      })
+      if (members.length !== req.userIds.length) {
+        throw new HTTPException(400, {
+          message: 'One or more selected users are not members of the team',
         })
       }
     }
@@ -122,35 +134,131 @@ export class QuotaService {
       throw new HTTPException(404, { message: 'Quota rule not found' })
     }
 
-    const data: Prisma.QuotaRuleUpdateInput = {}
-    if (req.scopeMode !== undefined) data.scopeMode = req.scopeMode
-    if (req.role !== undefined) {
-      data.role = req.role
-    }
-    if (req.userIds !== undefined) {
-      data.userIds = req.userIds ?? Prisma.JsonNull
+    const effectiveScopeMode = req.scopeMode ?? existing.scopeMode
+    const effectiveRole =
+      effectiveScopeMode === 'selected_members'
+        ? null
+        : req.role !== undefined
+          ? req.role
+          : existing.role
+    const effectiveUserIds =
+      effectiveScopeMode === 'selected_members'
+        ? req.userIds !== undefined
+          ? req.userIds
+          : Array.isArray(existing.userIds)
+            ? (existing.userIds as string[])
+            : []
+        : null
+    const effectiveResource = req.resource ?? existing.resource
+    const effectiveResourceData =
+      req.resourceData !== undefined
+        ? req.resourceData
+        : (existing.resourceData as Record<string, unknown> | null)
+    const effectiveLimit = req.limit ?? existing.limit
+    const effectivePeriod = req.period ? normalizeQuotaPeriod(req.period) : existing.period
+    const effectiveEnabled = req.enabled ?? existing.enabled
 
-      // Clean up records for removed users if updating userIds
-      if (req.userIds) {
-        await this.prismaClient.quotaRecord.deleteMany({
-          where: {
-            ruleId,
-            userId: { notIn: req.userIds },
-          },
+    // Validate effective merged state
+    if (effectiveScopeMode === 'selected_members') {
+      if (!effectiveUserIds || effectiveUserIds.length === 0) {
+        throw new HTTPException(400, {
+          message: 'userIds must contain at least one user when scopeMode is "selected_members"',
+        })
+      }
+      const members = await this.prismaClient.teamMember.findMany({
+        where: {
+          teamId,
+          userId: { in: effectiveUserIds },
+        },
+        select: { userId: true },
+      })
+      if (members.length !== effectiveUserIds.length) {
+        throw new HTTPException(400, {
+          message: 'One or more selected users are not members of the team',
         })
       }
     }
-    if (req.resource !== undefined) data.resource = req.resource
-    if (req.resourceData !== undefined) {
-      data.resourceData = req.resourceData ?? Prisma.JsonNull
-    }
-    if (req.limit !== undefined) data.limit = req.limit
-    if (req.period !== undefined) data.period = normalizeQuotaPeriod(req.period)
-    if (req.enabled !== undefined) data.enabled = req.enabled
 
-    const updated = await this.prismaClient.quotaRule.update({
-      where: { id: ruleId },
-      data,
+    if (effectiveResource === 'agent_skill_call_count') {
+      const res = skillResourceDataSchema.safeParse(effectiveResourceData)
+      if (!res.success) {
+        throw new HTTPException(400, {
+          message: 'resourceData.id is required for agent_skill_call_count',
+        })
+      }
+    } else if (effectiveResource === 'agent_mcp_call_count') {
+      const res = mcpResourceDataSchema.safeParse(effectiveResourceData)
+      if (!res.success) {
+        throw new HTTPException(400, {
+          message: 'resourceData.id is required for agent_mcp_call_count',
+        })
+      }
+    } else if (effectiveResource === 'agent_bash_call_count') {
+      const res = bashResourceDataSchema.safeParse(effectiveResourceData)
+      if (!res.success) {
+        throw new HTTPException(400, {
+          message: 'resourceData.match is required for agent_bash_call_count',
+        })
+      }
+    } else if (effectiveResource === 'agent_network_call_count') {
+      const res = networkResourceDataSchema.safeParse(effectiveResourceData)
+      if (!res.success) {
+        throw new HTTPException(400, {
+          message: 'resourceData.domain is required for agent_network_call_count',
+        })
+      }
+    }
+
+    if (effectiveLimit <= 0) {
+      throw new HTTPException(400, {
+        message: 'Limit must be greater than 0',
+      })
+    }
+
+    const isAccountingDimensionChanged =
+      (req.resource !== undefined && req.resource !== existing.resource) ||
+      (req.period !== undefined && normalizeQuotaPeriod(req.period) !== existing.period) ||
+      (req.scopeMode !== undefined && req.scopeMode !== existing.scopeMode) ||
+      (req.role !== undefined && req.role !== existing.role) ||
+      (req.resourceData !== undefined &&
+        JSON.stringify(req.resourceData) !== JSON.stringify(existing.resourceData))
+
+    const updated = await this.prismaClient.$transaction(async (tx) => {
+      if (isAccountingDimensionChanged) {
+        // Reset all records when accounting dimensions change
+        await tx.quotaRecord.deleteMany({
+          where: { ruleId },
+        })
+      } else if (effectiveScopeMode === 'selected_members' && req.userIds !== undefined) {
+        // Clean up records for removed users if updating userIds
+        if (req.userIds && req.userIds.length > 0) {
+          await tx.quotaRecord.deleteMany({
+            where: {
+              ruleId,
+              userId: { notIn: req.userIds },
+            },
+          })
+        }
+      }
+
+      const data: Prisma.QuotaRuleUpdateInput = {
+        scopeMode: effectiveScopeMode,
+        role: effectiveRole,
+        userIds:
+          effectiveScopeMode === 'selected_members' && effectiveUserIds
+            ? effectiveUserIds
+            : Prisma.JsonNull,
+        resource: effectiveResource,
+        resourceData: effectiveResourceData ?? Prisma.JsonNull,
+        limit: effectiveLimit,
+        period: effectivePeriod,
+        enabled: effectiveEnabled,
+      }
+
+      return tx.quotaRule.update({
+        where: { id: ruleId },
+        data,
+      })
     })
 
     quotaRuleCache.invalidate(teamId)
@@ -372,7 +480,12 @@ export class QuotaService {
       const targetUserId = rule.getTargetUserId(event)
 
       await this.prismaClient.$transaction(async (tx) => {
-        const rawRecord = targetUserId
+        if (targetUserId === null) {
+          // Serialize all_members record checks/creations on the parent rule row
+          await tx.$queryRaw`SELECT id FROM quota_rules WHERE id = ${rule.id} FOR UPDATE`
+        }
+
+        let rawRecord = targetUserId
           ? ((
               await tx.$queryRaw<RawQuotaRecord[]>`
                 SELECT * FROM quota_records
@@ -387,6 +500,19 @@ export class QuotaService {
                 FOR UPDATE
               `
             )[0] ?? null)
+
+        if (!rawRecord && targetUserId !== null) {
+          // Lock parent rule on first user record check and re-query
+          await tx.$queryRaw`SELECT id FROM quota_rules WHERE id = ${rule.id} FOR UPDATE`
+          rawRecord =
+            (
+              await tx.$queryRaw<RawQuotaRecord[]>`
+              SELECT * FROM quota_records
+              WHERE rule_id = ${rule.id} AND user_id = ${targetUserId}
+              FOR UPDATE
+            `
+            )[0] ?? null
+        }
 
         const isWindowActive = Boolean(
           rawRecord?.period_start &&
@@ -433,7 +559,12 @@ export class QuotaService {
       const targetUserId = rule.getTargetUserId(event)
 
       await this.prismaClient.$transaction(async (tx) => {
-        const rawRecord = targetUserId
+        if (targetUserId === null) {
+          // Serialize all_members (shared pool) creations and updates on the parent rule row
+          await tx.$queryRaw`SELECT id FROM quota_rules WHERE id = ${rule.id} FOR UPDATE`
+        }
+
+        let rawRecord = targetUserId
           ? ((
               await tx.$queryRaw<RawQuotaRecord[]>`
                 SELECT * FROM quota_records
@@ -448,6 +579,19 @@ export class QuotaService {
                 FOR UPDATE
               `
             )[0] ?? null)
+
+        if (!rawRecord && targetUserId !== null) {
+          // Lock parent rule on first user record creation and re-query
+          await tx.$queryRaw`SELECT id FROM quota_rules WHERE id = ${rule.id} FOR UPDATE`
+          rawRecord =
+            (
+              await tx.$queryRaw<RawQuotaRecord[]>`
+              SELECT * FROM quota_records
+              WHERE rule_id = ${rule.id} AND user_id = ${targetUserId}
+              FOR UPDATE
+            `
+            )[0] ?? null
+        }
 
         const isWindowActive = Boolean(
           rawRecord?.period_start &&


### PR DESCRIPTION
## Summary

Addresses code review findings on the quota system by serializing initial quota record creations to eliminate duplicate shared records under concurrent first usage, validating effective merged state and team membership on rule updates, and transactionally resetting records when accounting dimensions change.

## Changes

- **Concurrent Shared-Pool Creation Serialization**: Acquired parent `QuotaRule` row locks (`SELECT ... FOR UPDATE`) during first-record lookups in `checkQuota` and `consumeQuota` to prevent duplicate record insertion under concurrent first access for `all_members` rules and user-specific rules.
- **Merged Rule & Team Member Validation**: In `QuotaService.createRule` and `QuotaService.updateRule`, validated that selected `userIds` are members of the specified team via `teamMember`. In `updateRule`, merged partial patches with existing rule properties to validate the composite rule against required resource-data constraints (e.g. `skillId`, `mcpServerId`, bash/network match expressions) and scope requirements.
- **Transactional Accounting Dimension Reset**: In `QuotaService.updateRule`, transactionally pruned all existing `QuotaRecord` entries for a rule when core accounting dimensions (`resource`, `period`, `scopeMode`, `role`, or `resourceData`) change, and removed orphaned records when `userIds` are updated in `selected_members` mode.
- **Regression Tests**: Added test cases covering concurrent `all_members` consumption, team-membership enforcement on create/update, merged update validation, and record reset on dimension updates.

## Verification

Ran all verification suites simultaneously:
- `bun run lint` (passed)
- `bun run format` (passed)
- `bun run typecheck` (passed)
- `bun run test` (122 files, 1,171 tests passed)
- `bun run test:e2e:workflow` (14 files, 58 tests passed)
- `bun run test:e2e:webui` (9 tests passed)
- `bun run test:e2e:app` (35 tests passed)

## Notes

None.