### PR TITLE
fix(share): hide and soft-delete symlinks when target assets are trashed

### DIFF
--- a/packages/core/src/asset/asset.test.ts
+++ b/packages/core/src/asset/asset.test.ts
@@ -3575,5 +3575,133 @@ describe('AssetService — natural sort by name', () => {
       })
       expect(updatedFile.name).toBe('renamed.png')
     })
+
+    it('cascades soft-delete and restoration to symlinks and updates parent fileCount', async () => {
+      const team = await prisma.team.create({ data: { name: 'Test Team ' + Date.now() } })
+      const project = await prisma.project.create({
+        data: { name: 'Test Project', teamId: team.id },
+      })
+      const rootFolder = await prisma.asset.create({
+        data: {
+          name: 'Root',
+          type: AssetType.folder,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+        },
+      })
+      const shareRoot = await prisma.asset.create({
+        data: {
+          name: 'Share Root',
+          type: AssetType.share_root,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+          fileCount: 0,
+        },
+      })
+
+      const file = await prisma.asset.create({
+        data: {
+          name: 'test-file.txt',
+          type: AssetType.file,
+          parentId: rootFolder.id,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+        },
+      })
+      await prisma.asset.update({
+        where: { id: rootFolder.id },
+        data: { fileCount: 1 },
+      })
+
+      const symlink = await prisma.asset.create({
+        data: {
+          name: file.name,
+          type: AssetType.symlink,
+          parentId: shareRoot.id,
+          targetId: file.id,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+        },
+      })
+      await prisma.asset.update({
+        where: { id: shareRoot.id },
+        data: { fileCount: 1 },
+      })
+
+      // Soft delete the file
+      await assetService.deleteAssets([file.id])
+
+      const deletedSymlink = await prisma.asset.findUnique({ where: { id: symlink.id } })
+      expect(deletedSymlink?.isDeleted).toBe(true)
+      expect(deletedSymlink?.status).toBe(AssetStatus.trashed)
+
+      const updatedShareRoot = await prisma.asset.findUnique({ where: { id: shareRoot.id } })
+      expect(updatedShareRoot?.fileCount).toBe(0)
+
+      // Restore the file
+      await assetService.restoreAssets([file.id])
+
+      const restoredSymlink = await prisma.asset.findUnique({ where: { id: symlink.id } })
+      expect(restoredSymlink?.isDeleted).toBe(false)
+      expect(restoredSymlink?.status).toBe(AssetStatus.processed)
+
+      const restoredShareRoot = await prisma.asset.findUnique({ where: { id: shareRoot.id } })
+      expect(restoredShareRoot?.fileCount).toBe(1)
+    })
+
+    it('cascades permanent purge to symlinks when emptying trash', async () => {
+      const team = await prisma.team.create({ data: { name: 'Test Team ' + Date.now() } })
+      const project = await prisma.project.create({
+        data: { name: 'Test Project', teamId: team.id },
+      })
+      const rootFolder = await prisma.asset.create({
+        data: {
+          name: 'Root',
+          type: AssetType.folder,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+        },
+      })
+      const shareRoot = await prisma.asset.create({
+        data: {
+          name: 'Share Root',
+          type: AssetType.share_root,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+          fileCount: 0,
+        },
+      })
+
+      const file = await prisma.asset.create({
+        data: {
+          name: 'file-to-purge.txt',
+          type: AssetType.file,
+          parentId: rootFolder.id,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+        },
+      })
+
+      const symlink = await prisma.asset.create({
+        data: {
+          name: file.name,
+          type: AssetType.symlink,
+          parentId: shareRoot.id,
+          targetId: file.id,
+          projectId: project.id,
+          status: AssetStatus.uploaded,
+        },
+      })
+
+      // Soft delete then empty trash
+      await assetService.deleteAssets([file.id])
+      await assetService.emptyTrash(project.id)
+
+      const purgedFile = await prisma.asset.findUnique({ where: { id: file.id } })
+      expect(purgedFile).toBeNull()
+
+      const purgedSymlink = await prisma.asset.findUnique({ where: { id: symlink.id } })
+      expect(purgedSymlink).toBeNull()
+    })
   })
 })

--- a/packages/core/src/asset/asset.ts
+++ b/packages/core/src/asset/asset.ts
@@ -632,10 +632,7 @@ export class AssetService {
         projectId: req.projectId,
         isDeleted: true,
         deletedAt: { gte: thirtyDaysAgo },
-        OR: [
-          { type: { in: typesToQuery } },
-          { type: AssetType.symlink, target: { type: { in: typesToQuery } } },
-        ],
+        type: { in: typesToQuery },
       }
     } else {
       if (!req.assetId) {
@@ -654,7 +651,7 @@ export class AssetService {
         isDeleted: false,
         OR: [
           { type: { in: typesToQuery } },
-          { type: AssetType.symlink, target: { type: { in: typesToQuery } } },
+          { type: AssetType.symlink, target: { isDeleted: false, type: { in: typesToQuery } } },
         ],
       }
     }
@@ -1103,6 +1100,39 @@ export class AssetService {
           })
         }
 
+        const allDeletedIds = [a.id, ...descendantIds]
+        const symlinks = await tx.asset.findMany({
+          where: {
+            targetId: { in: allDeletedIds },
+            isDeleted: false,
+            type: AssetType.symlink,
+          },
+        })
+
+        if (symlinks.length > 0) {
+          await tx.asset.updateMany({
+            where: { id: { in: symlinks.map((s) => s.id) } },
+            data: {
+              isDeleted: true,
+              status: AssetStatus.trashed,
+              deletedAt: new Date(),
+            },
+          })
+
+          const parentCounts = new Map<string, number>()
+          for (const s of symlinks) {
+            if (s.parentId) {
+              parentCounts.set(s.parentId, (parentCounts.get(s.parentId) || 0) + 1)
+            }
+          }
+          for (const [parentId, count] of parentCounts.entries()) {
+            await tx.asset.update({
+              where: { id: parentId },
+              data: { fileCount: { decrement: count } },
+            })
+          }
+        }
+
         await tx.asset.update({
           where: { id: a.id },
           data: {
@@ -1126,9 +1156,16 @@ export class AssetService {
         UNION ALL
         SELECT a.id FROM assets a
         INNER JOIN descendant d ON a.parent_id = d.id
+      ),
+      all_purging_targets AS (
+        SELECT id FROM descendant
+      ),
+      all_affected_symlinks AS (
+        SELECT s.id FROM assets s
+        WHERE s.type = 'symlink' AND s.target_id IN (SELECT id FROM all_purging_targets)
       )
       UPDATE assets SET status = 'pending_purge', updated_at = NOW()
-      WHERE id IN (SELECT id FROM descendant);
+      WHERE id IN (SELECT id FROM all_purging_targets) OR id IN (SELECT id FROM all_affected_symlinks);
     `
   }
 
@@ -1312,6 +1349,39 @@ export class AssetService {
             where: { id: { in: descendantIds } },
             data: { isDeleted: false },
           })
+        }
+
+        const allRestoredIds = [a.id, ...descendantIds]
+        const symlinks = await tx.asset.findMany({
+          where: {
+            targetId: { in: allRestoredIds },
+            isDeleted: true,
+            type: AssetType.symlink,
+          },
+        })
+
+        if (symlinks.length > 0) {
+          await tx.asset.updateMany({
+            where: { id: { in: symlinks.map((s) => s.id) } },
+            data: {
+              isDeleted: false,
+              status: AssetStatus.processed,
+              deletedAt: null,
+            },
+          })
+
+          const parentCounts = new Map<string, number>()
+          for (const s of symlinks) {
+            if (s.parentId) {
+              parentCounts.set(s.parentId, (parentCounts.get(s.parentId) || 0) + 1)
+            }
+          }
+          for (const [parentId, count] of parentCounts.entries()) {
+            await tx.asset.update({
+              where: { id: parentId },
+              data: { fileCount: { increment: count } },
+            })
+          }
         }
 
         await tx.asset.update({

--- a/packages/core/src/share/share.test.ts
+++ b/packages/core/src/share/share.test.ts
@@ -335,4 +335,161 @@ describe('ShareService', () => {
     const item = list.data.find((l) => l.id === shareLink.id)
     expect(item?.creator?.image).toBe('http://s3/avatars/user123-presigned.png')
   })
+
+  it('hides soft-deleted files from share link and restores them upon file restoration', async () => {
+    const project = await prisma.project.findUniqueOrThrow({ where: { id: projectId } })
+    const file = await prisma.asset.create({
+      data: {
+        name: 'shared-doc.pdf',
+        type: AssetType.file,
+        status: 'processed',
+        projectId,
+        parentId: project.rootFolderId,
+      },
+    })
+
+    const shareLink = await shareService.createShareLink(projectId, {
+      name: 'Doc Share',
+    })
+
+    await shareService.addAssetToShare(shareLink.id, {
+      assetIds: [file.id],
+    })
+
+    // Verify initial state: 1 file in share link
+    const initialChildren = await assetService.listChildren({
+      assetId: shareLink.rootFolderId,
+      assetType: 'file',
+    })
+    expect(initialChildren.data).toHaveLength(1)
+    expect(initialChildren.data[0].name).toBe('shared-doc.pdf')
+
+    const initialShareRoot = await prisma.asset.findUnique({
+      where: { id: shareLink.rootFolderId },
+    })
+    expect(initialShareRoot?.fileCount).toBe(1)
+
+    const symlink = await prisma.asset.findFirst({
+      where: { targetId: file.id, parentId: shareLink.rootFolderId },
+    })
+    expect(symlink).toBeDefined()
+    await expect(shareService.verifyPublicAccess(file.id)).resolves.toBeDefined()
+    await expect(shareService.verifyPublicAccess(symlink!.id)).resolves.toBeDefined()
+
+    // 1. Soft-delete the file (move to trash)
+    await assetService.deleteAssets([file.id])
+
+    // Verify: file should disappear from share link children
+    const afterDeleteChildren = await assetService.listChildren({
+      assetId: shareLink.rootFolderId,
+      assetType: 'file',
+    })
+    expect(afterDeleteChildren.data).toHaveLength(0)
+
+    // Verify: share root fileCount should be decremented to 0
+    const afterDeleteShareRoot = await prisma.asset.findUnique({
+      where: { id: shareLink.rootFolderId },
+    })
+    expect(afterDeleteShareRoot?.fileCount).toBe(0)
+
+    // Verify: public access is rejected
+    await expect(shareService.verifyPublicAccess(file.id)).rejects.toThrow()
+    await expect(shareService.verifyPublicAccess(symlink!.id)).rejects.toThrow()
+
+    // Verify: project's recently-deleted view does NOT list symlinks
+    const recentlyDeleted = await assetService.listChildren({
+      projectId,
+      showDeleted: true,
+      assetType: 'file',
+    })
+    expect(recentlyDeleted.data).toHaveLength(1)
+    expect(recentlyDeleted.data[0].id).toBe(file.id)
+
+    // 2. Restore the file from trash
+    await assetService.restoreAssets([file.id])
+
+    // Verify: file reappears in share link children
+    const afterRestoreChildren = await assetService.listChildren({
+      assetId: shareLink.rootFolderId,
+      assetType: 'file',
+    })
+    expect(afterRestoreChildren.data).toHaveLength(1)
+    expect(afterRestoreChildren.data[0].name).toBe('shared-doc.pdf')
+
+    // Verify: share root fileCount is restored to 1
+    const afterRestoreShareRoot = await prisma.asset.findUnique({
+      where: { id: shareLink.rootFolderId },
+    })
+    expect(afterRestoreShareRoot?.fileCount).toBe(1)
+
+    // Verify: public access works again
+    await expect(shareService.verifyPublicAccess(file.id)).resolves.toBeDefined()
+    await expect(shareService.verifyPublicAccess(symlink!.id)).resolves.toBeDefined()
+  })
+
+  it('hides soft-deleted folders from share link and restores them upon folder restoration', async () => {
+    const project = await prisma.project.findUniqueOrThrow({ where: { id: projectId } })
+    const folder = await prisma.asset.create({
+      data: {
+        name: 'Shared Folder',
+        type: AssetType.folder,
+        status: 'processed',
+        projectId,
+        parentId: project.rootFolderId,
+      },
+    })
+    const childFile = await prisma.asset.create({
+      data: {
+        name: 'inner-file.txt',
+        type: AssetType.file,
+        status: 'processed',
+        projectId,
+        parentId: folder.id,
+      },
+    })
+
+    const shareLink = await shareService.createShareLink(projectId, {
+      name: 'Folder Share',
+    })
+
+    await shareService.addAssetToShare(shareLink.id, {
+      assetIds: [folder.id],
+    })
+
+    // Initial check: folder is in share link
+    const initialChildren = await assetService.listChildren({
+      assetId: shareLink.rootFolderId,
+      assetType: 'folder',
+    })
+    expect(initialChildren.data).toHaveLength(1)
+    expect(initialChildren.data[0].name).toBe('Shared Folder')
+    await expect(shareService.verifyPublicAccess(childFile.id)).resolves.toBeDefined()
+
+    // 1. Soft-delete the folder
+    await assetService.deleteAssets([folder.id])
+
+    // Verify: folder disappears from share link
+    const afterDeleteChildren = await assetService.listChildren({
+      assetId: shareLink.rootFolderId,
+      assetType: 'folder',
+    })
+    expect(afterDeleteChildren.data).toHaveLength(0)
+
+    // Verify: access to child file inside folder is rejected
+    await expect(shareService.verifyPublicAccess(childFile.id)).rejects.toThrow()
+
+    // 2. Restore the folder
+    await assetService.restoreAssets([folder.id])
+
+    // Verify: folder reappears in share link
+    const afterRestoreChildren = await assetService.listChildren({
+      assetId: shareLink.rootFolderId,
+      assetType: 'folder',
+    })
+    expect(afterRestoreChildren.data).toHaveLength(1)
+    expect(afterRestoreChildren.data[0].name).toBe('Shared Folder')
+
+    // Verify: access to child file inside folder is restored
+    await expect(shareService.verifyPublicAccess(childFile.id)).resolves.toBeDefined()
+  })
 })

--- a/packages/core/src/share/share.ts
+++ b/packages/core/src/share/share.ts
@@ -260,16 +260,17 @@ export class ShareService {
       WITH RECURSIVE 
       -- Trace ancestors in the real asset tree
       real_ancestors AS (
-        SELECT id, parent_id, type::text FROM assets WHERE id = ${assetId}
+        SELECT id, parent_id, type::text FROM assets WHERE id = ${assetId} AND is_deleted = false
         UNION ALL
         SELECT a.id, a.parent_id, a.type::text FROM assets a
         INNER JOIN real_ancestors ra ON ra.parent_id = a.id
+        WHERE a.is_deleted = false
       ),
       -- Find all symlinks pointing to any of these real ancestors
       found_symlinks AS (
         SELECT s.id, s.parent_id, s.type::text FROM assets s
         INNER JOIN real_ancestors ra ON s.target_id = ra.id
-        WHERE s.type = 'symlink'
+        WHERE s.type = 'symlink' AND s.is_deleted = false
       ),
       -- Combine: start with either real ancestors that are 'share' type, or symlinks that lead to 'share' type
       search_starts AS (
@@ -283,6 +284,7 @@ export class ShareService {
         UNION ALL
         SELECT a.id, a.parent_id, a.type::text FROM assets a
         INNER JOIN share_trace st ON st.parent_id = a.id
+        WHERE a.is_deleted = false
       )
       SELECT id as "shareRootId" FROM share_trace WHERE type = 'share' LIMIT 1;
     `


### PR DESCRIPTION
## Summary

Fixes a bug where files or folders added to a Share Link remained visible and accessible after being soft-deleted (moved to trash).

## Changes

- **Symlink Lifecycle in Soft Delete & Restore**: Updated `assetService.deleteAssets` and `assetService.restoreAssets` to cascade `isDeleted` and `status` updates to all `symlink` records pointing to the deleted/restored assets and their descendants, while synchronizing the parent folder `fileCount`.
- **Query-Level Defense in `listChildren`**: Enhanced `assetService.listChildren` when `showDeleted: false` to filter symlinks whose targets are soft-deleted (`target: { isDeleted: false, type: { in: typesToQuery } }`), and excluded symlinks when `showDeleted: true` so the Project Recently Deleted view only lists original assets.
- **Public Access Verification**: Updated `shareService.verifyPublicAccess` recursive CTE to ensure soft-deleted ancestors and symlinks are excluded from public share authorization.
- **Purge Cascade**: Updated `assetService.cascadeStatusToPendingPurge` to cascade status to symlinks targeting purged assets so orphaned symlinks are cleaned up on permanent purge.
- **Reproduction & Unit Tests**: Added test coverage in `packages/core/src/share/share.test.ts` and `packages/core/src/asset/asset.test.ts` verifying soft delete, restoration, public access denial, fileCount adjustments, and purge cascade for shared files and folders.

## Verification

All checks and tests passed simultaneously:
- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test` (132 test files, 1311 tests passed)
- `bun run test:e2e:app` (38 tests passed)
- `bun run test:e2e:webui` (9 tests passed)
- `bun run test:e2e:workflow` (14 test files, 58 tests passed)

## Notes

None.