### PR TITLE
feat(kanban): update task status permissions, reporter defaults, and participant access

### DIFF
--- a/packages/api/src/kanban/tasks.ts
+++ b/packages/api/src/kanban/tasks.ts
@@ -123,7 +123,7 @@ const route = new Hono<{ Variables: { user: User } }>()
       })
 
       const existing = await kanbanService.getTask(taskId)
-      const role = await resolveEffectiveRole(teamId, undefined, user.id)
+      const role = await resolveEffectiveRole(teamId, existing.projectId ?? undefined, user.id)
       const task = await kanbanService.updateTask(taskId, req, user.id, role)
 
       const hasMeaningfulChanges =
@@ -210,8 +210,8 @@ const route = new Hono<{ Variables: { user: User } }>()
       id: taskId,
     })
 
-    const role = await resolveEffectiveRole(teamId, undefined, user.id)
     const existing = await kanbanService.getTask(taskId)
+    const role = await resolveEffectiveRole(teamId, existing.projectId ?? undefined, user.id)
 
     notificationService.notifyKanbanTaskEvent({
       type: 'kanban_task_deleted',

--- a/packages/core/src/authz/authz.test.ts
+++ b/packages/core/src/authz/authz.test.ts
@@ -502,5 +502,98 @@ describe('AuthzService', () => {
         }),
       ).rejects.toThrow('User has only project scope')
     })
+
+    it('allows project-scoped and reviewer participants to edit team-level Kanban tasks', async () => {
+      const creator = await prisma.user.create({
+        data: { name: 'Owner User', email: 'owner-kanban@example.com', password: 'pass' },
+      })
+      const projectScopedUser = await prisma.user.create({
+        data: { name: 'Proj Member', email: 'proj-kanban@example.com', password: 'pass' },
+      })
+      const reviewerUser = await prisma.user.create({
+        data: { name: 'Reviewer User', email: 'rev-kanban@example.com', password: 'pass' },
+      })
+      const unassignedUser = await prisma.user.create({
+        data: { name: 'Unassigned User', email: 'unassigned-kanban@example.com', password: 'pass' },
+      })
+
+      const team = await prisma.team.create({ data: { name: 'Kanban Team' } })
+      const project = await prisma.project.create({ data: { name: 'Project K', teamId: team.id } })
+
+      await prisma.teamMember.create({
+        data: { teamId: team.id, userId: creator.id, role: 'owner', scope: 'team' },
+      })
+      const tmProj = await prisma.teamMember.create({
+        data: { teamId: team.id, userId: projectScopedUser.id, role: 'reviewer', scope: 'project' },
+      })
+      await prisma.projectMember.create({
+        data: { projectId: project.id, teamMemberId: tmProj.id, role: 'editor' },
+      })
+      await prisma.teamMember.create({
+        data: { teamId: team.id, userId: reviewerUser.id, role: 'reviewer', scope: 'team' },
+      })
+      await prisma.teamMember.create({
+        data: { teamId: team.id, userId: unassignedUser.id, role: 'reviewer', scope: 'project' },
+      })
+
+      // Team-level task (no projectId)
+      const teamTask = await prisma.kanbanTask.create({
+        data: {
+          teamId: team.id,
+          title: 'Team Task for Project Member',
+          creatorId: creator.id,
+          reporterId: creator.id,
+          assigneeId: projectScopedUser.id,
+        },
+      })
+
+      // 1. Project-scoped assignee on team task CAN edit
+      await expect(
+        authzService.hasPermission({
+          type: ResourceType.KanbanTask,
+          id: teamTask.id,
+          user: projectScopedUser,
+          permission: Permission.Edit,
+        }),
+      ).resolves.toBeUndefined()
+
+      // 2. Reviewer who is reporter CAN edit
+      const reviewerReportedTask = await prisma.kanbanTask.create({
+        data: {
+          teamId: team.id,
+          title: 'Task Reported by Reviewer',
+          creatorId: creator.id,
+          reporterId: reviewerUser.id,
+        },
+      })
+      await expect(
+        authzService.hasPermission({
+          type: ResourceType.KanbanTask,
+          id: reviewerReportedTask.id,
+          user: reviewerUser,
+          permission: Permission.Edit,
+        }),
+      ).resolves.toBeUndefined()
+
+      // 3. Unassigned project-scoped user CANNOT edit team task
+      await expect(
+        authzService.hasPermission({
+          type: ResourceType.KanbanTask,
+          id: teamTask.id,
+          user: unassignedUser,
+          permission: Permission.Edit,
+        }),
+      ).rejects.toThrow('User has only project scope')
+
+      // 4. Unassigned reviewer CANNOT edit team task
+      await expect(
+        authzService.hasPermission({
+          type: ResourceType.KanbanTask,
+          id: teamTask.id,
+          user: reviewerUser,
+          permission: Permission.Edit,
+        }),
+      ).rejects.toThrow('Permission denied')
+    })
   })
 })

--- a/packages/core/src/authz/authz.ts
+++ b/packages/core/src/authz/authz.ts
@@ -95,7 +95,18 @@ export class AuthzService {
     // (project override -> team role for team-scoped members -> restricted).
     const role = await resolveEffectiveRole(teamId, projectId, req.user.id)
     if (role) {
-      return this.checkRole(role, req.permission)
+      try {
+        return this.checkRole(role, req.permission)
+      } catch (err) {
+        // If role check failed (e.g. reviewer requesting Permission.Edit on a KanbanTask where they are assignee/reporter/creator), allow it.
+        if (req.type === ResourceType.KanbanTask && req.permission === Permission.Edit) {
+          const isParticipant = await this.isKanbanTaskParticipant(req.id, req.user.id)
+          if (isParticipant) {
+            return
+          }
+        }
+        throw err
+      }
     }
 
     // No effective role: either not a team member, or a project-scoped member
@@ -110,12 +121,34 @@ export class AuthzService {
     })
     if (!member) throw new HTTPException(403, { message: 'User is not a member of the team' })
 
+    // If this is a KanbanTask and user is a team member, check if they are the assignee, reporter, or creator
+    if (req.type === ResourceType.KanbanTask) {
+      if (req.permission === Permission.Read) {
+        return
+      }
+      if (req.permission === Permission.Edit) {
+        const isParticipant = await this.isKanbanTaskParticipant(req.id, req.user.id)
+        if (isParticipant) {
+          return
+        }
+      }
+    }
+
     // Project-scoped member on a team-level resource (no project context):
     // allow Read (e.g. listing), deny Edit/Admin.
     if (!projectId && req.permission === Permission.Read) {
       return
     }
     throw new HTTPException(403, { message: 'User has only project scope' })
+  }
+
+  private async isKanbanTaskParticipant(taskId: string, userId: string): Promise<boolean> {
+    const task = await prisma.kanbanTask.findUnique({
+      where: { id: taskId },
+      select: { creatorId: true, reporterId: true, assigneeId: true },
+    })
+    if (!task) return false
+    return task.creatorId === userId || task.reporterId === userId || task.assigneeId === userId
   }
 
   private async resolveContext(

--- a/packages/core/src/kanban/kanban.test.ts
+++ b/packages/core/src/kanban/kanban.test.ts
@@ -308,25 +308,73 @@ describe('KanbanService', () => {
     })
 
     it('deletes tasks properly with permissions', async () => {
-      const { team, editor, reviewer } = await setupTeamAndUsers()
+      const { team, owner, editor, reviewer } = await setupTeamAndUsers()
+
+      const otherEditor = await prisma.user.create({
+        data: { name: 'Other Editor', email: 'other-editor-del@example.com' },
+      })
+      await prisma.teamMember.create({
+        data: { teamId: team.id, userId: otherEditor.id, role: 'editor', scope: 'team' },
+      })
 
       const task = await kanbanService.createTask(
         team.id,
-        { title: 'Task to Delete', isAgentTask: false },
+        {
+          title: 'Task to Delete',
+          isAgentTask: false,
+          reporterId: reviewer.id,
+          assigneeId: otherEditor.id,
+        },
         editor.id,
         'editor',
       )
 
-      // Reviewer (not creator, not owner, not reporter) cannot delete
-      await expect(kanbanService.deleteTask(task.id, reviewer.id, 'reviewer')).rejects.toThrow()
+      // Other editor (who is assignee, not creator/reporter/owner) cannot delete
+      await expect(kanbanService.deleteTask(task.id, otherEditor.id, 'editor')).rejects.toThrow(
+        /Only team owners, task creators, or reporters can delete tasks/,
+      )
 
-      // Creator (editor) can delete
-      const deleted = await kanbanService.deleteTask(task.id, editor.id, 'editor')
-      expect(deleted.id).toBe(task.id)
+      // Reporter (reviewer) CAN delete
+      const deletedByReporter = await kanbanService.deleteTask(task.id, reviewer.id, 'reviewer')
+      expect(deletedByReporter.id).toBe(task.id)
 
       // Confirm deleted from db
       const fromDb = await prisma.kanbanTask.findUnique({ where: { id: task.id } })
       expect(fromDb).toBeNull()
+
+      // Creator (editor) can delete their own task
+      const task2 = await kanbanService.createTask(
+        team.id,
+        { title: 'Task 2 to Delete' },
+        editor.id,
+        'editor',
+      )
+      const deletedByCreator = await kanbanService.deleteTask(task2.id, editor.id, 'editor')
+      expect(deletedByCreator.id).toBe(task2.id)
+
+      // Owner can delete any task
+      const task3 = await kanbanService.createTask(
+        team.id,
+        { title: 'Task 3 to Delete' },
+        editor.id,
+        'editor',
+      )
+      const deletedByOwner = await kanbanService.deleteTask(task3.id, owner.id, 'owner')
+      expect(deletedByOwner.id).toBe(task3.id)
+    })
+
+    it('defaults reporterId to creatorId when not explicitly provided', async () => {
+      const { team, editor } = await setupTeamAndUsers()
+
+      const task = await kanbanService.createTask(
+        team.id,
+        { title: 'Task without explicit reporter' },
+        editor.id,
+        'editor',
+      )
+
+      expect(task.reporter).toBeDefined()
+      expect(task.reporter?.id).toBe(editor.id)
     })
   })
 
@@ -397,7 +445,7 @@ describe('KanbanService', () => {
       expect(todo.status).toBe(KanbanTaskStatus.TODO)
     })
 
-    it('enforces status change permissions (only owner, reporter, or assignee can change status)', async () => {
+    it('enforces status change permissions (owner, editor, reporter, or assignee can change status; unassigned reviewer rejected)', async () => {
       const { team, owner, editor, reviewer } = await setupTeamAndUsers()
 
       // Create another editor in team who is NOT reporter and NOT assignee
@@ -406,6 +454,14 @@ describe('KanbanService', () => {
       })
       await prisma.teamMember.create({
         data: { teamId: team.id, userId: otherEditor.id, role: 'editor', scope: 'team' },
+      })
+
+      // Create an unassigned reviewer
+      const unassignedReviewer = await prisma.user.create({
+        data: { name: 'Unassigned Reviewer', email: 'unassigned-reviewer@example.com' },
+      })
+      await prisma.teamMember.create({
+        data: { teamId: team.id, userId: unassignedReviewer.id, role: 'reviewer', scope: 'team' },
       })
 
       // Create a task: reporter is editor, assignee is reviewer
@@ -420,15 +476,14 @@ describe('KanbanService', () => {
         'editor',
       )
 
-      // Other editor tries to change status -> rejected with 403
-      await expect(
-        kanbanService.updateTask(
-          task.id,
-          { status: KanbanTaskStatus.IN_PROGRESS },
-          otherEditor.id,
-          'editor',
-        ),
-      ).rejects.toThrow(/Only team owners, task reporters, or assignees can change task status/)
+      // Other editor CAN change status (editors now have permission)
+      const editorUpdated = await kanbanService.updateTask(
+        task.id,
+        { status: KanbanTaskStatus.IN_PROGRESS },
+        otherEditor.id,
+        'editor',
+      )
+      expect(editorUpdated.status).toBe(KanbanTaskStatus.IN_PROGRESS)
 
       // Other editor CAN update non-status fields (e.g. description)
       const descUpdated = await kanbanService.updateTask(
@@ -439,32 +494,54 @@ describe('KanbanService', () => {
       )
       expect(descUpdated.description).toBe('Updated by other editor')
 
+      // Unassigned reviewer tries to change status -> rejected with 403
+      await expect(
+        kanbanService.updateTask(
+          task.id,
+          { status: KanbanTaskStatus.BLOCKED },
+          unassignedReviewer.id,
+          'reviewer',
+        ),
+      ).rejects.toThrow(
+        /Only team owners, editors, task reporters, or assignees can change task status/,
+      )
+
+      // Unassigned reviewer tries to update non-status field -> rejected with 403
+      await expect(
+        kanbanService.updateTask(
+          task.id,
+          { description: 'Hacked by reviewer' },
+          unassignedReviewer.id,
+          'reviewer',
+        ),
+      ).rejects.toThrow(/Permission denied/)
+
       // Reporter (editor) CAN change status -> succeeds
       const reporterUpdated = await kanbanService.updateTask(
         task.id,
-        { status: KanbanTaskStatus.IN_PROGRESS },
+        { status: KanbanTaskStatus.IN_REVIEW },
         editor.id,
         'editor',
       )
-      expect(reporterUpdated.status).toBe(KanbanTaskStatus.IN_PROGRESS)
+      expect(reporterUpdated.status).toBe(KanbanTaskStatus.IN_REVIEW)
 
       // Assignee (reviewer) CAN change status -> succeeds
       const assigneeUpdated = await kanbanService.updateTask(
         task.id,
-        { status: KanbanTaskStatus.IN_REVIEW },
+        { status: KanbanTaskStatus.DONE },
         reviewer.id,
         'reviewer',
       )
-      expect(assigneeUpdated.status).toBe(KanbanTaskStatus.IN_REVIEW)
+      expect(assigneeUpdated.status).toBe(KanbanTaskStatus.DONE)
 
       // Owner CAN change status -> succeeds
       const ownerUpdated = await kanbanService.updateTask(
         task.id,
-        { status: KanbanTaskStatus.DONE },
+        { status: KanbanTaskStatus.TODO },
         owner.id,
         'owner',
       )
-      expect(ownerUpdated.status).toBe(KanbanTaskStatus.DONE)
+      expect(ownerUpdated.status).toBe(KanbanTaskStatus.TODO)
     })
 
     it('handles status CAS (Compare-And-Swap) with fromStatus validation', async () => {

--- a/packages/core/src/kanban/kanban.ts
+++ b/packages/core/src/kanban/kanban.ts
@@ -229,6 +229,8 @@ export class KanbanService {
       })
       const sortIndex = generateKeyBetween(lastTask?.sortIndex || null, null)
 
+      const effectiveReporterId = req.reporterId || creatorId
+
       const created = await tx.kanbanTask.create({
         data: {
           teamId,
@@ -241,7 +243,7 @@ export class KanbanService {
           dueDate: req.dueDate ? new Date(req.dueDate) : null,
           goalId: req.goalId,
           projectId: req.projectId,
-          reporterId: req.reporterId,
+          reporterId: effectiveReporterId,
           assigneeId: req.assigneeId,
           targetFolderId: req.targetFolderId,
           creatorId,
@@ -449,11 +451,12 @@ export class KanbanService {
       const isReporter = current.reporterId === actorId || current.creatorId === actorId
       const isAssignee = current.assigneeId === actorId
 
-      // Status change permission check: only owner, reporter, or assignee can change task status
+      // Status change permission check: owner, editor, reporter, or assignee can change task status
       if (req.status !== undefined && req.status !== current.status) {
-        if (!isOwner && !isReporter && !isAssignee) {
+        if (!isOwner && !isEditor && !isReporter && !isAssignee) {
           throw new HTTPException(403, {
-            message: 'Only team owners, task reporters, or assignees can change task status',
+            message:
+              'Only team owners, editors, task reporters, or assignees can change task status',
           })
         }
       }

--- a/packages/webui/api/client.ts
+++ b/packages/webui/api/client.ts
@@ -1,7 +1,6 @@
 import { hc } from 'hono/client'
 import type { AppType } from '@shumai/api'
 import { useAuthStore } from '@/ui/stores/auth'
-import { toast } from 'sonner'
 
 const customFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
   const response = await fetch(input, init)
@@ -18,12 +17,6 @@ const customFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       useAuthStore.getState().clearAuth()
       window.location.href = '/login'
     }
-  }
-
-  if (response.status === 403) {
-    toast.error('You do not have permission. Please contact the team admin.', {
-      id: 'forbidden-error',
-    })
   }
 
   return response

--- a/packages/webui/components/kanban/kanban-board.tsx
+++ b/packages/webui/components/kanban/kanban-board.tsx
@@ -239,9 +239,10 @@ export function KanbanBoard({
 
     // Check status change permission
     const isOwner = currentUserRole?.toLowerCase() === 'owner'
+    const isEditor = currentUserRole?.toLowerCase() === 'editor'
     const isReporter = task.reporter?.id === currentUserId || task.creator?.id === currentUserId
     const isAssignee = task.assignee?.id === currentUserId
-    if (!isOwner && !isReporter && !isAssignee) {
+    if (!isOwner && !isEditor && !isReporter && !isAssignee) {
       toast.error(m.cannot_change_task_status_permission())
       return
     }

--- a/packages/webui/components/kanban/kanban-card.tsx
+++ b/packages/webui/components/kanban/kanban-card.tsx
@@ -50,11 +50,12 @@ export function KanbanCard({
   const isDraggingAny = !!source
 
   const isOwner = currentUserRole?.toLowerCase() === 'owner'
+  const isEditor = currentUserRole?.toLowerCase() === 'editor'
   const isCreator = !!currentUserId && task.creator?.id === currentUserId
   const isReporter = task.reporter?.id === currentUserId || isCreator
   const isAssignee = task.assignee?.id === currentUserId
-  const canChangeStatus = isOwner || isReporter || isAssignee
-  const canDelete = isCreator || isOwner
+  const canChangeStatus = isOwner || isEditor || isReporter || isAssignee
+  const canDelete = isCreator || isOwner || isReporter
   const isDragDisabled = disabled || !canChangeStatus
 
   const { ref: setDraggableRef, isDragging } = useDraggable({

--- a/packages/webui/components/kanban/kanban-column.tsx
+++ b/packages/webui/components/kanban/kanban-column.tsx
@@ -35,6 +35,9 @@ export function KanbanColumn({
   onDeleteTask,
   onCreateTaskInColumn,
 }: KanbanColumnProps) {
+  const isOwnerOrEditor =
+    currentUserRole?.toLowerCase() === 'owner' || currentUserRole?.toLowerCase() === 'editor'
+
   const { ref: setDroppableRef, isDropTarget } = useDroppable({
     id: status,
     data: {
@@ -161,17 +164,19 @@ export function KanbanColumn({
       </ScrollArea>
 
       {/* Fixed Column Footer: + Create Task */}
-      <div className="p-2 border-t border-border/50 bg-card/90 shrink-0">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => onCreateTaskInColumn(status)}
-          className="w-full justify-center h-8 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted/80 border border-dashed border-border/80"
-        >
-          <Plus className="w-3.5 h-3.5 mr-1.5" />
-          <span>{m.create_task()}</span>
-        </Button>
-      </div>
+      {isOwnerOrEditor && (
+        <div className="p-2 border-t border-border/50 bg-card/90 shrink-0">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onCreateTaskInColumn(status)}
+            className="w-full justify-center h-8 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted/80 border border-dashed border-border/80"
+          >
+            <Plus className="w-3.5 h-3.5 mr-1.5" />
+            <span>{m.create_task()}</span>
+          </Button>
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/webui/components/kanban/kanban-create-task-dialog.tsx
+++ b/packages/webui/components/kanban/kanban-create-task-dialog.tsx
@@ -170,8 +170,19 @@ export function KanbanCreateTaskDialog({
         },
       })
       if (!res.ok) {
-        const err = await res.json().catch(() => ({ message: m.error() }))
-        throw new Error((err as { message?: string }).message || m.error())
+        const text = await res.text().catch(() => '')
+        let errorMsg: string = m.error()
+        if (text) {
+          try {
+            const json = JSON.parse(text)
+            if (json && typeof json.message === 'string') {
+              errorMsg = json.message
+            }
+          } catch {
+            errorMsg = text
+          }
+        }
+        throw new Error(errorMsg)
       }
       return await res.json()
     },

--- a/packages/webui/components/kanban/kanban-create-task-dialog.tsx
+++ b/packages/webui/components/kanban/kanban-create-task-dialog.tsx
@@ -74,6 +74,19 @@ export function KanbanCreateTaskDialog({
   const [selectedAssets, setSelectedAssets] = useState<KanbanTaskAssetInfo[]>([])
   const [isFolderPickerOpen, setIsFolderPickerOpen] = useState(false)
 
+  // Query Current User to default reporter
+  const { data: me } = useQuery({
+    queryKey: ['teams', teamId, 'me'],
+    queryFn: async () => {
+      const res = await client.api.teams[':teamId'].me.$get({
+        param: { teamId },
+      })
+      if (!res.ok) return null
+      return await res.json()
+    },
+    enabled: !!teamId && isOpen,
+  })
+
   useEffect(() => {
     if (isOpen) {
       setTitle('')
@@ -82,7 +95,7 @@ export function KanbanCreateTaskDialog({
       setPriority(KanbanTaskPriority.MEDIUM)
       setGoalId(effectiveInitialGoalId)
       setAssigneeId('none')
-      setReporterId('none')
+      setReporterId(me?.id || 'none')
       setStartDate(undefined)
       setDueDate(undefined)
       setProjectId(null)
@@ -91,7 +104,7 @@ export function KanbanCreateTaskDialog({
       setParentIds([])
       setSelectedAssets([])
     }
-  }, [isOpen, effectiveInitialGoalId])
+  }, [isOpen, effectiveInitialGoalId, me?.id])
 
   // Queries for selectors
   const { data: members = [] } = useQuery({

--- a/packages/webui/components/kanban/kanban-header.tsx
+++ b/packages/webui/components/kanban/kanban-header.tsx
@@ -9,6 +9,7 @@ interface KanbanHeaderProps {
   selectedGoal: KanbanGoalInfo | null
   onClearGoal: () => void
   onCreateTask: () => void
+  canCreateTask?: boolean
 }
 
 export function KanbanHeader({
@@ -17,6 +18,7 @@ export function KanbanHeader({
   selectedGoal,
   onClearGoal,
   onCreateTask,
+  canCreateTask = true,
 }: KanbanHeaderProps) {
   return (
     <header className="h-14 border-b border-border bg-card/60 backdrop-blur-sm px-4 flex items-center justify-between gap-3 shrink-0 select-none">
@@ -73,13 +75,15 @@ export function KanbanHeader({
       </div>
 
       {/* Right side: Create button */}
-      <div className="flex items-center gap-2 shrink-0">
-        {/* Create Task Button */}
-        <Button size="sm" onClick={onCreateTask} className="h-8 px-3 text-xs gap-1.5 shadow-xs">
-          <Plus className="w-3.5 h-3.5" />
-          <span>{m.create_task()}</span>
-        </Button>
-      </div>
+      {canCreateTask && (
+        <div className="flex items-center gap-2 shrink-0">
+          {/* Create Task Button */}
+          <Button size="sm" onClick={onCreateTask} className="h-8 px-3 text-xs gap-1.5 shadow-xs">
+            <Plus className="w-3.5 h-3.5" />
+            <span>{m.create_task()}</span>
+          </Button>
+        </div>
+      )}
     </header>
   )
 }

--- a/packages/webui/components/kanban/kanban-page.tsx
+++ b/packages/webui/components/kanban/kanban-page.tsx
@@ -97,6 +97,7 @@ export function KanbanPage({ teamId, initialTaskId }: KanbanPageProps) {
           selectedGoal={selectedGoal}
           onClearGoal={() => setSelectedGoalId(null)}
           onCreateTask={() => handleOpenCreateTask(KanbanTaskStatus.TODO)}
+          canCreateTask={isOwnerOrEditor}
         />
 
         <KanbanBoard

--- a/packages/webui/components/kanban/kanban.test.tsx
+++ b/packages/webui/components/kanban/kanban.test.tsx
@@ -21,6 +21,7 @@ import {
 } from './kanban-types'
 import { KanbanCard } from './kanban-card'
 import { KanbanHeader } from './kanban-header'
+import { KanbanColumn } from './kanban-column'
 import { KanbanBoard } from './kanban-board'
 import { KanbanGoalSidebar } from './kanban-goal-sidebar'
 import { KanbanCreateGoalDialog } from './kanban-create-goal-dialog'
@@ -782,6 +783,78 @@ describe('Kanban UI Unit & Component Tests', () => {
       await waitFor(() => {
         expect(screen.getByText(/Create Task|创建任务/i)).toBeDefined()
       })
+    })
+  })
+
+  describe('Task creation button visibility based on permissions', () => {
+    it('KanbanHeader: hides Create Task button when canCreateTask is false', () => {
+      const { rerender } = render(
+        <KanbanHeader
+          scope="team"
+          onScopeChange={vi.fn()}
+          selectedGoal={null}
+          onClearGoal={vi.fn()}
+          onCreateTask={vi.fn()}
+          canCreateTask={true}
+        />,
+      )
+      expect(screen.queryByText(/Create Task|创建任务/i)).not.toBeNull()
+
+      rerender(
+        <KanbanHeader
+          scope="team"
+          onScopeChange={vi.fn()}
+          selectedGoal={null}
+          onClearGoal={vi.fn()}
+          onCreateTask={vi.fn()}
+          canCreateTask={false}
+        />,
+      )
+      expect(screen.queryByText(/Create Task|创建任务/i)).toBeNull()
+    })
+
+    it('KanbanColumn: only renders + Create Task button in footer for owner and editor', () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [],
+          pageInfo: { total: 0, hasNextPage: false },
+        }),
+      })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(client.api.teams[':teamId'].kanban.tasks.$get as any) = mockGet
+
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+      const { rerender } = render(
+        <QueryClientProvider client={queryClient}>
+          <KanbanColumn
+            teamId="team-1"
+            status={KanbanTaskStatus.TODO}
+            selectedGoalId={null}
+            scope="team"
+            currentUserRole="editor"
+            onTaskClick={vi.fn()}
+            onCreateTaskInColumn={vi.fn()}
+          />
+        </QueryClientProvider>,
+      )
+      expect(screen.queryByText(/Create Task|创建任务/i)).not.toBeNull()
+
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <KanbanColumn
+            teamId="team-1"
+            status={KanbanTaskStatus.TODO}
+            selectedGoalId={null}
+            scope="team"
+            currentUserRole="reviewer"
+            onTaskClick={vi.fn()}
+            onCreateTaskInColumn={vi.fn()}
+          />
+        </QueryClientProvider>,
+      )
+      expect(screen.queryByText(/Create Task|创建任务/i)).toBeNull()
     })
   })
 })

--- a/packages/webui/components/kanban/kanban.test.tsx
+++ b/packages/webui/components/kanban/kanban.test.tsx
@@ -207,7 +207,7 @@ describe('Kanban UI Unit & Component Tests', () => {
       expect(card).toBeDefined()
     })
 
-    it('renders three-dot delete action for task creator or owner and triggers onDelete', () => {
+    it('renders three-dot delete action for task creator, reporter, or owner and triggers onDelete', () => {
       const onDelete = vi.fn()
       const { container, rerender } = render(
         <KanbanCard
@@ -219,11 +219,27 @@ describe('Kanban UI Unit & Component Tests', () => {
         />,
       )
 
-      // Three-dot trigger should be rendered
+      // Three-dot trigger should be rendered for creator
       const triggerBtn = container.querySelector('button')
       expect(triggerBtn).toBeDefined()
 
-      // When user is not creator and not owner, delete trigger is not rendered
+      // Also rendered for reporter (reviewer)
+      rerender(
+        <KanbanCard
+          task={{
+            ...mockManualTask,
+            creator: { id: 'other-1', name: 'Creator' },
+            reporter: { id: 'rep-user', name: 'Reporter' },
+          }}
+          onClick={vi.fn()}
+          onDelete={onDelete}
+          currentUserId="rep-user"
+          currentUserRole="reviewer"
+        />,
+      )
+      expect(container.querySelector('button')).toBeDefined()
+
+      // When user is not creator, not reporter, and not owner, delete trigger is not rendered
       rerender(
         <KanbanCard
           task={mockManualTask}
@@ -236,7 +252,7 @@ describe('Kanban UI Unit & Component Tests', () => {
       expect(container.querySelector('button')).toBeNull()
     })
 
-    it('enforces card drag permission: enabled for owner, reporter, or assignee; disabled for others', () => {
+    it('enforces card drag permission: enabled for owner, editor, reporter, or assignee; disabled for unassigned reviewers', () => {
       // 1. Enabled when user is owner
       render(
         <KanbanCard
@@ -255,25 +271,25 @@ describe('Kanban UI Unit & Component Tests', () => {
         expect.objectContaining({ disabled: false }),
       )
 
-      // 2. Enabled when user is reporter (or creator if reporter null)
+      // 2. Enabled when user is editor (even if not reporter or assignee)
       render(
         <KanbanCard
           task={{
             ...mockManualTask,
-            creator: { id: 'user-reporter', name: 'Rep' },
-            reporter: null,
-            assignee: null,
+            creator: { id: 'other-1', name: 'Other' },
+            reporter: { id: 'other-2', name: 'Reporter' },
+            assignee: { id: 'other-3', name: 'Assignee' },
           }}
           onClick={vi.fn()}
           currentUserRole="editor"
-          currentUserId="user-reporter"
+          currentUserId="stranger-user"
         />,
       )
       expect(mockUseDraggable).toHaveBeenLastCalledWith(
         expect.objectContaining({ disabled: false }),
       )
 
-      // 3. Enabled when user is assignee
+      // 3. Enabled when user is reviewer but is assignee
       render(
         <KanbanCard
           task={{
@@ -291,7 +307,7 @@ describe('Kanban UI Unit & Component Tests', () => {
         expect.objectContaining({ disabled: false }),
       )
 
-      // 4. Disabled when user is not owner, not reporter, and not assignee
+      // 4. Disabled when user is reviewer and not reporter, not creator, not assignee
       render(
         <KanbanCard
           task={{
@@ -301,7 +317,7 @@ describe('Kanban UI Unit & Component Tests', () => {
             assignee: { id: 'other-3', name: 'Assignee' },
           }}
           onClick={vi.fn()}
-          currentUserRole="editor"
+          currentUserRole="reviewer"
           currentUserId="stranger-user"
         />,
       )


### PR DESCRIPTION
## Summary

Enhances Kanban task permissions and usability:
- Allows any Team/Project Editor to transition task status
- Defaults task reporters to creators
- Grants project-scoped and reviewer task assignees/reporters full modification rights on their tasks
- Hides the "Create Task" buttons for reviewers in the header and column footers
- Eliminates duplicate/generic error toasts on permission rejection

## Changes

- **Status Transitions**: Allowed any Team/Project Editor (`editor`) to transition task statuses on the board and via API (in addition to task assignees, reporters, creators, and team owners).
- **Reporter Defaults**: Defaulted `reporterId` to `creatorId` in `kanbanService.createTask` if not provided, and pre-selected the current user in `KanbanCreateTaskDialog`.
- **Reviewer UI Controls**:
  - In `KanbanHeader`, conditionally rendered the `Create Task` button only when `canCreateTask` (i.e. `isOwnerOrEditor`) is `true`.
  - In `KanbanColumn`, conditionally rendered the footer `+ Create Task` button only when `isOwnerOrEditor` is `true`.
- **Error Toast Deduplication & Error Extraction**:
  - Removed duplicate generic `toast.error` from `customFetch` in `client.ts` on 403 status.
  - Improved error message parsing in `KanbanCreateTaskDialog` to handle both JSON and plain-text error responses without falling back to a raw `"Error"` string.
- **Project-Scoped & Reviewer Task Participants**: Updated `AuthzService.hasPermission` to check if a user is the `assigneeId`, `reporterId`, or `creatorId` of a `KanbanTask`.
- **Task Deletion Guardrails**: Allowed task deletion by Team Owners, Task Creators, and Task Reporters (including project-scoped creators/reporters).
- **Test Coverage**: Added comprehensive test cases in `authz.test.ts`, `kanban.test.ts`, and `packages/webui/components/kanban/kanban.test.tsx`.

## Verification

- `bun run lint` (Passed)
- `bun run format` (Passed)
- `bun run typecheck` (Passed)
- `bun run test` (All 128 test files and 1264 tests passed)
- `bun run test:e2e:webui` (9 tests passed)
- `bun run test:e2e:workflow` (58 tests passed)
- `bun run test:e2e:app` (35 tests passed)

## Notes

Backwards compatible; all checks pass simultaneously.