### PR TITLE
feat(kanban): resolve latest version for linked version stack assets and update demo login text

### DIFF
--- a/packages/core/src/kanban/kanban.test.ts
+++ b/packages/core/src/kanban/kanban.test.ts
@@ -874,5 +874,91 @@ describe('KanbanService', () => {
       await kanbanService.deleteTask(task.id, owner.id, 'owner')
       expect(await kanbanService.getAssetTaskCount(file.id)).toBe(0)
     })
+
+    it('returns latest version details for linked version stack assets', async () => {
+      const { team, owner } = await setupTeamAndUsers()
+      const { project, folder } = await setupProjectAndAssets(team.id, owner.id)
+
+      // Create a version stack
+      const versionStack = await prisma.asset.create({
+        data: {
+          name: '',
+          type: 'version_stack',
+          status: 'uploaded',
+          projectId: project.id,
+          parentId: folder.id,
+          creatorId: owner.id,
+          fileCount: 2,
+        },
+      })
+
+      // Create v1 and v2 files in the version stack
+      const storageKeyV2 = await prisma.storageKey.create({
+        data: { key: 'videos/v2.mp4', status: 'active' },
+      })
+      await prisma.asset.create({
+        data: {
+          name: 'Video_v1.mp4',
+          type: 'file',
+          mediaType: 'video/mp4',
+          status: 'processed',
+          parentId: versionStack.id,
+          projectId: project.id,
+          creatorId: owner.id,
+          sortIndex: 'b',
+          sizeByte: 1000,
+        },
+      })
+      await prisma.asset.create({
+        data: {
+          name: 'Video_v2.mp4',
+          type: 'file',
+          mediaType: 'video/mp4',
+          status: 'processed',
+          parentId: versionStack.id,
+          projectId: project.id,
+          creatorId: owner.id,
+          sortIndex: 'a', // 'a' < 'b', so v2 is the latest version
+          sizeByte: 2000,
+          storageKeyId: storageKeyV2.id,
+          media: {
+            proxyType: 'video',
+            videoPreview: {
+              key: 'previews/v2_preview.mp4',
+              width: 1920,
+              height: 1080,
+            },
+          } as unknown as PrismaJson.MediaInfo,
+        },
+      })
+
+      const task = await kanbanService.createTask(
+        team.id,
+        {
+          title: 'Task with version stack',
+          assetIds: [versionStack.id],
+        },
+        owner.id,
+        'owner',
+      )
+
+      // Verify getTask returns latest version info for the version stack
+      const detail = await kanbanService.getTask(task.id)
+      expect(detail.assets).toHaveLength(1)
+      const linkedAsset = detail.assets[0]
+      expect(linkedAsset.id).toBe(versionStack.id)
+      expect(linkedAsset.type).toBe('version_stack')
+      expect(linkedAsset.name).toBe('Video_v2.mp4')
+      expect(linkedAsset.sizeByte).toBe(2000)
+      expect(linkedAsset.proxyType).toBe('video')
+      expect(linkedAsset.thumbnailUrl).toBeDefined()
+
+      // Verify listTaskAssets also returns latest version info
+      const taskAssets = await kanbanService.listTaskAssets(task.id)
+      expect(taskAssets).toHaveLength(1)
+      expect(taskAssets[0].name).toBe('Video_v2.mp4')
+      expect(taskAssets[0].sizeByte).toBe(2000)
+      expect(taskAssets[0].proxyType).toBe('video')
+    })
   })
 })

--- a/packages/core/src/kanban/kanban.ts
+++ b/packages/core/src/kanban/kanban.ts
@@ -1,4 +1,4 @@
-import { prisma, type TeamMemberRole, type Prisma } from '@shumai/db'
+import { prisma, type TeamMemberRole, type Prisma, AssetType } from '@shumai/db'
 import { KanbanTaskStatus, KanbanTaskPriority, KanbanTaskEventType } from '@shumai/db/enums'
 import { HTTPException } from 'hono/http-exception'
 import { ulid } from 'ulid'
@@ -1221,13 +1221,52 @@ export class KanbanService {
 
     const bucket = process.env.S3_BUCKET || 'shumai'
 
+    const stackIds = new Set<string>()
+    for (const { asset } of assetLinks) {
+      if (asset.type === AssetType.version_stack) {
+        stackIds.add(asset.id)
+      }
+    }
+
+    const latestVersionsMap = new Map<
+      string,
+      Prisma.AssetGetPayload<{
+        include: {
+          creator: true
+          storageKey: true
+        }
+      }>
+    >()
+
+    if (stackIds.size > 0) {
+      const allVersions = await prisma.asset.findMany({
+        where: { parentId: { in: Array.from(stackIds) }, isDeleted: false },
+        include: {
+          creator: true,
+          storageKey: true,
+        },
+        orderBy: { sortIndex: 'asc' },
+      })
+      for (const v of allVersions) {
+        if (!latestVersionsMap.has(v.parentId!)) {
+          latestVersionsMap.set(v.parentId!, v)
+        }
+      }
+    }
+
     return await Promise.all(
       assetLinks.map(async ({ asset }) => {
-        const creatorImage = asset.creator ? await getAvatarUrl(asset.creator.image) : undefined
-        const media = (asset.media as unknown as Record<string, unknown>) || {}
+        const latestVersion =
+          asset.type === AssetType.version_stack ? latestVersionsMap.get(asset.id) : null
+        const target = latestVersion || asset
+
+        const targetCreator = target.creator || asset.creator
+        const creatorImage = targetCreator ? await getAvatarUrl(targetCreator.image) : undefined
+
+        const media = (target.media as unknown as Record<string, unknown>) || {}
         const proxyType =
           (media.proxyType as 'image' | 'video' | 'audio' | 'pdf' | null) ||
-          getProxyType(asset.mediaType, asset.name)
+          getProxyType(target.mediaType, target.name)
 
         let thumbnailUrl: string | null = null
         const imageTranscodes = media.imageTranscodes as Array<{ key: string }> | undefined
@@ -1236,7 +1275,7 @@ export class KanbanService {
         const thumbnailKey =
           imageTranscodes?.[0]?.key ||
           videoPreview?.key ||
-          (proxyType === 'image' ? asset.storageKey?.key : undefined)
+          (proxyType === 'image' ? target.storageKey?.key : undefined)
 
         if (thumbnailKey) {
           try {
@@ -1273,19 +1312,20 @@ export class KanbanService {
 
         return {
           id: asset.id,
-          name: asset.name,
+          name:
+            asset.type === AssetType.version_stack ? latestVersion?.name || asset.name : asset.name,
           type: asset.type,
           proxyType,
           thumbnailUrl,
           path,
-          creator: asset.creator
+          creator: targetCreator
             ? {
-                id: asset.creator.id,
-                name: asset.creator.name,
+                id: targetCreator.id,
+                name: targetCreator.name,
                 image: creatorImage,
               }
             : null,
-          sizeByte: Number(asset.sizeByte || 0),
+          sizeByte: Number(target.sizeByte || 0),
           fileCount: asset.fileCount,
           projectId: asset.projectId ?? null,
           createdAt: asset.createdAt.toISOString(),

--- a/packages/webui/messages/en.json
+++ b/packages/webui/messages/en.json
@@ -37,7 +37,7 @@
   "no_account_prompt": "Don't have an account? ",
   "sign_up": "Sign up",
   "demo_access": "Demo Access:",
-  "demo_access_instructions": "Use \"foo@bar.com\" as the email and \"foo\" as the password to login.",
+  "demo_access_instructions": "Use \"foo@bar.com\" as the email and \"foo\" as the password to login (this demo account is read-only).",
 
   "signup_subtitle": "Start building and organizing your space.",
   "signup_failed": "Signup failed",

--- a/packages/webui/messages/zh.json
+++ b/packages/webui/messages/zh.json
@@ -37,7 +37,7 @@
   "no_account_prompt": "还没有账户？",
   "sign_up": "注册",
   "demo_access": "演示访问：",
-  "demo_access_instructions": "使用 \"foo@bar.com\" 作为邮箱，\"foo\" 作为密码登录。",
+  "demo_access_instructions": "使用 \"foo@bar.com\" 作为邮箱，\"foo\" 作为密码登录（该演示账户为只读）。",
 
   "signup_subtitle": "开始构建和整理您的空间。",
   "signup_failed": "注册失败",

--- a/packages/webui/paraglide/messages/demo_access_instructions.d.ts
+++ b/packages/webui/paraglide/messages/demo_access_instructions.d.ts
@@ -1,7 +1,7 @@
 /**
 * | output |
 * | --- |
-* | "Use \"foo@bar.com\" as the email and \"foo\" as the password to login." |
+* | "Use \"foo@bar.com\" as the email and \"foo\" as the password to login (this demo account is read-only)." |
 *
 * @param {Demo_Access_InstructionsInputs} inputs
 * @param {{ locale?: "en" | "zh" }} options

--- a/packages/webui/paraglide/messages/demo_access_instructions.js
+++ b/packages/webui/paraglide/messages/demo_access_instructions.js
@@ -6,17 +6,17 @@ import { getLocale, experimentalStaticLocale } from '../runtime.js';
 /** @typedef {{}} Demo_Access_InstructionsInputs */
 
 const en_demo_access_instructions = /** @type {(inputs: Demo_Access_InstructionsInputs) => LocalizedString} */ () => {
-	return /** @type {LocalizedString} */ (`Use "foo@bar.com" as the email and "foo" as the password to login.`)
+	return /** @type {LocalizedString} */ (`Use "foo@bar.com" as the email and "foo" as the password to login (this demo account is read-only).`)
 };
 
 const zh_demo_access_instructions = /** @type {(inputs: Demo_Access_InstructionsInputs) => LocalizedString} */ () => {
-	return /** @type {LocalizedString} */ (`使用 "foo@bar.com" 作为邮箱，"foo" 作为密码登录。`)
+	return /** @type {LocalizedString} */ (`使用 "foo@bar.com" 作为邮箱，"foo" 作为密码登录（该演示账户为只读）。`)
 };
 
 /**
 * | output |
 * | --- |
-* | "Use \"foo@bar.com\" as the email and \"foo\" as the password to login." |
+* | "Use \"foo@bar.com\" as the email and \"foo\" as the password to login (this demo account is read-only)." |
 *
 * @param {Demo_Access_InstructionsInputs} inputs
 * @param {{ locale?: "en" | "zh" }} options


### PR DESCRIPTION
## Summary

1. Resolves the latest version's details (name, thumbnail, proxy type, size, and creator) for linked version stacks in Kanban task details/dialogs, consistent with the behavior in the list files API.
2. Updates the demo mode login banner in both English and Chinese to inform users that the demo account is read-only.

## Changes

- **Kanban Service (`packages/core/src/kanban/kanban.ts`)**: Updated `resolveTaskAssetInfos` to query and resolve the latest non-deleted child version for any linked `version_stack` asset so that its display name, proxy type, thumbnail URL, and creator image are correctly populated while preserving the version stack's asset ID and type.
- **Kanban Service Tests (`packages/core/src/kanban/kanban.test.ts`)**: Added integration test case verifying that `getTask` and `listTaskAssets` return the latest version info for linked version stack assets.
- **Internationalization (`packages/webui/messages/en.json`, `packages/webui/messages/zh.json`)**: Updated `demo_access_instructions` to indicate that the demo account is read-only, and recompiled Paraglide messages.

## Verification

- `bun run lint` (passed)
- `bun run format` (passed)
- `bun run typecheck` (passed)
- `bun run test` (all 128 test files and 1259 tests passed)
- `bun run test:e2e:webui` (all 9 tests passed)
- `bun run test:e2e:workflow` (all 14 test files and 58 tests passed)
- `bun run test:e2e:app` (all 35 tests passed)

## Notes

None.