### PR TITLE
fix(transcode): apply team hardware acceleration and source bitrate capping to watermark transcoding

### DIFF
--- a/packages/transcode/src/activities/watermark.test.ts
+++ b/packages/transcode/src/activities/watermark.test.ts
@@ -182,7 +182,13 @@ describe('Watermark Activities', () => {
   describe('transcodeWatermarkMediaActivity', () => {
     const bucket = process.env.S3_BUCKET || 'shumai'
 
-    async function seedAsset(name: string, mediaType: string, key: string, proxyType: string) {
+    async function seedAsset(
+      name: string,
+      mediaType: string,
+      key: string,
+      proxyType: string,
+      projectId?: string,
+    ) {
       const storageKey = await prisma.storageKey.create({ data: { key } })
       return prisma.asset.create({
         data: {
@@ -190,6 +196,7 @@ describe('Watermark Activities', () => {
           type: 'file',
           mediaType,
           status: 'processed',
+          projectId,
           storageKeyId: storageKey.id,
           media: {
             duration: 0,
@@ -327,12 +334,71 @@ describe('Watermark Activities', () => {
       expect(media.proxyType).toBe('video')
       expect(media.videoTranscodes?.length).toBeGreaterThan(0)
       expect(media.videoTranscodes?.[0].key).toContain('watermark-')
-      expect(s3Service.putObject).toHaveBeenCalledWith(
-        bucket,
-        expect.stringContaining('watermark-'),
-        expect.anything(),
-        expect.any(Number),
-        'video/mp4',
+      expect(transcodeService.transcodeVideo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hardwareAcceleration: 'off',
+          sourceVideoBitrate: 1000,
+        }),
+      )
+
+      fs.rmSync(outFilePath, { force: true })
+    })
+
+    it('passes team hardwareAcceleration and videoBitRate to transcodeVideo', async () => {
+      const team = await prisma.team.create({
+        data: {
+          name: 'HW Accel Team',
+          settings: {
+            transcode: {
+              videoStrategy: 'best_match',
+              hardwareAcceleration: 'auto',
+            },
+          },
+        },
+      })
+      const project = await prisma.project.create({
+        data: {
+          name: 'HW Accel Project',
+          teamId: team.id,
+        },
+      })
+
+      const assetKey = 'files/e2e-wm/video-hw.mp4'
+      const asset = await seedAsset('video-hw.mp4', 'video/mp4', assetKey, 'video', project.id)
+      const config = await seedConfig()
+
+      vi.mocked(transcodeService.getVideoInfo).mockResolvedValue({
+        originalWidth: 1280,
+        originalHeight: 720,
+        duration: 15,
+        bitRate: 2000000,
+        videoBitRate: 1800000,
+        frameRate: 24,
+        totalFrames: 360,
+        startTimecode: '00:00:00:00',
+        hasAudio: false,
+        mimeType: 'video/mp4',
+      })
+      vi.mocked(s3Service.putObject).mockResolvedValue(undefined as never)
+
+      const stem = 'video-hw'
+      const configId = config.id
+      const outFilePath = path.join('/tmp', `${stem}-watermark-${configId}-100p.mp4`)
+      fs.writeFileSync(outFilePath, Buffer.from('fake mp4'))
+
+      const media = await transcodeWatermarkMediaActivity({
+        assetId: asset.id,
+        watermarkConfigId: config.id,
+      })
+
+      expect(media.proxyType).toBe('video')
+      expect(media.metadata?.bitRate).toBe(2000000)
+      expect(transcodeService.transcodeVideo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hardwareAcceleration: 'auto',
+          sourceVideoBitrate: 1800000,
+          disableAudio: true,
+        }),
       )
 
       fs.rmSync(outFilePath, { force: true })

--- a/packages/transcode/src/activities/watermark.ts
+++ b/packages/transcode/src/activities/watermark.ts
@@ -133,7 +133,12 @@ export async function transcodeWatermarkMediaActivity(
 
   const asset = await prisma.asset.findUnique({
     where: { id: params.assetId },
-    include: { storageKey: true },
+    include: {
+      storageKey: true,
+      project: {
+        include: { team: true },
+      },
+    },
   })
 
   if (!asset || !asset.storageKey?.key) {
@@ -142,6 +147,9 @@ export async function transcodeWatermarkMediaActivity(
       nonRetryable: true,
     })
   }
+
+  const teamSettings = asset.project?.team?.settings as PrismaJson.Settings | null
+  const hardwareAcceleration = teamSettings?.transcode?.hardwareAcceleration ?? 'off'
 
   // The config column is declared as PrismaJson.WatermarkConfigSpec, which is
   // structurally identical to the DTO type, so no cast is required.
@@ -165,20 +173,26 @@ export async function transcodeWatermarkMediaActivity(
     let originalWidth = 1920
     let originalHeight = 1080
     let duration = 0
+    let bitRate = 0
+    let videoBitRate: number | undefined
     let frameRate = 30
     let totalFrames = 0
     let startTimecode = '00:00:00:00'
     let hasAudio = false
+    let sourceVideoBitrate: number | undefined
 
     if (isVideo) {
       const info = await transcodeService.getVideoInfo(rawFilePath)
       originalWidth = info.originalWidth
       originalHeight = info.originalHeight
       duration = info.duration
+      bitRate = info.bitRate
+      videoBitRate = info.videoBitRate
       frameRate = info.frameRate
       totalFrames = info.totalFrames
       startTimecode = info.startTimecode || '00:00:00:00'
       hasAudio = info.hasAudio
+      sourceVideoBitrate = info.videoBitRate || info.bitRate
     } else if (isImage) {
       const info = await transcodeService.getImageInfo(rawFilePath)
       originalWidth = info.originalWidth
@@ -237,7 +251,8 @@ export async function transcodeWatermarkMediaActivity(
         originalWidth,
         originalHeight,
         duration,
-        bitRate: 0,
+        bitRate,
+        videoBitRate,
         frameRate,
         totalFrames,
         startTimecode,
@@ -321,6 +336,8 @@ export async function transcodeWatermarkMediaActivity(
           height: targetHeight,
           disableAudio: !hasAudio,
           overlayFile: overlayPngPath,
+          hardwareAcceleration,
+          sourceVideoBitrate,
         })
 
         const stat = fs.statSync(outFilePath)


### PR DESCRIPTION
## Summary

Watermark video proxy generation in `transcodeWatermarkMediaActivity` previously defaulted to software encoding (`libx264`) without inspecting the team's hardware acceleration setting, and did not supply `sourceVideoBitrate`, causing ffmpeg to always apply the maximum resolution ceiling bitrate rather than capping based on the source video. This PR resolves both discrepancies.

## Changes

- Updated `transcodeWatermarkMediaActivity` in `packages/transcode/src/activities/watermark.ts` to include `project` and `team` in the Prisma asset query to read the team's `settings.transcode.hardwareAcceleration` (falling back to `'off'`).
- Extracted `sourceVideoBitrate` from `getVideoInfo` (`info.videoBitRate || info.bitRate`) and populated `mediaInfo.metadata.bitRate` and `mediaInfo.metadata.videoBitRate`.
- Forwarded `hardwareAcceleration` and `sourceVideoBitrate` to `transcodeService.transcodeVideo`.
- Added unit tests in `packages/transcode/src/activities/watermark.test.ts` to verify hardware acceleration and source bitrate forwarding.

## Verification

- `bun run lint` (passed with 0 warnings)
- `bun run format` (passed)
- `bun run typecheck` (passed)
- `bun run test` (132 test files passed, 1307 tests passed)
- `bun run test:e2e:app` (38 tests passed)
- `bun run test:e2e:webui` (9 tests passed)
- `bun run test:e2e:workflow` (14 test files passed, 58 tests passed)

## Notes

No breaking changes or schema migrations required.