### PR TITLE
fix(kanban): improve drag-drop to column bottom, remove empty drop line, and fix timeline alignment

### DIFF
--- a/packages/webui/components/kanban/edit-task-dialog/task-event-timeline.tsx
+++ b/packages/webui/components/kanban/edit-task-dialog/task-event-timeline.tsx
@@ -75,10 +75,10 @@ export function TaskEventTimeline({ teamId, taskId, initialEvents }: TaskEventTi
               {m.no_activity_yet()}
             </div>
           ) : (
-            <div className="relative pl-4 space-y-3 before:absolute before:left-1.5 before:top-2 before:bottom-2 before:w-0.5 before:bg-border/60">
+            <div className="relative pl-5 space-y-3 before:absolute before:left-[4px] before:top-2 before:bottom-2 before:w-[2px] before:bg-border/60">
               {events.map((event) => (
                 <div key={event.id} className="relative flex items-start gap-2 text-xs">
-                  <div className="absolute -left-4 top-1 w-2.5 h-2.5 rounded-full bg-background border-2 border-primary shrink-0" />
+                  <div className="absolute -left-5 top-[3px] w-2.5 h-2.5 rounded-full bg-background border-2 border-primary shrink-0" />
 
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center justify-between gap-1">

--- a/packages/webui/components/kanban/kanban-board.tsx
+++ b/packages/webui/components/kanban/kanban-board.tsx
@@ -249,7 +249,7 @@ export function KanbanBoard({
 
     const targetData = target.data as
       | { type?: 'reorder'; task?: KanbanTaskInfo; position?: 'before' | 'after' }
-      | { type?: 'kanban_column'; status?: KanbanTaskStatus }
+      | { type?: 'kanban_column'; status?: KanbanTaskStatus; lastTask?: KanbanTaskInfo }
       | undefined
 
     if (!targetData) return
@@ -279,6 +279,26 @@ export function KanbanBoard({
 
     if (targetData.type === 'kanban_column' && targetData.status) {
       const toStatus = targetData.status
+      const lastTask = targetData.lastTask
+
+      if (lastTask) {
+        if (task.id === lastTask.id) {
+          if (task.status === toStatus) return
+          updateTask({ taskId: task.id, fromStatus: task.status, status: toStatus })
+          return
+        }
+
+        updateTask({
+          taskId: task.id,
+          fromStatus: task.status,
+          status: toStatus,
+          afterIndex: lastTask.sortIndex ?? undefined,
+          targetTaskId: lastTask.id,
+          position: 'after',
+        })
+        return
+      }
+
       if (task.status === toStatus) return
 
       updateTask({ taskId: task.id, fromStatus: task.status, status: toStatus })

--- a/packages/webui/components/kanban/kanban-card.tsx
+++ b/packages/webui/components/kanban/kanban-card.tsx
@@ -31,6 +31,7 @@ interface KanbanCardProps {
   onDelete?: (task: KanbanTaskInfo) => void
   disabled?: boolean
   isFirst?: boolean
+  isLast?: boolean
   showBottomIndicator?: boolean
   currentUserId?: string
   currentUserRole?: string
@@ -42,6 +43,7 @@ export function KanbanCard({
   onDelete,
   disabled,
   isFirst,
+  isLast,
   showBottomIndicator,
   currentUserId,
   currentUserRole,
@@ -109,7 +111,8 @@ export function KanbanCard({
       <div
         ref={setBottomDroppableRef}
         className={cn(
-          'absolute bottom-0 left-0 right-0 h-1/2 z-20',
+          'absolute bottom-0 left-0 right-0 z-20',
+          isLast ? '-bottom-6 h-[calc(50%+24px)]' : 'h-1/2',
           isDraggingAny && !isDragging ? 'pointer-events-auto' : 'pointer-events-none',
         )}
       />

--- a/packages/webui/components/kanban/kanban-column.tsx
+++ b/packages/webui/components/kanban/kanban-column.tsx
@@ -38,30 +38,6 @@ export function KanbanColumn({
   const isOwnerOrEditor =
     currentUserRole?.toLowerCase() === 'owner' || currentUserRole?.toLowerCase() === 'editor'
 
-  const { ref: setDroppableRef, isDropTarget } = useDroppable({
-    id: status,
-    data: {
-      type: 'kanban_column',
-      status,
-    },
-  })
-
-  const { source, target } = useDragOperation()
-  const isDraggingTask = source?.data?.type === 'kanban_task'
-  const isOverThisColumn =
-    isDraggingTask &&
-    (isDropTarget ||
-      (target?.data?.type === 'kanban_column' && target.data.status === status) ||
-      (target?.data?.type === 'reorder' &&
-        (target.data.task as KanbanTaskInfo | undefined)?.status === status))
-
-  const isOverColumnEmptySpace =
-    isDraggingTask && target?.data?.type === 'kanban_column' && target.data.status === status
-
-  const { ref: loadMoreRef, inView } = useInView({
-    threshold: 0.1,
-  })
-
   const assigneeId = scope === 'my' ? currentUserId : undefined
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery({
@@ -86,6 +62,10 @@ export function KanbanColumn({
     enabled: !!teamId,
   })
 
+  const { ref: loadMoreRef, inView } = useInView({
+    threshold: 0.1,
+  })
+
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingNextPage) {
       fetchNextPage()
@@ -96,7 +76,29 @@ export function KanbanColumn({
     return data?.pages?.flatMap((page) => (Array.isArray(page?.data) ? page.data : [])) || []
   }, [data])
 
+  const { source, target } = useDragOperation()
   const lastVisibleTask = allTasks.filter((t) => t.id !== source?.id).at(-1)
+
+  const { ref: setDroppableRef, isDropTarget } = useDroppable({
+    id: status,
+    data: {
+      type: 'kanban_column',
+      status,
+      lastTask: lastVisibleTask,
+    },
+  })
+
+  const isDraggingTask = source?.data?.type === 'kanban_task'
+  const isOverThisColumn =
+    isDraggingTask &&
+    (isDropTarget ||
+      (target?.data?.type === 'kanban_column' && target.data.status === status) ||
+      (target?.data?.type === 'reorder' &&
+        (target.data.task as KanbanTaskInfo | undefined)?.status === status))
+
+  const isOverColumnEmptySpace =
+    isDraggingTask && target?.data?.type === 'kanban_column' && target.data.status === status
+
   const totalCount = data?.pages?.[0]?.pageInfo?.total ?? allTasks.length
   const statusColor = getStatusColor(status)
 
@@ -132,10 +134,7 @@ export function KanbanColumn({
               <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
             </div>
           ) : allTasks.length === 0 ? (
-            <div className="relative flex flex-col items-center justify-center py-10 px-4 text-center">
-              {isOverColumnEmptySpace && (
-                <div className="absolute top-3 left-3 right-3 h-[3px] rounded-full bg-primary shadow-[0_0_8px_rgba(var(--primary),0.6)] z-30 pointer-events-none" />
-              )}
+            <div className="flex flex-col items-center justify-center py-10 px-4 text-center">
               <p className="text-xs text-muted-foreground/70">{m.no_tasks_in_column()}</p>
             </div>
           ) : (
@@ -146,6 +145,7 @@ export function KanbanColumn({
                 onClick={onTaskClick}
                 onDelete={onDeleteTask}
                 isFirst={index === 0}
+                isLast={index === allTasks.length - 1}
                 showBottomIndicator={isOverColumnEmptySpace && task.id === lastVisibleTask?.id}
                 currentUserId={currentUserId}
                 currentUserRole={currentUserRole}

--- a/packages/webui/components/kanban/kanban.test.tsx
+++ b/packages/webui/components/kanban/kanban.test.tsx
@@ -29,6 +29,7 @@ import { KanbanCreateTaskDialog } from './kanban-create-task-dialog'
 import { TaskRelatedAssets } from './task-related-assets'
 import { TaskCommentCard } from './edit-task-dialog/task-comment-card'
 import { TaskCommentInput } from './edit-task-dialog/task-comment-input'
+import { TaskEventTimeline } from './edit-task-dialog/task-event-timeline'
 import type { KanbanTaskAssetInfo } from '@shumai/dtos'
 import { client } from '@/ui/api/client'
 
@@ -855,6 +856,78 @@ describe('Kanban UI Unit & Component Tests', () => {
         </QueryClientProvider>,
       )
       expect(screen.queryByText(/Create Task|创建任务/i)).toBeNull()
+    })
+  })
+
+  describe('Kanban UI Alignment & DnD Improvements', () => {
+    it('TaskEventTimeline: renders timeline line and circles with aligned center positioning', () => {
+      const mockEvents = [
+        {
+          id: 'ev-1',
+          taskId: 't-1',
+          type: KanbanTaskEventType.CREATED,
+          actor: { id: 'u-1', name: 'Alice' },
+          fromStatus: null,
+          toStatus: KanbanTaskStatus.TODO,
+          data: null,
+          createdAt: '2026-08-20T00:00:00.000Z',
+        },
+      ]
+
+      const { container } = render(
+        <TaskEventTimeline teamId="team-1" taskId="t-1" initialEvents={mockEvents} />,
+        { wrapper: createWrapper() },
+      )
+
+      // Container has pl-5 and before:left-[4px] before:w-[2px]
+      const timelineContainer = container.querySelector('.pl-5')
+      expect(timelineContainer).toBeDefined()
+      expect(timelineContainer?.className).toContain('before:left-[4px]')
+      expect(timelineContainer?.className).toContain('before:w-[2px]')
+
+      // Circle node has -left-5 top-[3px] w-2.5 h-2.5
+      const circleNode = container.querySelector('.-left-5')
+      expect(circleNode).toBeDefined()
+      expect(circleNode?.className).toContain('top-[3px]')
+      expect(circleNode?.className).toContain('w-2.5')
+    })
+
+    it('KanbanCard: expands bottom drop zone when isLast is true', () => {
+      const mockTask: KanbanTaskInfo = {
+        id: 'task-last',
+        title: 'Last Task',
+        isAgentTask: false,
+        status: KanbanTaskStatus.TODO,
+        priority: KanbanTaskPriority.MEDIUM,
+        startDate: null,
+        dueDate: null,
+        startedAt: null,
+        completedAt: null,
+        teamId: 'team-1',
+        projectId: null,
+        creator: { id: 'u-1', name: 'Alice' },
+        reporter: null,
+        assignee: null,
+        goal: null,
+        targetFolderId: null,
+        latestStatusEvent: null,
+        commentCount: 0,
+        dependencyCount: 0,
+        dependentCount: 0,
+        assetCount: 0,
+        createdAt: '2026-08-20T00:00:00.000Z',
+        updatedAt: '2026-08-20T00:00:00.000Z',
+      }
+
+      const { container, rerender } = render(
+        <KanbanCard task={mockTask} onClick={vi.fn()} isLast={false} />,
+      )
+      // When isLast is false, uses standard h-1/2 without -bottom-6
+      expect(container.querySelector('.-bottom-6')).toBeNull()
+
+      // When isLast is true, expands drop area with -bottom-6
+      rerender(<KanbanCard task={mockTask} onClick={vi.fn()} isLast={true} />)
+      expect(container.querySelector('.-bottom-6')).toBeDefined()
     })
   })
 })


### PR DESCRIPTION
## Summary

Improves Kanban drag-and-drop behavior and UI alignment:
1. Fixes in-column task reordering so dragging a task downward into the column space below other tasks moves it to the bottom.
2. Removes the redundant horizontal drop indicator line when dragging over an empty column.
3. Fixes circle and vertical line center alignment in the task dialog Activity tab timeline.

## Changes

- `packages/webui/components/kanban/kanban-board.tsx`: Updated `handleDragEnd` to support reordering to the bottom of the column when dropping onto `kanban_column`.
- `packages/webui/components/kanban/kanban-card.tsx`: Added `isLast` prop and expanded the bottom droppable target area for the last card.
- `packages/webui/components/kanban/kanban-column.tsx`: Passed `lastTask` in `useDroppable` data, passed `isLast` to `KanbanCard`, and removed the top line drop indicator in the empty state.
- `packages/webui/components/kanban/edit-task-dialog/task-event-timeline.tsx`: Aligned vertical line center (=5\text{px}$) and circle center (=5\text{px}$), and vertically centered circle with line-height.
- `packages/webui/components/kanban/kanban.test.tsx`: Added unit tests for timeline center alignment and `isLast` expanded drop zones.

## Verification

- `bun run lint`: Passed (0 errors, 0 warnings).
- `bun run format`: Passed.
- `bun run typecheck`: Passed.
- `bun run test`: Passed (128 test files, 1266 tests).
- `bun run test:e2e:webui`: Passed (9 tests).
- `bun run test:e2e:workflow`: Passed (14 test files, 58 tests).
- `bun run test:e2e:app`: Passed (35 tests).

## Notes

None.