### PR TITLE
fix(api): forward pagination parameters in folder children endpoint

### DIFF
--- a/packages/api/src/folder.test.ts
+++ b/packages/api/src/folder.test.ts
@@ -188,6 +188,46 @@ describe('folder api', () => {
       type: ResourceType.Asset,
       id: 'test-id',
     })
+    expect(assetService.listChildren).toHaveBeenCalledWith({
+      assetId: 'test-id',
+      assetType: 'folder',
+    })
+  })
+
+  it('GET /folders/:folderId/children forwards pagination parameters', async () => {
+    vi.mocked(assetService.listChildren).mockResolvedValue({
+      data: [
+        {
+          id: 'child-id-2',
+          name: 'child-folder-2',
+          sizeByte: 0,
+          fileCount: 0,
+          type: 'folder',
+          status: 'active',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+      pageInfo: { total: 30, cursor: 'cursorNextToken' },
+    })
+
+    const app = new Hono().use('*', authMiddleware).route('/', folderRoute)
+    const res = await app.request(
+      '/folders/test-id/children?assetType=folder&first=20&after=cursorToken123&prefix=sub',
+    )
+
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.data).toHaveLength(1)
+    expect(json.pageInfo.cursor).toBe('cursorNextToken')
+
+    expect(assetService.listChildren).toHaveBeenCalledWith({
+      assetId: 'test-id',
+      assetType: 'folder',
+      first: 20,
+      after: 'cursorToken123',
+      prefix: 'sub',
+    })
   })
 
   it('DELETE /folders', async () => {

--- a/packages/api/src/folder.ts
+++ b/packages/api/src/folder.ts
@@ -120,12 +120,8 @@ const route = new Hono<{ Variables: { user: User } }>()
     })
 
     const resp = await assetService.listChildren({
+      ...req,
       assetId: folderId,
-      assetType: req.assetType,
-      projectId: req.projectId,
-      showDeleted: req.showDeleted,
-      sort: req.sort,
-      order: req.order,
     })
     return c.json(resp)
   })


### PR DESCRIPTION
## Summary

Fix infinite pagination loop on left folder tree by forwarding pagination query parameters (`after`, `first`, etc.) in the `GET /folders/:folderId/children` endpoint.

## Changes

- Forward `...req` to `assetService.listChildren` in `packages/api/src/folder.ts`.
- Add unit test in `packages/api/src/folder.test.ts` ensuring pagination query arguments are forwarded to the service layer.

## Verification

- `bun run test` passed.
- `bun run lint` passed.
- `bun run format` passed.
- `bun run typecheck` passed.
- `bun run test:e2e:webui` passed.
- `bun run test:e2e:workflow` passed.
- `bun run test:e2e:app` passed.

## Notes

None.