### PR TITLE
fix(ci): pin bun version to 1.3.14 across CI and Docker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install
@@ -76,9 +76,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install
@@ -118,9 +118,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install
@@ -152,9 +152,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile:1.7-labs
 # Stage 1: Builder
-FROM oven/bun:1 AS builder
+FROM oven/bun:1.3.14 AS builder
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN bun run build.ts
 RUN bun run scripts/extract-runtime-deps.ts
 
 # Stage 2: Runner
-FROM oven/bun:1 AS runner
+FROM oven/bun:1.3.14 AS runner
 
 # Install ffmpeg/ffprobe
 COPY --from=mwader/static-ffmpeg:8.1 /ffmpeg /usr/local/bin/


### PR DESCRIPTION
## Summary

Pins the Bun runtime version to `1.3.14` across GitHub Actions CI workflows and the production Dockerfile to avoid compatibility issues introduced in Bun 1.4.

## Changes

- **`.github/workflows/ci.yaml`**: Updated `oven-sh/setup-bun@v1` to `@v2` and pinned `bun-version: 1.3.14` across all workflow jobs (`build_and_test`, `e2e_video_player`, `e2e_app`, `workflow_e2e`).
- **`.github/workflows/release-npm.yaml`**: Pinned `bun-version: 1.3.14` in the release job.
- **`Dockerfile`**: Pinned builder (`oven/bun:1.3.14 AS builder`) and runner (`oven/bun:1.3.14 AS runner`) base images from floating `oven/bun:1` to `oven/bun:1.3.14`.

## Verification

Ran all workspace checks locally:
- `bun run lint` (Passed)
- `bun run format` (Passed)
- `bun run typecheck` (Passed)
- `bun run test` (128 test files passed, 1258 tests passed)
- `bun run test:e2e:webui` (9 passed)
- `bun run test:e2e:app` (35 passed)
- `bun run test:e2e:workflow` (14 passed, 58 tests passed)

## Notes

None.