### PR TITLE
feat(kanban): add unassigned goal record and fix all tasks count

### DIFF
--- a/packages/core/src/kanban/kanban.test.ts
+++ b/packages/core/src/kanban/kanban.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { prisma } from '@shumai/db'
 import { setupTestDbHooks } from '@shumai/db/test'
 import { KanbanTaskStatus, KanbanTaskPriority } from '@shumai/db/enums'
+import { UNASSIGNED_GOAL_ID } from '@shumai/dtos'
 import { kanbanService } from './kanban'
 
 describe('KanbanService', () => {
@@ -42,8 +43,27 @@ describe('KanbanService', () => {
   // Goals
   // --------------------------------------------------------------------------
   describe('Goals', () => {
-    it('creates, lists, updates, and deletes goals', async () => {
+    it('creates, lists, updates, and deletes goals including unassigned record', async () => {
       const { team, owner, editor } = await setupTeamAndUsers()
+
+      // When no custom goals exist, listGoals returns only the unassigned goal record with taskCount 0
+      const initialGoals = await kanbanService.listGoals(team.id)
+      expect(initialGoals.length).toBe(1)
+      expect(initialGoals[0].id).toBe(UNASSIGNED_GOAL_ID)
+      expect(initialGoals[0].taskCount).toBe(0)
+
+      // Create an unassigned task (no goalId)
+      const unassignedTask = await kanbanService.createTask(
+        team.id,
+        { title: 'Unassigned Task' },
+        editor.id,
+        'editor',
+      )
+
+      const goalsWithUnassignedTask = await kanbanService.listGoals(team.id)
+      expect(goalsWithUnassignedTask.length).toBe(1)
+      expect(goalsWithUnassignedTask[0].id).toBe(UNASSIGNED_GOAL_ID)
+      expect(goalsWithUnassignedTask[0].taskCount).toBe(1)
 
       const goal = await kanbanService.createGoal(
         team.id,
@@ -60,7 +80,7 @@ describe('KanbanService', () => {
       expect(goal.taskCount).toBe(0)
 
       // Create a task under this goal
-      await kanbanService.createTask(
+      const assignedTask = await kanbanService.createTask(
         team.id,
         {
           title: 'Design Wireframes',
@@ -70,10 +90,27 @@ describe('KanbanService', () => {
         'editor',
       )
 
-      // Get goal progress
+      // Get goals: should return [unassignedGoal, customGoal]
       const listedGoals = await kanbanService.listGoals(team.id)
-      expect(listedGoals.length).toBe(1)
+      expect(listedGoals.length).toBe(2)
+      expect(listedGoals[0].id).toBe(UNASSIGNED_GOAL_ID)
       expect(listedGoals[0].taskCount).toBe(1)
+      expect(listedGoals[1].id).toBe(goal.id)
+      expect(listedGoals[1].taskCount).toBe(1)
+
+      // Filtering tasks with goalId = UNASSIGNED_GOAL_ID
+      const unassignedTasksList = await kanbanService.listTasks(team.id, {
+        goalId: UNASSIGNED_GOAL_ID,
+      })
+      expect(unassignedTasksList.data.length).toBe(1)
+      expect(unassignedTasksList.data[0].id).toBe(unassignedTask.id)
+
+      // Filtering tasks with custom goalId
+      const assignedTasksList = await kanbanService.listTasks(team.id, {
+        goalId: goal.id,
+      })
+      expect(assignedTasksList.data.length).toBe(1)
+      expect(assignedTasksList.data[0].id).toBe(assignedTask.id)
 
       // Update goal
       const updated = await kanbanService.updateGoal(
@@ -83,10 +120,23 @@ describe('KanbanService', () => {
       )
       expect(updated.title).toBe('Q3 Launch Release Updated')
 
-      // Delete goal
+      // Should reject updating unassigned goal
+      await expect(
+        kanbanService.updateGoal(UNASSIGNED_GOAL_ID, { title: 'Illegal' }, 'owner'),
+      ).rejects.toThrow('Cannot edit or delete the unassigned goal')
+
+      // Should reject deleting unassigned goal
+      await expect(kanbanService.deleteGoal(UNASSIGNED_GOAL_ID, 'owner')).rejects.toThrow(
+        'Cannot edit or delete the unassigned goal',
+      )
+
+      // Delete custom goal
       await kanbanService.deleteGoal(goal.id, 'owner')
       const afterDelete = await kanbanService.listGoals(team.id)
-      expect(afterDelete.length).toBe(0)
+      // Only unassigned record remains, now with 2 unassigned tasks (since assignedTask's goal was set to null on delete)
+      expect(afterDelete.length).toBe(1)
+      expect(afterDelete[0].id).toBe(UNASSIGNED_GOAL_ID)
+      expect(afterDelete[0].taskCount).toBe(2)
     })
   })
 

--- a/packages/core/src/kanban/kanban.ts
+++ b/packages/core/src/kanban/kanban.ts
@@ -25,6 +25,7 @@ import type {
   KanbanEventInfo,
   KanbanGoalInfo,
 } from '@shumai/dtos'
+import { UNASSIGNED_GOAL_ID } from '@shumai/dtos'
 
 export class KanbanService {
   // --------------------------------------------------------------------------
@@ -96,6 +97,10 @@ export class KanbanService {
       throw new HTTPException(403, { message: 'Only team owners can update goals' })
     }
 
+    if (goalId === UNASSIGNED_GOAL_ID) {
+      throw new HTTPException(400, { message: 'Cannot edit or delete the unassigned goal' })
+    }
+
     const existing = await prisma.kanbanGoal.findUnique({ where: { id: goalId } })
     if (!existing) {
       throw new HTTPException(404, { message: 'Goal not found' })
@@ -131,6 +136,10 @@ export class KanbanService {
       throw new HTTPException(403, { message: 'Only team owners can delete goals' })
     }
 
+    if (goalId === UNASSIGNED_GOAL_ID) {
+      throw new HTTPException(400, { message: 'Cannot edit or delete the unassigned goal' })
+    }
+
     const existing = await prisma.kanbanGoal.findUnique({ where: { id: goalId } })
     if (!existing) {
       throw new HTTPException(404, { message: 'Goal not found' })
@@ -144,17 +153,33 @@ export class KanbanService {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _req?: ListKanbanGoalsRequest,
   ): Promise<KanbanGoalInfo[]> {
-    const goals = await prisma.kanbanGoal.findMany({
-      where: { teamId },
-      include: {
-        _count: {
-          select: { tasks: true },
+    const [goals, unassignedCount] = await Promise.all([
+      prisma.kanbanGoal.findMany({
+        where: { teamId },
+        include: {
+          _count: {
+            select: { tasks: true },
+          },
         },
-      },
-      orderBy: { id: 'desc' },
-    })
+        orderBy: { id: 'desc' },
+      }),
+      prisma.kanbanTask.count({
+        where: { teamId, goalId: null },
+      }),
+    ])
 
-    return goals.map((g) => ({
+    const unassignedGoal: KanbanGoalInfo = {
+      id: UNASSIGNED_GOAL_ID,
+      title: 'Unassigned',
+      description: null,
+      teamId,
+      creatorId: null,
+      taskCount: unassignedCount,
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    }
+
+    const goalInfos = goals.map((g) => ({
       id: g.id,
       title: g.title,
       description: g.description,
@@ -164,6 +189,8 @@ export class KanbanService {
       createdAt: g.createdAt.toISOString(),
       updatedAt: g.updatedAt.toISOString(),
     }))
+
+    return [unassignedGoal, ...goalInfos]
   }
 
   // --------------------------------------------------------------------------
@@ -677,11 +704,15 @@ export class KanbanService {
     teamId: string,
     params: ListKanbanTasksRequest,
   ): Promise<{ data: KanbanTaskInfo[]; pageInfo: { total?: number; cursor?: string } }> {
-    const where = {
+    const where: Prisma.KanbanTaskWhereInput = {
       teamId,
       ...(params.status && { status: params.status }),
       ...(params.isAgentTask !== undefined && { isAgentTask: params.isAgentTask }),
-      ...(params.goalId && { goalId: params.goalId }),
+      ...(params.goalId === UNASSIGNED_GOAL_ID
+        ? { goalId: null }
+        : params.goalId
+          ? { goalId: params.goalId }
+          : {}),
       ...(params.projectId && { projectId: params.projectId }),
       ...(params.priority && { priority: params.priority }),
       ...(params.assigneeId && { assigneeId: params.assigneeId }),

--- a/packages/dtos/src/kanban/goal.ts
+++ b/packages/dtos/src/kanban/goal.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+export const UNASSIGNED_GOAL_ID = 'unassigned'
+
 export const createKanbanGoalSchema = z.object({
   title: z.string().min(1),
   description: z.string().optional(),

--- a/packages/webui/components/kanban/edit-task-dialog/task-info-form.tsx
+++ b/packages/webui/components/kanban/edit-task-dialog/task-info-form.tsx
@@ -25,6 +25,7 @@ import {
   type AgentInfo,
   type KanbanTaskAssetInfo,
   type UpdateKanbanTaskRequest,
+  UNASSIGNED_GOAL_ID,
 } from '@shumai/dtos'
 import { getPriorityBadgeColor, getPriorityLabel } from '../kanban-types'
 import { TaskParentSelector } from '../task-parent-selector'
@@ -285,14 +286,16 @@ export function TaskInfoForm({ teamId, task, canEdit = true }: TaskInfoFormProps
                 <SelectItem value="none">
                   <span className="text-muted-foreground italic">None</span>
                 </SelectItem>
-                {goals.map((g) => (
-                  <SelectItem key={g.id} value={g.id}>
-                    <div className="flex items-center gap-2">
-                      <Target className="w-3.5 h-3.5 text-primary" />
-                      <span>{g.title}</span>
-                    </div>
-                  </SelectItem>
-                ))}
+                {goals
+                  .filter((g) => g.id !== UNASSIGNED_GOAL_ID)
+                  .map((g) => (
+                    <SelectItem key={g.id} value={g.id}>
+                      <div className="flex items-center gap-2">
+                        <Target className="w-3.5 h-3.5 text-primary" />
+                        <span>{g.title}</span>
+                      </div>
+                    </SelectItem>
+                  ))}
               </SelectContent>
             </Select>
           </div>

--- a/packages/webui/components/kanban/kanban-create-task-dialog.tsx
+++ b/packages/webui/components/kanban/kanban-create-task-dialog.tsx
@@ -30,6 +30,7 @@ import {
   type KanbanGoalInfo,
   type AgentInfo,
   type KanbanTaskAssetInfo,
+  UNASSIGNED_GOAL_ID,
 } from '@shumai/dtos'
 import { getPriorityBadgeColor, getPriorityLabel } from './kanban-types'
 import { TaskTargetFolderDialog } from './edit-task-dialog/task-target-folder-dialog'
@@ -54,11 +55,14 @@ export function KanbanCreateTaskDialog({
 }: KanbanCreateTaskDialogProps) {
   const queryClient = useQueryClient()
 
+  const effectiveInitialGoalId =
+    initialGoalId === UNASSIGNED_GOAL_ID || !initialGoalId ? 'none' : initialGoalId
+
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
   const [isAgentTask, setIsAgentTask] = useState(false)
   const [priority, setPriority] = useState<KanbanTaskPriority>(KanbanTaskPriority.MEDIUM)
-  const [goalId, setGoalId] = useState<string>(initialGoalId || 'none')
+  const [goalId, setGoalId] = useState<string>(effectiveInitialGoalId)
   const [assigneeId, setAssigneeId] = useState<string>('none')
   const [reporterId, setReporterId] = useState<string>('none')
   const [startDate, setStartDate] = useState<Date | undefined>(undefined)
@@ -76,7 +80,7 @@ export function KanbanCreateTaskDialog({
       setDescription('')
       setIsAgentTask(false)
       setPriority(KanbanTaskPriority.MEDIUM)
-      setGoalId(initialGoalId || 'none')
+      setGoalId(effectiveInitialGoalId)
       setAssigneeId('none')
       setReporterId('none')
       setStartDate(undefined)
@@ -87,7 +91,7 @@ export function KanbanCreateTaskDialog({
       setParentIds([])
       setSelectedAssets([])
     }
-  }, [isOpen, initialGoalId])
+  }, [isOpen, effectiveInitialGoalId])
 
   // Queries for selectors
   const { data: members = [] } = useQuery({
@@ -276,14 +280,16 @@ export function KanbanCreateTaskDialog({
                     <SelectItem value="none">
                       <span className="text-muted-foreground italic">None</span>
                     </SelectItem>
-                    {goals.map((g) => (
-                      <SelectItem key={g.id} value={g.id}>
-                        <div className="flex items-center gap-2">
-                          <Target className="w-3.5 h-3.5 text-primary" />
-                          <span>{g.title}</span>
-                        </div>
-                      </SelectItem>
-                    ))}
+                    {goals
+                      .filter((g) => g.id !== UNASSIGNED_GOAL_ID)
+                      .map((g) => (
+                        <SelectItem key={g.id} value={g.id}>
+                          <div className="flex items-center gap-2">
+                            <Target className="w-3.5 h-3.5 text-primary" />
+                            <span>{g.title}</span>
+                          </div>
+                        </SelectItem>
+                      ))}
                   </SelectContent>
                 </Select>
               </div>

--- a/packages/webui/components/kanban/kanban-goal-sidebar.tsx
+++ b/packages/webui/components/kanban/kanban-goal-sidebar.tsx
@@ -33,7 +33,7 @@ import {
   ChevronRight,
 } from 'lucide-react'
 import { toast } from 'sonner'
-import type { KanbanGoalInfo } from '@shumai/dtos'
+import { type KanbanGoalInfo, UNASSIGNED_GOAL_ID } from '@shumai/dtos'
 import { KanbanCreateGoalDialog } from './kanban-create-goal-dialog'
 
 interface KanbanGoalSidebarProps {
@@ -214,6 +214,8 @@ export function KanbanGoalSidebar({
           ) : (
             goals.map((goal) => {
               const isSelected = selectedGoalId === goal.id
+              const isUnassigned = goal.id === UNASSIGNED_GOAL_ID
+              const title = isUnassigned ? m.unassigned() : goal.title
               return (
                 <div
                   key={goal.id}
@@ -232,8 +234,8 @@ export function KanbanGoalSidebar({
                         isSelected ? 'text-sidebar-primary' : 'text-muted-foreground',
                       )}
                     />
-                    <span className="truncate" title={goal.title}>
-                      {goal.title}
+                    <span className="truncate" title={title}>
+                      {title}
                     </span>
                   </div>
 
@@ -244,7 +246,7 @@ export function KanbanGoalSidebar({
                       </span>
                     )}
 
-                    {isOwnerOrEditor && (
+                    {isOwnerOrEditor && !isUnassigned && (
                       <div
                         className="opacity-0 group-hover:opacity-100 [&:has([data-state=open])]:opacity-100 focus-within:opacity-100 transition-opacity flex items-center"
                         onClick={(e) => e.stopPropagation()}

--- a/packages/webui/components/kanban/kanban-goal-sidebar.tsx
+++ b/packages/webui/components/kanban/kanban-goal-sidebar.tsx
@@ -216,6 +216,7 @@ export function KanbanGoalSidebar({
               const isSelected = selectedGoalId === goal.id
               const isUnassigned = goal.id === UNASSIGNED_GOAL_ID
               const title = isUnassigned ? m.unassigned() : goal.title
+              const hasActions = isOwnerOrEditor && !isUnassigned
               return (
                 <div
                   key={goal.id}
@@ -239,49 +240,57 @@ export function KanbanGoalSidebar({
                     </span>
                   </div>
 
-                  <div className="flex items-center gap-1 shrink-0 ml-1">
-                    {(goal.taskCount ?? 0) > 0 && (
-                      <span className="text-[10px] font-mono px-1.5 py-0.5 rounded-full bg-sidebar-border text-sidebar-foreground/60">
-                        {goal.taskCount}
-                      </span>
-                    )}
+                  <div className="flex items-center shrink-0 ml-1">
+                    {hasActions ? (
+                      <>
+                        {(goal.taskCount ?? 0) > 0 && (
+                          <span className="text-[10px] font-mono px-1.5 py-0.5 rounded-full bg-sidebar-border text-sidebar-foreground/60 group-hover:hidden group-focus-within:hidden [&:has(~_div_[data-state=open])]:hidden">
+                            {goal.taskCount}
+                          </span>
+                        )}
 
-                    {isOwnerOrEditor && !isUnassigned && (
-                      <div
-                        className="opacity-0 group-hover:opacity-100 [&:has([data-state=open])]:opacity-100 focus-within:opacity-100 transition-opacity flex items-center"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <DropdownMenu modal={false}>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="icon-sm"
-                              className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
-                            >
-                              <MoreHorizontal className="w-3.5 h-3.5" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end" className="w-36">
-                            <DropdownMenuItem
-                              onClick={() => {
-                                setGoalToEdit(goal)
-                              }}
-                            >
-                              <Edit2 className="w-3.5 h-3.5 mr-2" />
-                              {m.edit()}
-                            </DropdownMenuItem>
-                            <DropdownMenuItem
-                              className="text-destructive focus:text-destructive focus:bg-destructive/10"
-                              onClick={() => {
-                                setGoalToDelete(goal)
-                              }}
-                            >
-                              <Trash2 className="w-3.5 h-3.5 mr-2" />
-                              {m.delete()}
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      </div>
+                        <div
+                          className="hidden group-hover:flex group-focus-within:flex [&:has([data-state=open])]:flex items-center"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <DropdownMenu modal={false}>
+                            <DropdownMenuTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="icon-sm"
+                                className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
+                              >
+                                <MoreHorizontal className="w-3.5 h-3.5" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end" className="w-36">
+                              <DropdownMenuItem
+                                onClick={() => {
+                                  setGoalToEdit(goal)
+                                }}
+                              >
+                                <Edit2 className="w-3.5 h-3.5 mr-2" />
+                                {m.edit()}
+                              </DropdownMenuItem>
+                              <DropdownMenuItem
+                                className="text-destructive focus:text-destructive focus:bg-destructive/10"
+                                onClick={() => {
+                                  setGoalToDelete(goal)
+                                }}
+                              >
+                                <Trash2 className="w-3.5 h-3.5 mr-2" />
+                                {m.delete()}
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        </div>
+                      </>
+                    ) : (
+                      (goal.taskCount ?? 0) > 0 && (
+                        <span className="text-[10px] font-mono px-1.5 py-0.5 rounded-full bg-sidebar-border text-sidebar-foreground/60">
+                          {goal.taskCount}
+                        </span>
+                      )
                     )}
                   </div>
                 </div>

--- a/packages/webui/components/kanban/kanban-header.tsx
+++ b/packages/webui/components/kanban/kanban-header.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/ui/components/ui/button'
 import { m } from '@/ui/paraglide/messages.js'
 import { Users, User, Plus, Target, X } from 'lucide-react'
-import type { KanbanGoalInfo } from '@shumai/dtos'
+import { type KanbanGoalInfo, UNASSIGNED_GOAL_ID } from '@shumai/dtos'
 
 interface KanbanHeaderProps {
   scope: 'team' | 'my'
@@ -56,7 +56,9 @@ export function KanbanHeader({
         {selectedGoal && (
           <div className="hidden sm:flex items-center gap-1.5 px-2 py-1 rounded-md bg-sidebar-accent border border-sidebar-border text-xs text-sidebar-accent-foreground min-w-0 max-w-[200px] md:max-w-[280px]">
             <Target className="w-3.5 h-3.5 text-sidebar-primary shrink-0" />
-            <span className="truncate font-medium">{selectedGoal.title}</span>
+            <span className="truncate font-medium">
+              {selectedGoal.id === UNASSIGNED_GOAL_ID ? m.unassigned() : selectedGoal.title}
+            </span>
             <Button
               variant="ghost"
               size="icon-xs"

--- a/packages/webui/components/kanban/kanban.test.tsx
+++ b/packages/webui/components/kanban/kanban.test.tsx
@@ -10,6 +10,7 @@ import {
   type KanbanTaskInfo,
   type KanbanGoalInfo,
   type KanbanCommentInfo,
+  UNASSIGNED_GOAL_ID,
 } from '@shumai/dtos'
 import {
   getStatusLabel,
@@ -21,7 +22,9 @@ import {
 import { KanbanCard } from './kanban-card'
 import { KanbanHeader } from './kanban-header'
 import { KanbanBoard } from './kanban-board'
+import { KanbanGoalSidebar } from './kanban-goal-sidebar'
 import { KanbanCreateGoalDialog } from './kanban-create-goal-dialog'
+import { KanbanCreateTaskDialog } from './kanban-create-task-dialog'
 import { TaskRelatedAssets } from './task-related-assets'
 import { TaskCommentCard } from './edit-task-dialog/task-comment-card'
 import { TaskCommentInput } from './edit-task-dialog/task-comment-input'
@@ -69,6 +72,7 @@ vi.mock('@/ui/api/client', () => ({
         ':teamId': {
           kanban: {
             goals: {
+              $get: vi.fn(),
               $post: vi.fn(),
               ':goalId': {
                 $patch: vi.fn(),
@@ -83,6 +87,18 @@ vi.mock('@/ui/api/client', () => ({
                 $delete: vi.fn(),
               },
             },
+          },
+          members: {
+            $get: vi.fn().mockResolvedValue({ ok: true, json: async () => [] }),
+          },
+          agents: {
+            $get: vi.fn().mockResolvedValue({ ok: true, json: async () => [] }),
+          },
+          me: {
+            $get: vi.fn().mockResolvedValue({
+              ok: true,
+              json: async () => ({ id: 'u-1', name: 'User 1', role: 'owner' }),
+            }),
           },
         },
       },
@@ -638,6 +654,118 @@ describe('Kanban UI Unit & Component Tests', () => {
       expect(removeButtons.length).toBe(2)
       fireEvent.click(removeButtons[0])
       expect(onRemove).toHaveBeenCalledWith('asset-1')
+    })
+  })
+
+  describe('KanbanGoalSidebar component', () => {
+    it('renders goals list with unassigned goal and calculates All Tasks sum correctly', async () => {
+      const mockGoals: KanbanGoalInfo[] = [
+        {
+          id: UNASSIGNED_GOAL_ID,
+          title: 'Unassigned',
+          teamId: 'team-1',
+          creatorId: null,
+          taskCount: 3,
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+        },
+        {
+          id: 'goal-1',
+          title: 'Sprint 1',
+          teamId: 'team-1',
+          creatorId: 'user-1',
+          taskCount: 5,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ]
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(client.api.teams[':teamId'].kanban.goals.$get as any) = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: mockGoals }),
+      })
+
+      const onSelectGoal = vi.fn()
+      render(
+        <KanbanGoalSidebar
+          teamId="team-1"
+          selectedGoalId={null}
+          onSelectGoal={onSelectGoal}
+          isOwnerOrEditor={true}
+        />,
+        { wrapper: createWrapper() },
+      )
+
+      // Total count in All Tasks should be 3 + 5 = 8
+      await waitFor(() => {
+        expect(screen.getByText('8')).toBeDefined()
+        expect(screen.getByText(/All Tasks|所有任务/i)).toBeDefined()
+        expect(screen.getByText(/Unassigned|未指派/i)).toBeDefined()
+        expect(screen.getByText('Sprint 1')).toBeDefined()
+      })
+
+      // Clicking Unassigned triggers onSelectGoal with UNASSIGNED_GOAL_ID
+      const unassignedElement = screen.getByText(/Unassigned|未指派/i)
+      fireEvent.click(unassignedElement)
+      expect(onSelectGoal).toHaveBeenCalledWith(UNASSIGNED_GOAL_ID)
+    })
+  })
+
+  describe('KanbanCreateTaskDialog goal handling', () => {
+    it('defaults goalId to none when opened with unassigned goal and excludes unassigned from options', async () => {
+      const mockGoals: KanbanGoalInfo[] = [
+        {
+          id: UNASSIGNED_GOAL_ID,
+          title: 'Unassigned',
+          teamId: 'team-1',
+          creatorId: null,
+          taskCount: 2,
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+        },
+        {
+          id: 'goal-1',
+          title: 'Alpha Goal',
+          teamId: 'team-1',
+          creatorId: 'user-1',
+          taskCount: 1,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ]
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(client.api.teams[':teamId'].kanban.goals.$get as any) = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: mockGoals }),
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(client.api.teams[':teamId'].members.$get as any) = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(client.api.teams[':teamId'].agents.$get as any) = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      })
+
+      render(
+        <KanbanCreateTaskDialog
+          teamId="team-1"
+          isOpen={true}
+          onClose={vi.fn()}
+          initialGoalId={UNASSIGNED_GOAL_ID}
+        />,
+        { wrapper: createWrapper() },
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText(/Create Task|创建任务/i)).toBeDefined()
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

Include an unassigned goal record in the Kanban Goals API to provide accurate task counts for unassigned tasks and correct the computed "All Tasks" total. In the UI, display the Unassigned entry directly beneath "All Tasks" as a non-editable filter item.

## Changes

- **DTOs ()**: Exported `UNASSIGNED_GOAL_ID = 'unassigned'`.
- **Core Service ()**:
  - `kanbanService.listGoals`: Queries count of tasks where `goalId: null` and prepends a virtual `UNASSIGNED_GOAL_ID` record.
  - `kanbanService.listTasks`: Maps `goalId === UNASSIGNED_GOAL_ID` to `goalId: null` filter in Prisma query.
  - `kanbanService.updateGoal` & `kanbanService.deleteGoal`: Prevent modifying or deleting `UNASSIGNED_GOAL_ID`.
- **WebUI ()**:
  - `kanban-goal-sidebar.tsx`: Renders the Unassigned goal item with localized text `m.unassigned()` and disables/hides the three-dot edit/delete menu.
  - `kanban-header.tsx`: Displays `m.unassigned()` in the goal filter badge when unassigned is selected.
  - `kanban-create-task-dialog.tsx` & `task-info-form.tsx`: Excludes `UNASSIGNED_GOAL_ID` from the goal assignment dropdown and defaults creation with `goalId: 'none'` when selected.
- **Tests**:
  - Core service tests in `kanban.test.ts` verifying unassigned goal listing, task querying, and mutation rejection.
  - WebUI unit tests in `kanban.test.tsx` verifying sidebar sum and task creation dropdown filtering.

## Verification

- `bun run lint` - passed
- `bun run format` - passed
- `bun run typecheck` - passed
- `bun run test` - passed (128 test files, 1258 tests)
- `bun run test:e2e:app` - passed (35 tests)
- `bun run test:e2e:webui` - passed (9 tests)
- `bun run test:e2e:workflow` - passed (14 test files, 58 tests)

## Notes

None.