### PR TITLE
feat(webui): truncate long file names with 100ms hover tooltip

### DIFF
--- a/apps/web/e2e/helpers/files.ts
+++ b/apps/web/e2e/helpers/files.ts
@@ -7,15 +7,16 @@ interface CreateShareResponse {
 }
 
 /**
- * Locates a file/folder card by its name. File names are rendered as
- * `EditableText` inputs (not text nodes), so `getByText` does not match them.
- * The returned locator points at the card wrapper div (right-clickable to open
- * the card context menu).
+ * Locates a file/folder card by its name. Matches both read-only text nodes
+ * and active EditableText inputs. The returned locator points at the card
+ * wrapper div (right-clickable to open the card context menu).
  */
 export function fileCard(page: Page, name: string): Locator {
   return page
     .locator('div.group')
-    .filter({ has: page.locator(`input[value="${name}"]`) })
+    .filter({
+      has: page.locator(`input[value="${name}"]`).or(page.getByText(name, { exact: true })),
+    })
     .first()
 }
 

--- a/packages/webui/components/file-browser/file-card.tsx
+++ b/packages/webui/components/file-browser/file-card.tsx
@@ -305,7 +305,7 @@ export function FileCard({
             onBlur={handleRename}
             onKeyDown={handleKeyDown}
             disabled={!isEditing}
-            className="h-auto p-0 text-sm text-foreground !bg-transparent"
+            className="h-auto p-0 text-sm font-medium text-foreground truncate !bg-transparent"
           />
           <p className="text-sm text-muted-foreground">
             {displayItem.createdAt &&

--- a/packages/webui/components/file-browser/file-list-item.test.tsx
+++ b/packages/webui/components/file-browser/file-list-item.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FileListItem } from './file-list-item'
+import type { AssetInfo } from '@shumai/dtos'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('@dnd-kit/react', () => ({
+  useDraggable: () => ({
+    ref: vi.fn(),
+    isDragging: false,
+  }),
+}))
+
+vi.mock('@/ui/api/client', () => ({
+  client: {
+    api: {
+      files: {
+        ':fileId': {
+          $get: vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({}),
+          }),
+        },
+      },
+    },
+  },
+}))
+
+describe('FileListItem', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
+    vi.useRealTimers()
+    cleanup()
+  })
+
+  const mockItem: AssetInfo = {
+    id: 'file-123',
+    name: 'very_long_file_name_for_testing_purposes.mov',
+    type: 'file',
+    sizeByte: 1024 * 1024 * 5,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    status: 'processed',
+  } as AssetInfo
+
+  const renderComponent = (props: Partial<React.ComponentProps<typeof FileListItem>> = {}) => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <FileListItem
+          item={mockItem}
+          isSelected={false}
+          isChecked={false}
+          isEditing={false}
+          onSelect={vi.fn()}
+          onDoubleClick={vi.fn()}
+          onContextMenu={vi.fn()}
+          onDragStart={vi.fn()}
+          onDrop={vi.fn()}
+          onRename={vi.fn()}
+          onFinishEditing={vi.fn()}
+          onSaveField={vi.fn()}
+          fields={[]}
+          {...props}
+        />
+      </QueryClientProvider>,
+    )
+  }
+
+  it('renders truncated text span when not editing', () => {
+    renderComponent()
+
+    expect(screen.queryByRole('textbox')).toBeNull()
+    const nameSpan = screen.getByText('very_long_file_name_for_testing_purposes.mov')
+    expect(nameSpan).toBeTruthy()
+    expect(nameSpan.tagName.toLowerCase()).toBe('span')
+    expect(nameSpan.className).toContain('truncate')
+  })
+
+  it('shows tooltip on hover when item name overflows', () => {
+    renderComponent()
+
+    const span = screen.getByText('very_long_file_name_for_testing_purposes.mov')
+    Object.defineProperty(span, 'scrollWidth', { value: 350, configurable: true })
+    Object.defineProperty(span, 'clientWidth', { value: 150, configurable: true })
+
+    fireEvent.pointerMove(span, { pointerType: 'mouse' })
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    const tooltip = screen.getByRole('tooltip')
+    expect(tooltip).toBeTruthy()
+    expect(tooltip.textContent).toContain('very_long_file_name_for_testing_purposes.mov')
+  })
+
+  it('switches to input in editing mode', () => {
+    renderComponent({ isEditing: true })
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    expect(input).toBeTruthy()
+    expect(input.value).toBe('very_long_file_name_for_testing_purposes.mov')
+  })
+
+  it('calls onSelect when row is clicked', () => {
+    const onSelect = vi.fn()
+    renderComponent({ onSelect })
+
+    const span = screen.getByText('very_long_file_name_for_testing_purposes.mov')
+    fireEvent.click(span)
+
+    expect(onSelect).toHaveBeenCalled()
+  })
+
+  it('calls onDoubleClick when row is double clicked', () => {
+    const onDoubleClick = vi.fn()
+    renderComponent({ onDoubleClick })
+
+    const span = screen.getByText('very_long_file_name_for_testing_purposes.mov')
+    fireEvent.doubleClick(span)
+
+    expect(onDoubleClick).toHaveBeenCalled()
+  })
+})

--- a/packages/webui/components/file-browser/file-list-item.tsx
+++ b/packages/webui/components/file-browser/file-list-item.tsx
@@ -235,7 +235,7 @@ export function FileListItem({
             onBlur={handleRename}
             onKeyDown={handleKeyDown}
             disabled={!isEditing}
-            className="h-auto p-0 text-sm font-medium text-foreground truncate"
+            className="h-auto p-0 text-sm font-medium text-foreground truncate min-w-0 flex-1"
           />
           {displayItem.status === 'error' && (
             <span className="text-xs text-destructive font-semibold shrink-0">

--- a/packages/webui/components/file-browser/folder-card.tsx
+++ b/packages/webui/components/file-browser/folder-card.tsx
@@ -344,8 +344,7 @@ export function FolderCard({
             onBlur={handleRename}
             onKeyDown={handleKeyDown}
             disabled={!isEditing}
-            className="font-semibold text-foreground text-lg leading-tight truncate h-auto p-0 !bg-transparent"
-            title={name}
+            className="h-auto p-0 text-sm font-medium text-foreground truncate !bg-transparent"
           />
 
           <div className="flex items-center justify-between text-muted-foreground">

--- a/packages/webui/components/ui/editable-text.test.tsx
+++ b/packages/webui/components/ui/editable-text.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EditableText } from './editable-text'
+
+describe('EditableText', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
+    vi.useRealTimers()
+    cleanup()
+  })
+
+  it('renders a span in read-only (disabled) mode with the value', () => {
+    render(<EditableText value="MyLongFileName.mp4" disabled={true} />)
+
+    expect(screen.queryByRole('textbox')).toBeNull()
+    const span = screen.getByText('MyLongFileName.mp4')
+    expect(span).toBeTruthy()
+    expect(span.tagName.toLowerCase()).toBe('span')
+    expect(span.className).toContain('truncate')
+  })
+
+  it('renders an input in editable (!disabled) mode', () => {
+    const handleChange = vi.fn()
+    render(<EditableText value="MyFile.txt" disabled={false} onChange={handleChange} />)
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    expect(input).toBeTruthy()
+    expect(input.value).toBe('MyFile.txt')
+  })
+
+  it('does not show tooltip on hover when text is not truncated', () => {
+    render(<EditableText value="Short.png" disabled={true} />)
+
+    const span = screen.getByText('Short.png')
+    Object.defineProperty(span, 'scrollWidth', { value: 80, configurable: true })
+    Object.defineProperty(span, 'clientWidth', { value: 100, configurable: true })
+
+    fireEvent.pointerMove(span, { pointerType: 'mouse' })
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    // Tooltip should not be displayed
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+
+  it('shows full name in tooltip after 100ms when text is truncated', () => {
+    render(
+      <EditableText
+        value="A_very_long_file_name_that_will_overflow_the_column_width.mov"
+        disabled={true}
+      />,
+    )
+
+    const span = screen.getByText('A_very_long_file_name_that_will_overflow_the_column_width.mov')
+    Object.defineProperty(span, 'scrollWidth', { value: 300, configurable: true })
+    Object.defineProperty(span, 'clientWidth', { value: 120, configurable: true })
+
+    fireEvent.pointerMove(span, { pointerType: 'mouse' })
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    const tooltip = screen.getByRole('tooltip')
+    expect(tooltip).toBeTruthy()
+    expect(tooltip.textContent).toContain(
+      'A_very_long_file_name_that_will_overflow_the_column_width.mov',
+    )
+  })
+
+  it('handles input events and keydown when editing', () => {
+    const handleKeyDown = vi.fn()
+    const handleBlur = vi.fn()
+    render(
+      <EditableText
+        value="Editable.txt"
+        disabled={false}
+        onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
+      />,
+    )
+
+    const input = screen.getByRole('textbox')
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(handleKeyDown).toHaveBeenCalledTimes(1)
+
+    fireEvent.blur(input)
+    expect(handleBlur).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/webui/components/ui/editable-text.tsx
+++ b/packages/webui/components/ui/editable-text.tsx
@@ -1,33 +1,96 @@
 import { Input } from '@/ui/components/ui/input'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/ui/components/ui/tooltip'
 import { cn } from '@/ui/lib/utils'
-import React from 'react'
+import React, { useRef, useState } from 'react'
 
-export type EditableTextProps = React.ComponentPropsWithoutRef<'input'>
+export type EditableTextProps = React.ComponentPropsWithoutRef<'input'> & {
+  tooltipSide?: 'top' | 'right' | 'bottom' | 'left'
+  tooltipDelayDuration?: number
+}
 
 const EditableText = React.forwardRef<HTMLInputElement, EditableTextProps>(
-  ({ className, onClick, onMouseDown, disabled, ...props }, ref) => {
+  (
+    {
+      className,
+      onClick,
+      onMouseDown,
+      disabled,
+      value,
+      title: _title,
+      tooltipSide = 'top',
+      tooltipDelayDuration = 100,
+      ...props
+    },
+    ref,
+  ) => {
+    const [isOpen, setIsOpen] = useState(false)
+    const spanRef = useRef<HTMLSpanElement>(null)
+
+    const textContent = typeof value === 'string' ? value : (value?.toString() ?? '')
+
+    if (disabled) {
+      return (
+        <TooltipProvider delayDuration={tooltipDelayDuration}>
+          <Tooltip
+            open={isOpen}
+            onOpenChange={(nextOpen) => {
+              if (nextOpen) {
+                if (spanRef.current && spanRef.current.scrollWidth > spanRef.current.clientWidth) {
+                  setIsOpen(true)
+                } else {
+                  setIsOpen(false)
+                }
+              } else {
+                setIsOpen(false)
+              }
+            }}
+          >
+            <TooltipTrigger asChild>
+              <span
+                ref={spanRef}
+                className={cn(
+                  'box-border block min-w-0 w-full rounded-sm border border-transparent px-1 py-0.5 text-base shadow-none transition-all outline-none cursor-default opacity-100 select-none truncate',
+                  className,
+                )}
+                onClick={onClick}
+                onMouseDown={onMouseDown}
+              >
+                {textContent}
+              </span>
+            </TooltipTrigger>
+            {isOpen && (
+              <TooltipContent
+                side={tooltipSide}
+                className="max-w-md break-all text-wrap [text-wrap:normal] text-left"
+              >
+                {textContent}
+              </TooltipContent>
+            )}
+          </Tooltip>
+        </TooltipProvider>
+      )
+    }
+
     return (
       <Input
         ref={ref}
-        readOnly={disabled}
-        tabIndex={disabled ? -1 : undefined}
+        value={value}
+        tabIndex={0}
         className={cn(
-          'h-auto min-h-0 w-full rounded-sm border px-1 py-0.5 text-base shadow-none transition-all outline-none focus-visible:ring-0',
-          !disabled
-            ? 'border-blue-500 !bg-muted/10 ring-1 ring-blue-500'
-            : 'border-transparent !bg-transparent cursor-default opacity-100 focus-visible:border-transparent focus-visible:ring-0 caret-transparent select-none',
+          'box-border block min-w-0 h-auto w-full rounded-sm border border-blue-500 !bg-muted/10 ring-1 ring-blue-500 px-1 py-0.5 text-base shadow-none transition-all outline-none focus-visible:ring-0',
           className,
         )}
         onClick={(e) => {
-          if (!disabled) {
-            e.stopPropagation()
-          }
+          e.stopPropagation()
           onClick?.(e)
         }}
         onMouseDown={(e) => {
-          if (!disabled) {
-            e.stopPropagation()
-          }
+          e.stopPropagation()
           onMouseDown?.(e)
         }}
         {...props}


### PR DESCRIPTION
## Summary

Truncates file and folder names with ellipsis when they overflow their column/card width, and displays the full name in a Radix tooltip on hover after a 100ms delay. When in rename/edit mode, renders the interactive input with matching dimensions to prevent layout shifts.

## Changes

- **EditableText Component (`packages/webui/components/ui/editable-text.tsx`)**:
  - In read-only mode (`disabled === true`), renders a `<span>` styled with `truncate` and matching 1px transparent border and padding to preserve identical element height.
  - Dynamically measures overflow (`scrollWidth > clientWidth`) on scheduled tooltip open (`delayDuration={100}`) and displays full name inside `TooltipContent` with natural wrapping (`[text-wrap:normal] break-all text-left`).
  - In edit mode (`disabled === false`), renders the standard `<Input>` element for editing with autofocus and text selection.
- **File List Item (`packages/webui/components/file-browser/file-list-item.tsx`)**:
  - Added `min-w-0 flex-1` to `EditableText` so the name flex child properly shrinks and truncates within the column width.
- **Folder & File Cards (`folder-card.tsx` & `file-card.tsx`)**:
  - Standardized font styling to `text-sm font-medium text-foreground truncate !bg-transparent` across cards and list views.
- **E2E Helpers (`apps/web/e2e/helpers/files.ts`)**:
  - Updated `fileCard` locator to match both text nodes and active input elements.
- **Unit Tests**:
  - Added unit test suites `packages/webui/components/ui/editable-text.test.tsx` and `packages/webui/components/file-browser/file-list-item.test.tsx`.

## Verification

Ran all verification suites simultaneously:
- `bun run lint` (Passed)
- `bun run format` (Passed)
- `bun run typecheck` (Passed)
- `bun run test` (134 test files, 1321 tests passed)
- `bun run test:e2e:webui` (9 tests passed)
- `bun run test:e2e:workflow` (14 test files, 58 tests passed)
- `bun run test:e2e:app` (38 tests passed)

## Notes

Zero layout shift between read and edit mode.