### PR TITLE
fix(kanban): use true thumbnail and poster for task asset previews

### DIFF
--- a/packages/core/src/asset/asset.ts
+++ b/packages/core/src/asset/asset.ts
@@ -2131,7 +2131,7 @@ export class AssetService {
     )
   }
 
-  private async toPreviewInfo(asset: Asset | AssetWithIncludes): Promise<PreviewInfo | null> {
+  async toPreviewInfo(asset: Asset | AssetWithIncludes): Promise<PreviewInfo | null> {
     if (!asset.media) return null
 
     const proxyType = (asset.media?.proxyType || null) as 'image' | 'video' | 'audio' | 'pdf' | null

--- a/packages/core/src/kanban/kanban.test.ts
+++ b/packages/core/src/kanban/kanban.test.ts
@@ -923,6 +923,9 @@ describe('KanbanService', () => {
           storageKeyId: storageKeyV2.id,
           media: {
             proxyType: 'video',
+            poster: {
+              key: 'posters/v2_poster.webp',
+            },
             videoPreview: {
               key: 'previews/v2_preview.mp4',
               width: 1920,
@@ -959,6 +962,104 @@ describe('KanbanService', () => {
       expect(taskAssets[0].name).toBe('Video_v2.mp4')
       expect(taskAssets[0].sizeByte).toBe(2000)
       expect(taskAssets[0].proxyType).toBe('video')
+    })
+
+    it('returns true thumbnail for video (poster), image (thumbnail), and pdf (poster)', async () => {
+      const { team, owner } = await setupTeamAndUsers()
+      const { project } = await setupProjectAndAssets(team.id, owner.id)
+
+      const videoStorage = await prisma.storageKey.create({
+        data: { key: 'files/video.mp4', status: 'active' },
+      })
+      const videoAsset = await prisma.asset.create({
+        data: {
+          name: 'Video.mp4',
+          type: 'file',
+          mediaType: 'video/mp4',
+          status: 'processed',
+          projectId: project.id,
+          creatorId: owner.id,
+          storageKeyId: videoStorage.id,
+          media: {
+            proxyType: 'video',
+            poster: { key: 'posters/video_poster.webp' },
+            videoPreview: { key: 'previews/video_preview.mp4' },
+          } as unknown as PrismaJson.MediaInfo,
+        },
+      })
+
+      const imageStorage = await prisma.storageKey.create({
+        data: { key: 'files/raw_image.tiff', status: 'active' },
+      })
+      const imageAsset = await prisma.asset.create({
+        data: {
+          name: 'Photo.tiff',
+          type: 'file',
+          mediaType: 'image/tiff',
+          status: 'processed',
+          projectId: project.id,
+          creatorId: owner.id,
+          storageKeyId: imageStorage.id,
+          media: {
+            proxyType: 'image',
+            thumbnail: { key: 'thumbnails/photo_300p.webp' },
+            imageTranscodes: [{ key: 'transcodes/photo_1080p.webp' }],
+          } as unknown as PrismaJson.MediaInfo,
+        },
+      })
+
+      const pdfStorage = await prisma.storageKey.create({
+        data: { key: 'files/doc.pdf', status: 'active' },
+      })
+      const pdfAsset = await prisma.asset.create({
+        data: {
+          name: 'Doc.pdf',
+          type: 'file',
+          mediaType: 'application/pdf',
+          status: 'processed',
+          projectId: project.id,
+          creatorId: owner.id,
+          storageKeyId: pdfStorage.id,
+          media: {
+            proxyType: 'pdf',
+            poster: { key: 'posters/doc_poster.webp' },
+          } as unknown as PrismaJson.MediaInfo,
+        },
+      })
+
+      const task = await kanbanService.createTask(
+        team.id,
+        {
+          title: 'Task with media assets',
+          assetIds: [videoAsset.id, imageAsset.id, pdfAsset.id],
+        },
+        owner.id,
+        'owner',
+      )
+
+      const detail = await kanbanService.getTask(task.id)
+      expect(detail.assets).toHaveLength(3)
+
+      const videoDetail = detail.assets.find((a) => a.id === videoAsset.id)
+      expect(videoDetail).toBeDefined()
+      expect(videoDetail?.proxyType).toBe('video')
+      // Must use poster, NOT videoPreview mp4
+      expect(videoDetail?.thumbnailUrl).toContain('posters/video_poster.webp')
+      expect(videoDetail?.thumbnailUrl).not.toContain('previews/video_preview.mp4')
+
+      const imageDetail = detail.assets.find((a) => a.id === imageAsset.id)
+      expect(imageDetail).toBeDefined()
+      expect(imageDetail?.proxyType).toBe('image')
+      // Must use 300p thumbnail, NOT full image transcode or original storage key
+      expect(imageDetail?.thumbnailUrl).toContain('thumbnails/photo_300p.webp')
+      expect(imageDetail?.thumbnailUrl).not.toContain('transcodes/photo_1080p.webp')
+      expect(imageDetail?.thumbnailUrl).not.toContain('files/raw_image.tiff')
+
+      const pdfDetail = detail.assets.find((a) => a.id === pdfAsset.id)
+      expect(pdfDetail).toBeDefined()
+      expect(pdfDetail?.proxyType).toBe('pdf')
+      // Must use poster for pdf
+      expect(pdfDetail?.thumbnailUrl).toContain('posters/doc_poster.webp')
     })
   })
 })

--- a/packages/core/src/kanban/kanban.ts
+++ b/packages/core/src/kanban/kanban.ts
@@ -7,6 +7,7 @@ import { paginateQuery } from '../pagination'
 import { getAvatarUrl } from '../user/avatar'
 import { s3Service } from '../s3/s3'
 import { getProxyType } from '../utils/mime'
+import { assetService } from '../asset/asset'
 import type {
   CreateKanbanGoalRequest,
   UpdateKanbanGoalRequest,
@@ -1219,8 +1220,6 @@ export class KanbanService {
   ): Promise<KanbanTaskAssetInfo[]> {
     if (!assetLinks || assetLinks.length === 0) return []
 
-    const bucket = process.env.S3_BUCKET || 'shumai'
-
     const stackIds = new Set<string>()
     for (const { asset } of assetLinks) {
       if (asset.type === AssetType.version_stack) {
@@ -1263,27 +1262,12 @@ export class KanbanService {
         const targetCreator = target.creator || asset.creator
         const creatorImage = targetCreator ? await getAvatarUrl(targetCreator.image) : undefined
 
-        const media = (target.media as unknown as Record<string, unknown>) || {}
+        const preview = await assetService.toPreviewInfo(target)
         const proxyType =
-          (media.proxyType as 'image' | 'video' | 'audio' | 'pdf' | null) ||
+          preview?.proxyType ||
+          (target.media as PrismaJson.MediaInfo | null)?.proxyType ||
           getProxyType(target.mediaType, target.name)
-
-        let thumbnailUrl: string | null = null
-        const imageTranscodes = media.imageTranscodes as Array<{ key: string }> | undefined
-        const videoPreview = media.videoPreview as { key?: string } | undefined
-
-        const thumbnailKey =
-          imageTranscodes?.[0]?.key ||
-          videoPreview?.key ||
-          (proxyType === 'image' ? target.storageKey?.key : undefined)
-
-        if (thumbnailKey) {
-          try {
-            thumbnailUrl = await s3Service.presign(bucket, thumbnailKey, 'GET')
-          } catch {
-            thumbnailUrl = null
-          }
-        }
+        const thumbnailUrl = preview?.thumbnailUrl ?? null
 
         let path = '/'
         try {


### PR DESCRIPTION
## Summary

Fixes the Kanban task asset thumbnail resolution logic by reusing `AssetService.toPreviewInfo`. Previously, video assets resolved to `videoPreview.mp4` (breaking the `<img>` preview) and images bypassed the 300p WebP thumbnail (`media.thumbnail.key`).

## Changes

- Made `AssetService.toPreviewInfo` public to standardize preview and thumbnail generation across the codebase.
- Updated `KanbanService.getTaskAssets` to resolve `proxyType` and `thumbnailUrl` via `assetService.toPreviewInfo(target)`:
  - Video and PDF assets now resolve to their poster WebP frame (`media.poster.key`).
  - Image assets now resolve to the 300p thumbnail (`media.thumbnail.key`).
  - Unprocessed assets return `thumbnailUrl: null`, falling back to standard UI type icons.
- Added comprehensive unit tests in `packages/core/src/kanban/kanban.test.ts` covering video poster, image thumbnail, and PDF poster handling.

## Verification

All required checks and test suites passed simultaneously:
- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test` (128 test files, 1260 tests passed)
- `bun run test:e2e:webui` (9 tests passed)
- `bun run test:e2e:workflow` (14 test files, 58 tests passed)
- `bun run test:e2e:app` (35 tests passed)

## Notes

None.