### PR TITLE
feat(webui): add simplified mobile-friendly layout for file and share lists

### DIFF
--- a/packages/webui/components/breadcrumb-nav.test.tsx
+++ b/packages/webui/components/breadcrumb-nav.test.tsx
@@ -83,4 +83,24 @@ describe('BreadcrumbNav component', () => {
 
     expect(screen.queryByTitle(/Linked Tasks|关联任务/i)).toBeNull()
   })
+
+  it('renders mobile navigation menu button when not in public share mode', () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <BreadcrumbNav {...baseProps} isPublic={false} />
+      </QueryClientProvider>,
+    )
+
+    expect(screen.getByRole('button', { name: /Open navigation menu/i })).toBeDefined()
+  })
+
+  it('hides mobile navigation menu button in public share mode', () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <BreadcrumbNav {...baseProps} isPublic={true} />
+      </QueryClientProvider>,
+    )
+
+    expect(screen.queryByRole('button', { name: /Open navigation menu/i })).toBeNull()
+  })
 })

--- a/packages/webui/components/breadcrumb-nav.test.tsx
+++ b/packages/webui/components/breadcrumb-nav.test.tsx
@@ -51,7 +51,7 @@ describe('BreadcrumbNav component', () => {
       </QueryClientProvider>,
     )
 
-    expect(screen.getByTitle(/Linked Tasks|关联任务/i)).toBeDefined()
+    expect(screen.getAllByTitle(/Linked Tasks|关联任务/i).length).toBeGreaterThan(0)
   })
 
   it('hides SquareKanban task link button on project root folder', () => {
@@ -94,13 +94,33 @@ describe('BreadcrumbNav component', () => {
     expect(screen.getByRole('button', { name: /Open navigation menu/i })).toBeDefined()
   })
 
-  it('hides mobile navigation menu button in public share mode', () => {
+  it('renders mobile breadcrumbs without All Projects and with project name', () => {
     render(
       <QueryClientProvider client={queryClient}>
-        <BreadcrumbNav {...baseProps} isPublic={true} />
+        <BreadcrumbNav {...baseProps} />
       </QueryClientProvider>,
     )
 
-    expect(screen.queryByRole('button', { name: /Open navigation menu/i })).toBeNull()
+    // Project name is in mobile and desktop
+    expect(screen.getAllByText('Demo Project').length).toBeGreaterThan(0)
+    // Folder A is rendered
+    expect(screen.getAllByText('Folder A').length).toBeGreaterThan(0)
+  })
+
+  it('renders omitted middle folders button (...) for deep hierarchy on mobile', () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <BreadcrumbNav
+          {...baseProps}
+          ancestorFolders={[
+            { id: 'parent-1', name: 'Middle Folder 1' },
+            { id: 'parent-2', name: 'Middle Folder 2' },
+          ]}
+          currentAsset={{ id: 'asset-deep', name: 'Deep Folder', type: 'folder' }}
+        />
+      </QueryClientProvider>,
+    )
+
+    expect(screen.getByRole('button', { name: /Show omitted folders/i })).toBeDefined()
   })
 })

--- a/packages/webui/components/breadcrumb-nav.tsx
+++ b/packages/webui/components/breadcrumb-nav.tsx
@@ -232,20 +232,334 @@ export function BreadcrumbNav({
           })),
       ]
 
+  const hasTerminal = Boolean(customTerminalBreadcrumb || (!isRootFolder && !compareMode))
+
+  const mobileProjectItem = {
+    name: projectName,
+    path: isPublic ? undefined : `/projects/${projectId}`,
+    id: 'root',
+  }
+
+  const mobileAncestorItems = ancestorFolders
+    .slice()
+    .reverse()
+    .map((folder) => ({
+      name: folder.name || '',
+      path: isPublic ? undefined : `/projects/${projectId}/folders/${folder.id}`,
+      id: folder.id,
+    }))
+
+  const mobileMiddleItems = hasTerminal ? mobileAncestorItems : mobileAncestorItems.slice(0, -1)
+  const mobileTerminalDirect =
+    !hasTerminal && mobileAncestorItems.length > 0
+      ? mobileAncestorItems[mobileAncestorItems.length - 1]
+      : null
+
+  const renderTerminal = (isMobile = false) => {
+    if (customTerminalBreadcrumb) {
+      return (
+        <span
+          className={cn(
+            'truncate rounded px-2 py-1 text-sm font-medium text-foreground',
+            isMobile && 'min-w-0 flex-1',
+          )}
+        >
+          {customTerminalBreadcrumb}
+        </span>
+      )
+    }
+
+    if (!isRootFolder && !compareMode) {
+      if (currentAsset.type === 'folder') {
+        return (
+          <span
+            className={cn(
+              'truncate rounded px-2 py-1 text-sm font-medium text-foreground',
+              isMobile && 'min-w-0 flex-1',
+            )}
+          >
+            {currentAsset.name}
+          </span>
+        )
+      }
+
+      return (
+        <DropdownMenu modal={false}>
+          <DropdownMenuTrigger
+            className={cn(
+              'flex items-center gap-1 truncate rounded px-2 py-1 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground',
+              isMobile && 'min-w-0 flex-1',
+            )}
+          >
+            <span className="truncate">{currentAsset.name}</span>
+            {currentAsset.version !== undefined && (
+              <Badge variant="outline" className="px-1 py-0 text-xs shrink-0">
+                v{currentAsset.version}
+              </Badge>
+            )}
+            <ChevronDown className="h-4 w-4 shrink-0" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-56">
+            {allowDownload &&
+              (hasVideoTranscodes ? (
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger className="flex items-center gap-2">
+                    <span>{m.download()}</span>
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuPortal>
+                    <DropdownMenuSubContent className="w-48">
+                      <DropdownMenuLabel>{m.download()}</DropdownMenuLabel>
+                      {downloadInfo?.videoTranscodes?.map((t) => {
+                        const longSide = Math.max(t.width, t.height)
+                        let resolution = `${t.height}p`
+                        if (longSide >= 3840) resolution = '2160p'
+                        else if (longSide >= 1920) resolution = '1080p'
+                        else if (longSide >= 1280) resolution = '720p'
+                        else if (longSide >= 960) resolution = '540p'
+                        else if (longSide >= 640) resolution = '360p'
+                        else if (longSide >= 320) resolution = '180p'
+                        return (
+                          <DropdownMenuItem
+                            key={resolution}
+                            onClick={() => handleDownload(t.key)}
+                            className="flex items-center justify-between"
+                          >
+                            <span>{resolution}</span>
+                            <span className="text-xs text-muted-foreground">MP4</span>
+                          </DropdownMenuItem>
+                        )
+                      })}
+                      {downloadInfo?.originalKey && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            onClick={() => handleDownload(downloadInfo.originalKey!)}
+                            className="flex items-center justify-between"
+                          >
+                            <span>Original</span>
+                            <span className="text-xs text-muted-foreground">
+                              {currentAsset.name?.split('.').pop()?.toUpperCase() || 'RAW'}
+                            </span>
+                          </DropdownMenuItem>
+                        </>
+                      )}
+                    </DropdownMenuSubContent>
+                  </DropdownMenuPortal>
+                </DropdownMenuSub>
+              ) : (
+                <DropdownMenuItem
+                  onClick={() =>
+                    downloadInfo?.originalKey && handleDownload(downloadInfo.originalKey)
+                  }
+                  disabled={!downloadInfo?.originalKey}
+                >
+                  {m.download()}
+                </DropdownMenuItem>
+              ))}
+            {canEdit && onRename && (
+              <DropdownMenuItem onClick={onRename}>{m.rename()}</DropdownMenuItem>
+            )}
+            {canEdit && onDelete && (
+              <DropdownMenuItem
+                onClick={onDelete}
+                className="text-destructive focus:text-destructive"
+              >
+                {m.delete()}
+              </DropdownMenuItem>
+            )}
+
+            {canCompareVersions && onCompareVersions && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => onCompareVersions()}>
+                  <Columns2 className="h-4 w-4" />
+                  <span>{m.compare_versions()}</span>
+                </DropdownMenuItem>
+              </>
+            )}
+
+            {versions && versions.length > 0 && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger className="flex items-center gap-2">
+                    <History className="h-4 w-4" />
+                    <span>Versions</span>
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuPortal>
+                    <DropdownMenuSubContent className="w-80 p-1">
+                      <div className="flex flex-col gap-1 max-h-96 overflow-y-auto">
+                        {versions.map((v) => {
+                          const isActive = currentAsset.version === v.version
+                          return (
+                            <DropdownMenuItem
+                              key={v.id}
+                              onClick={() => handleVersionClick(v.id)}
+                              className="flex items-center gap-3 py-2 px-3 rounded-md cursor-pointer focus:bg-accent focus:text-accent-foreground"
+                            >
+                              <div className="flex-shrink-0 flex items-center justify-center bg-muted dark:bg-muted-foreground/20 text-muted-foreground dark:text-muted-foreground rounded-full px-2 py-0.5 text-xs font-semibold select-none min-w-[2rem]">
+                                v{v.version}
+                              </div>
+
+                              <div className="h-10 w-16 flex-shrink-0 overflow-hidden rounded-md border border-border bg-muted flex items-center justify-center">
+                                {v.previewUrl ? (
+                                  <img
+                                    src={v.previewUrl}
+                                    alt={v.name || undefined}
+                                    className="h-full w-full object-cover"
+                                  />
+                                ) : (
+                                  <FileIcon className="h-4 w-4 text-muted-foreground" />
+                                )}
+                              </div>
+
+                              <div className="flex flex-col flex-1 min-w-0 text-left">
+                                <span className="truncate text-sm font-semibold text-foreground">
+                                  {v.name}
+                                </span>
+                                <span className="truncate text-xs text-muted-foreground">
+                                  {v.creator?.name || 'Unknown'}
+                                </span>
+                              </div>
+
+                              {isActive && (
+                                <Check className="h-4 w-4 text-primary ml-auto flex-shrink-0" />
+                              )}
+                            </DropdownMenuItem>
+                          )
+                        })}
+                      </div>
+                      <DropdownMenuSeparator />
+                      <div className="p-1">
+                        <button
+                          className="w-full text-center text-xs font-medium py-2 px-3 rounded-md bg-muted/80 hover:bg-muted text-foreground transition-colors cursor-pointer"
+                          onClick={() => setIsManageVersionsOpen(true)}
+                        >
+                          {m.manage_versions()}
+                        </button>
+                      </div>
+                    </DropdownMenuSubContent>
+                  </DropdownMenuPortal>
+                </DropdownMenuSub>
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )
+    }
+
+    return null
+  }
+
   return (
     <div className="flex h-14 flex-nowrap items-center justify-between gap-2 border-b border-border bg-card px-4 py-2 overflow-hidden">
-      <div className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
+      {/* Mobile Breadcrumbs (md:hidden) */}
+      <div className="flex md:hidden min-w-0 flex-1 items-center gap-1 overflow-hidden">
         {!isPublic && (
           <Button
             variant="ghost"
             size="icon"
             onClick={() => openMobileMenu()}
-            className="md:hidden h-8 w-8 text-foreground hover:bg-accent shrink-0 -ml-2 mr-1"
+            className="h-8 w-8 text-foreground hover:bg-accent shrink-0 -ml-2 mr-1"
             aria-label="Open navigation menu"
           >
             <Menu className="h-5 w-5" />
           </Button>
         )}
+
+        {hasTerminal || mobileTerminalDirect ? (
+          <>
+            {mobileProjectItem.path ? (
+              <Link
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                to={mobileProjectItem.path as any}
+                className="min-w-0 flex-1 max-w-[45%] truncate rounded px-1.5 py-1 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground shrink"
+              >
+                {mobileProjectItem.name}
+              </Link>
+            ) : (
+              <button
+                onClick={() => mobileProjectItem.id && onFolderClick?.(mobileProjectItem.id)}
+                className="min-w-0 flex-1 max-w-[45%] truncate rounded px-1.5 py-1 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground text-left shrink cursor-pointer"
+              >
+                {mobileProjectItem.name}
+              </button>
+            )}
+
+            <span className="text-muted-foreground shrink-0">/</span>
+
+            {mobileMiddleItems.length > 0 && (
+              <>
+                <DropdownMenu modal={false}>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      className="text-muted-foreground hover:text-foreground text-sm font-medium px-1.5 py-0.5 rounded hover:bg-accent shrink-0 cursor-pointer"
+                      aria-label="Show omitted folders"
+                    >
+                      ...
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="start">
+                    {mobileMiddleItems.map((item, idx) => (
+                      <DropdownMenuItem key={idx} asChild>
+                        {item.path ? (
+                          <Link
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            to={item.path as any}
+                            className="cursor-pointer"
+                          >
+                            {item.name}
+                          </Link>
+                        ) : (
+                          <button
+                            onClick={() => item.id && onFolderClick?.(item.id)}
+                            className="cursor-pointer w-full text-left"
+                          >
+                            {item.name}
+                          </button>
+                        )}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <span className="text-muted-foreground shrink-0">/</span>
+              </>
+            )}
+
+            {hasTerminal
+              ? renderTerminal(true)
+              : mobileTerminalDirect && (
+                  <span className="min-w-0 flex-1 truncate rounded px-1.5 py-1 text-sm font-medium text-foreground">
+                    {mobileTerminalDirect.name}
+                  </span>
+                )}
+          </>
+        ) : (
+          <span className="min-w-0 flex-1 truncate rounded px-1.5 py-1 text-sm font-medium text-foreground">
+            {mobileProjectItem.name}
+          </span>
+        )}
+
+        {showKanbanLink && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-xs gap-1.5 text-muted-foreground hover:text-foreground hover:bg-muted ml-1 cursor-pointer shrink-0"
+            onClick={() => setIsLinkedTasksOpen(true)}
+            title={m.linked_tasks()}
+          >
+            <SquareKanban className="w-4 h-4" />
+            {linkedTaskCount > 0 && (
+              <span className="inline-flex items-center justify-center px-1.5 py-0.2 text-[10px] font-semibold rounded-full bg-muted-foreground/15 text-foreground">
+                {linkedTaskCount}
+              </span>
+            )}
+          </Button>
+        )}
+      </div>
+
+      {/* Desktop Breadcrumbs (hidden md:flex) */}
+      <div className="hidden md:flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
         {breadcrumbs.map((breadcrumb, index) => (
           <div key={index} className="flex items-center gap-1">
             {index > 0 && <span className="text-muted-foreground">/</span>}
@@ -270,186 +584,18 @@ export function BreadcrumbNav({
             )}
           </div>
         ))}
-        {customTerminalBreadcrumb ? (
+        {hasTerminal && (
           <div className="flex items-center gap-1">
             <span className="text-muted-foreground">/</span>
-            <span className="truncate rounded px-2 py-1 text-sm font-medium text-foreground">
-              {customTerminalBreadcrumb}
-            </span>
+            {renderTerminal(false)}
           </div>
-        ) : !isRootFolder && !compareMode ? (
-          <div className="flex items-center gap-1">
-            <span className="text-muted-foreground">/</span>
-            {currentAsset.type === 'folder' ? (
-              <span className="truncate rounded px-2 py-1 text-sm font-medium text-foreground">
-                {currentAsset.name}
-              </span>
-            ) : (
-              <DropdownMenu modal={false}>
-                <DropdownMenuTrigger className="flex items-center gap-1 truncate rounded px-2 py-1 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground">
-                  <span>{currentAsset.name}</span>
-                  {currentAsset.version !== undefined && (
-                    <Badge variant="outline" className="px-1 py-0 text-xs">
-                      v{currentAsset.version}
-                    </Badge>
-                  )}
-                  <ChevronDown className="h-4 w-4" />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent className="w-56">
-                  {allowDownload &&
-                    (hasVideoTranscodes ? (
-                      <DropdownMenuSub>
-                        <DropdownMenuSubTrigger className="flex items-center gap-2">
-                          <span>{m.download()}</span>
-                        </DropdownMenuSubTrigger>
-                        <DropdownMenuPortal>
-                          <DropdownMenuSubContent className="w-48">
-                            <DropdownMenuLabel>{m.download()}</DropdownMenuLabel>
-                            {downloadInfo?.videoTranscodes?.map((t) => {
-                              const longSide = Math.max(t.width, t.height)
-                              let resolution = `${t.height}p`
-                              if (longSide >= 3840) resolution = '2160p'
-                              else if (longSide >= 1920) resolution = '1080p'
-                              else if (longSide >= 1280) resolution = '720p'
-                              else if (longSide >= 960) resolution = '540p'
-                              else if (longSide >= 640) resolution = '360p'
-                              else if (longSide >= 320) resolution = '180p'
-                              return (
-                                <DropdownMenuItem
-                                  key={resolution}
-                                  onClick={() => handleDownload(t.key)}
-                                  className="flex items-center justify-between"
-                                >
-                                  <span>{resolution}</span>
-                                  <span className="text-xs text-muted-foreground">MP4</span>
-                                </DropdownMenuItem>
-                              )
-                            })}
-                            {downloadInfo?.originalKey && (
-                              <>
-                                <DropdownMenuSeparator />
-                                <DropdownMenuItem
-                                  onClick={() => handleDownload(downloadInfo.originalKey!)}
-                                  className="flex items-center justify-between"
-                                >
-                                  <span>Original</span>
-                                  <span className="text-xs text-muted-foreground">
-                                    {currentAsset.name?.split('.').pop()?.toUpperCase() || 'RAW'}
-                                  </span>
-                                </DropdownMenuItem>
-                              </>
-                            )}
-                          </DropdownMenuSubContent>
-                        </DropdownMenuPortal>
-                      </DropdownMenuSub>
-                    ) : (
-                      <DropdownMenuItem
-                        onClick={() =>
-                          downloadInfo?.originalKey && handleDownload(downloadInfo.originalKey)
-                        }
-                        disabled={!downloadInfo?.originalKey}
-                      >
-                        {m.download()}
-                      </DropdownMenuItem>
-                    ))}
-                  {canEdit && onRename && (
-                    <DropdownMenuItem onClick={onRename}>{m.rename()}</DropdownMenuItem>
-                  )}
-                  {canEdit && onDelete && (
-                    <DropdownMenuItem
-                      onClick={onDelete}
-                      className="text-destructive focus:text-destructive"
-                    >
-                      {m.delete()}
-                    </DropdownMenuItem>
-                  )}
-
-                  {canCompareVersions && onCompareVersions && (
-                    <>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem onClick={() => onCompareVersions()}>
-                        <Columns2 className="h-4 w-4" />
-                        <span>{m.compare_versions()}</span>
-                      </DropdownMenuItem>
-                    </>
-                  )}
-
-                  {versions && versions.length > 0 && (
-                    <>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuSub>
-                        <DropdownMenuSubTrigger className="flex items-center gap-2">
-                          <History className="h-4 w-4" />
-                          <span>Versions</span>
-                        </DropdownMenuSubTrigger>
-                        <DropdownMenuPortal>
-                          <DropdownMenuSubContent className="w-80 p-1">
-                            <div className="flex flex-col gap-1 max-h-96 overflow-y-auto">
-                              {versions.map((v) => {
-                                const isActive = currentAsset.version === v.version
-                                return (
-                                  <DropdownMenuItem
-                                    key={v.id}
-                                    onClick={() => handleVersionClick(v.id)}
-                                    className="flex items-center gap-3 py-2 px-3 rounded-md cursor-pointer focus:bg-accent focus:text-accent-foreground"
-                                  >
-                                    <div className="flex-shrink-0 flex items-center justify-center bg-muted dark:bg-muted-foreground/20 text-muted-foreground dark:text-muted-foreground rounded-full px-2 py-0.5 text-xs font-semibold select-none min-w-[2rem]">
-                                      v{v.version}
-                                    </div>
-
-                                    <div className="h-10 w-16 flex-shrink-0 overflow-hidden rounded-md border border-border bg-muted flex items-center justify-center">
-                                      {v.previewUrl ? (
-                                        <img
-                                          src={v.previewUrl}
-                                          alt={v.name || undefined}
-                                          className="h-full w-full object-cover"
-                                        />
-                                      ) : (
-                                        <FileIcon className="h-4 w-4 text-muted-foreground" />
-                                      )}
-                                    </div>
-
-                                    <div className="flex flex-col flex-1 min-w-0 text-left">
-                                      <span className="truncate text-sm font-semibold text-foreground">
-                                        {v.name}
-                                      </span>
-                                      <span className="truncate text-xs text-muted-foreground">
-                                        {v.creator?.name || 'Unknown'}
-                                      </span>
-                                    </div>
-
-                                    {isActive && (
-                                      <Check className="h-4 w-4 text-primary ml-auto flex-shrink-0" />
-                                    )}
-                                  </DropdownMenuItem>
-                                )
-                              })}
-                            </div>
-                            <DropdownMenuSeparator />
-                            <div className="p-1">
-                              <button
-                                className="w-full text-center text-xs font-medium py-2 px-3 rounded-md bg-muted/80 hover:bg-muted text-foreground transition-colors cursor-pointer"
-                                onClick={() => setIsManageVersionsOpen(true)}
-                              >
-                                {m.manage_versions()}
-                              </button>
-                            </div>
-                          </DropdownMenuSubContent>
-                        </DropdownMenuPortal>
-                      </DropdownMenuSub>
-                    </>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
-          </div>
-        ) : null}
+        )}
 
         {showKanbanLink && (
           <Button
             variant="ghost"
             size="sm"
-            className="h-7 px-2 text-xs gap-1.5 text-muted-foreground hover:text-foreground hover:bg-muted ml-1 cursor-pointer"
+            className="h-7 px-2 text-xs gap-1.5 text-muted-foreground hover:text-foreground hover:bg-muted ml-1 cursor-pointer shrink-0"
             onClick={() => setIsLinkedTasksOpen(true)}
             title={m.linked_tasks()}
           >
@@ -461,51 +607,51 @@ export function BreadcrumbNav({
             )}
           </Button>
         )}
-
-        {showKanbanLink && isLinkedTasksOpen && targetAssetId && (
-          <AssetLinkedTasksDialog
-            teamId={teamId}
-            assetId={targetAssetId}
-            assetName={currentAsset.name}
-            isOpen={isLinkedTasksOpen}
-            onClose={() => setIsLinkedTasksOpen(false)}
-          />
-        )}
-
-        {fileId && versions && versions.length > 0 && (
-          <ManageVersionsDialog
-            open={isManageVersionsOpen}
-            onOpenChange={setIsManageVersionsOpen}
-            stackId={fileId}
-            canEdit={canEdit}
-            onStackDissolved={(remainingFileId) => {
-              setIsManageVersionsOpen(false)
-              navigate({
-                to: '/projects/$projectId/files/$fileId',
-                params: { projectId, fileId: remainingFileId },
-              })
-            }}
-            onVersionRemoved={(removedVersionId, remainingVersions) => {
-              const currentVersionId = currentAsset.version
-                ? versions.find((v) => v.version === currentAsset.version)?.id
-                : undefined
-              if (currentVersionId === removedVersionId) {
-                const topVersion = remainingVersions[0]
-                if (topVersion) {
-                  navigate({
-                    to: '/projects/$projectId/files/$fileId',
-                    params: { projectId, fileId },
-                    search: (prev: Record<string, unknown>) => ({
-                      ...prev,
-                      version: topVersion.id,
-                    }),
-                  })
-                }
-              }
-            }}
-          />
-        )}
       </div>
+
+      {showKanbanLink && isLinkedTasksOpen && targetAssetId && (
+        <AssetLinkedTasksDialog
+          teamId={teamId}
+          assetId={targetAssetId}
+          assetName={currentAsset.name}
+          isOpen={isLinkedTasksOpen}
+          onClose={() => setIsLinkedTasksOpen(false)}
+        />
+      )}
+
+      {fileId && versions && versions.length > 0 && (
+        <ManageVersionsDialog
+          open={isManageVersionsOpen}
+          onOpenChange={setIsManageVersionsOpen}
+          stackId={fileId}
+          canEdit={canEdit}
+          onStackDissolved={(remainingFileId) => {
+            setIsManageVersionsOpen(false)
+            navigate({
+              to: '/projects/$projectId/files/$fileId',
+              params: { projectId, fileId: remainingFileId },
+            })
+          }}
+          onVersionRemoved={(removedVersionId, remainingVersions) => {
+            const currentVersionId = currentAsset.version
+              ? versions.find((v) => v.version === currentAsset.version)?.id
+              : undefined
+            if (currentVersionId === removedVersionId) {
+              const topVersion = remainingVersions[0]
+              if (topVersion) {
+                navigate({
+                  to: '/projects/$projectId/files/$fileId',
+                  params: { projectId, fileId },
+                  search: (prev: Record<string, unknown>) => ({
+                    ...prev,
+                    version: topVersion.id,
+                  }),
+                })
+              }
+            }
+          }}
+        />
+      )}
 
       <div className="hidden md:flex items-center gap-2">
         <div className="flex flex-shrink-0 items-center gap-1 rounded-md border border-border bg-background p-1">

--- a/packages/webui/components/breadcrumb-nav.tsx
+++ b/packages/webui/components/breadcrumb-nav.tsx
@@ -453,144 +453,151 @@ export function BreadcrumbNav({
 
   return (
     <div className="flex h-14 flex-nowrap items-center justify-between gap-2 border-b border-border bg-card px-4 py-2 overflow-hidden">
-      {/* Mobile Breadcrumbs (md:hidden) */}
-      <div className="flex md:hidden min-w-0 flex-1 items-center gap-1 overflow-hidden">
+      <div className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
+        {/* Mobile menu button */}
         {!isPublic && (
           <Button
             variant="ghost"
             size="icon"
             onClick={() => openMobileMenu()}
-            className="h-8 w-8 text-foreground hover:bg-accent shrink-0 -ml-2 mr-1"
+            className="md:hidden h-8 w-8 text-foreground hover:bg-accent shrink-0 -ml-2 mr-1"
             aria-label="Open navigation menu"
           >
             <Menu className="h-5 w-5" />
           </Button>
         )}
 
-        {hasTerminal || mobileTerminalDirect ? (
-          <>
-            {mobileProjectItem.path ? (
-              <Link
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                to={mobileProjectItem.path as any}
-                className="min-w-0 flex-1 max-w-[45%] truncate rounded px-1.5 py-1 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground shrink"
-              >
-                {mobileProjectItem.name}
-              </Link>
-            ) : (
-              <button
-                onClick={() => mobileProjectItem.id && onFolderClick?.(mobileProjectItem.id)}
-                className="min-w-0 flex-1 max-w-[45%] truncate rounded px-1.5 py-1 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground text-left shrink cursor-pointer"
-              >
-                {mobileProjectItem.name}
-              </button>
-            )}
+        {/* Desktop-only: All Projects */}
+        {!isPublic && (
+          <div className="hidden md:flex items-center gap-1 shrink-0">
+            <Link
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              to={`/teams/${teamId}` as any}
+              className="truncate rounded px-2 py-1 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground text-muted-foreground"
+            >
+              {m.all_projects()}
+            </Link>
+            <span className="text-muted-foreground">/</span>
+          </div>
+        )}
 
-            <span className="text-muted-foreground shrink-0">/</span>
-
-            {mobileMiddleItems.length > 0 && (
-              <>
-                <DropdownMenu modal={false}>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      className="text-muted-foreground hover:text-foreground text-sm font-medium px-1.5 py-0.5 rounded hover:bg-accent shrink-0 cursor-pointer"
-                      aria-label="Show omitted folders"
-                    >
-                      ...
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start">
-                    {mobileMiddleItems.map((item, idx) => (
-                      <DropdownMenuItem key={idx} asChild>
-                        {item.path ? (
-                          <Link
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                            to={item.path as any}
-                            className="cursor-pointer"
-                          >
-                            {item.name}
-                          </Link>
-                        ) : (
-                          <button
-                            onClick={() => item.id && onFolderClick?.(item.id)}
-                            className="cursor-pointer w-full text-left"
-                          >
-                            {item.name}
-                          </button>
-                        )}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-                <span className="text-muted-foreground shrink-0">/</span>
-              </>
-            )}
-
-            {hasTerminal
-              ? renderTerminal(true)
-              : mobileTerminalDirect && (
-                  <span className="min-w-0 flex-1 truncate rounded px-1.5 py-1 text-sm font-medium text-foreground">
-                    {mobileTerminalDirect.name}
-                  </span>
-                )}
-          </>
+        {/* Project Name (Desktop & Mobile) */}
+        {hasTerminal || ancestorFolders.length > 0 ? (
+          mobileProjectItem.path ? (
+            <Link
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              to={mobileProjectItem.path as any}
+              className="min-w-0 max-w-[45%] md:max-w-none truncate rounded px-1.5 md:px-2 py-1 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground shrink"
+            >
+              {mobileProjectItem.name}
+            </Link>
+          ) : (
+            <button
+              onClick={() => mobileProjectItem.id && onFolderClick?.(mobileProjectItem.id)}
+              className="min-w-0 max-w-[45%] md:max-w-none truncate rounded px-1.5 md:px-2 py-1 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground text-left shrink cursor-pointer"
+            >
+              {mobileProjectItem.name}
+            </button>
+          )
         ) : (
-          <span className="min-w-0 flex-1 truncate rounded px-1.5 py-1 text-sm font-medium text-foreground">
+          <span className="min-w-0 flex-1 truncate rounded px-1.5 md:px-2 py-1 text-sm font-medium text-foreground">
             {mobileProjectItem.name}
           </span>
         )}
 
-        {showKanbanLink && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 px-2 text-xs gap-1.5 text-muted-foreground hover:text-foreground hover:bg-muted ml-1 cursor-pointer shrink-0"
-            onClick={() => setIsLinkedTasksOpen(true)}
-            title={m.linked_tasks()}
-          >
-            <SquareKanban className="w-4 h-4" />
-            {linkedTaskCount > 0 && (
-              <span className="inline-flex items-center justify-center px-1.5 py-0.2 text-[10px] font-semibold rounded-full bg-muted-foreground/15 text-foreground">
-                {linkedTaskCount}
-              </span>
-            )}
-          </Button>
+        {/* Mobile-only: Omitted Middle Ancestors (...) dropdown */}
+        {mobileMiddleItems.length > 0 && (
+          <div className="flex md:hidden items-center gap-1 shrink-0">
+            <span className="text-muted-foreground shrink-0">/</span>
+            <DropdownMenu modal={false}>
+              <DropdownMenuTrigger asChild>
+                <button
+                  className="text-muted-foreground hover:text-foreground text-sm font-medium px-1.5 py-0.5 rounded hover:bg-accent shrink-0 cursor-pointer"
+                  aria-label="Show omitted folders"
+                >
+                  ...
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                {mobileMiddleItems.map((item, idx) => (
+                  <DropdownMenuItem key={idx} asChild>
+                    {item.path ? (
+                      <Link
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        to={item.path as any}
+                        className="cursor-pointer"
+                      >
+                        {item.name}
+                      </Link>
+                    ) : (
+                      <button
+                        onClick={() => item.id && onFolderClick?.(item.id)}
+                        className="cursor-pointer w-full text-left"
+                      >
+                        {item.name}
+                      </button>
+                    )}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <span className="text-muted-foreground shrink-0">/</span>
+          </div>
         )}
-      </div>
 
-      {/* Desktop Breadcrumbs (hidden md:flex) */}
-      <div className="hidden md:flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
-        {breadcrumbs.map((breadcrumb, index) => (
-          <div key={index} className="flex items-center gap-1">
-            {index > 0 && <span className="text-muted-foreground">/</span>}
-            {breadcrumb.path ? (
-              <Link
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                to={breadcrumb.path as any}
-                className={cn(
-                  'truncate rounded px-2 py-1 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground',
-                  breadcrumb.isMuted ? 'text-muted-foreground' : 'text-foreground',
+        {/* Desktop-only: All Ancestor Folders */}
+        {ancestorFolders
+          .slice()
+          .reverse()
+          .map((folder) => {
+            const path = isPublic
+              ? undefined
+              : `/projects/${projectId}/folders/${folder.id}`
+            return (
+              <div key={folder.id} className="hidden md:flex items-center gap-1">
+                <span className="text-muted-foreground">/</span>
+                {path ? (
+                  <Link
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    to={path as any}
+                    className="truncate rounded px-2 py-1 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground text-foreground"
+                  >
+                    {folder.name}
+                  </Link>
+                ) : (
+                  <button
+                    onClick={() => folder.id && onFolderClick?.(folder.id)}
+                    className="truncate rounded px-2 py-1 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground text-foreground"
+                  >
+                    {folder.name}
+                  </button>
                 )}
-              >
-                {breadcrumb.name}
-              </Link>
-            ) : (
-              <button
-                onClick={() => breadcrumb.id && onFolderClick?.(breadcrumb.id)}
-                className="truncate rounded px-2 py-1 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground text-foreground"
-              >
-                {breadcrumb.name}
-              </button>
-            )}
-          </div>
-        ))}
-        {hasTerminal && (
-          <div className="flex items-center gap-1">
-            <span className="text-muted-foreground">/</span>
-            {renderTerminal(false)}
+              </div>
+            )
+          })}
+
+        {/* Terminal Item (Desktop & Mobile) */}
+        {(hasTerminal || (!hasTerminal && ancestorFolders.length > 0)) && (
+          <div className="flex items-center gap-1 min-w-0 flex-1 overflow-hidden">
+            <span
+              className={cn(
+                'text-muted-foreground shrink-0',
+                mobileMiddleItems.length > 0 ? 'hidden md:inline' : 'inline',
+              )}
+            >
+              /
+            </span>
+            {hasTerminal
+              ? renderTerminal(true)
+              : mobileTerminalDirect && (
+                  <span className="min-w-0 flex-1 truncate rounded px-2 py-1 text-sm font-medium text-foreground">
+                    {mobileTerminalDirect.name}
+                  </span>
+                )}
           </div>
         )}
 
+        {/* Linked Tasks */}
         {showKanbanLink && (
           <Button
             variant="ghost"

--- a/packages/webui/components/breadcrumb-nav.tsx
+++ b/packages/webui/components/breadcrumb-nav.tsx
@@ -239,7 +239,7 @@ export function BreadcrumbNav({
           <Button
             variant="ghost"
             size="icon"
-            onClick={() => openMobileMenu('folders')}
+            onClick={() => openMobileMenu()}
             className="md:hidden h-8 w-8 text-foreground hover:bg-accent shrink-0 -ml-2 mr-1"
             aria-label="Open navigation menu"
           >

--- a/packages/webui/components/breadcrumb-nav.tsx
+++ b/packages/webui/components/breadcrumb-nav.tsx
@@ -206,32 +206,6 @@ export function BreadcrumbNav({
   const isAudio = currentAsset.proxyType === 'audio'
   const hasVideoTranscodes = !isAudio && (downloadInfo?.videoTranscodes?.length ?? 0) > 0
 
-  const breadcrumbs: { name: string; path?: string; id?: string; isMuted?: boolean }[] = isPublic
-    ? [
-        {
-          name: projectName,
-          id: 'root', // Special ID for share root
-        },
-        ...ancestorFolders
-          .slice()
-          .reverse()
-          .map((folder) => ({
-            name: folder.name || '',
-            id: folder.id,
-          })),
-      ]
-    : [
-        { name: m.all_projects(), path: `/teams/${teamId}`, isMuted: true },
-        { name: projectName, path: `/projects/${projectId}` },
-        ...ancestorFolders
-          .slice()
-          .reverse()
-          .map((folder) => ({
-            name: folder.name || '',
-            path: `/projects/${projectId}/folders/${folder.id}`,
-          })),
-      ]
-
   const hasTerminal = Boolean(customTerminalBreadcrumb || (!isRootFolder && !compareMode))
 
   const mobileProjectItem = {
@@ -550,9 +524,7 @@ export function BreadcrumbNav({
           .slice()
           .reverse()
           .map((folder) => {
-            const path = isPublic
-              ? undefined
-              : `/projects/${projectId}/folders/${folder.id}`
+            const path = isPublic ? undefined : `/projects/${projectId}/folders/${folder.id}`
             return (
               <div key={folder.id} className="hidden md:flex items-center gap-1">
                 <span className="text-muted-foreground">/</span>

--- a/packages/webui/components/breadcrumb-nav.tsx
+++ b/packages/webui/components/breadcrumb-nav.tsx
@@ -41,9 +41,11 @@ import {
   History,
   LayoutGrid,
   List,
+  Menu,
   SquareKanban,
 } from 'lucide-react'
 import { useState } from 'react'
+import { useDualSidebarStore } from '@/ui/stores/dual-sidebar'
 import { ManageVersionsDialog } from './manage-versions-dialog'
 import { AssetLinkedTasksDialog } from './kanban/asset-linked-tasks-dialog'
 
@@ -127,6 +129,7 @@ export function BreadcrumbNav({
 }: BreadcrumbNavProps) {
   const navigate = useNavigate()
   const { canEdit } = usePermissions(projectId)
+  const { openMobileMenu } = useDualSidebarStore()
   const [isManageVersionsOpen, setIsManageVersionsOpen] = useState(false)
   const [isLinkedTasksOpen, setIsLinkedTasksOpen] = useState(false)
 
@@ -230,8 +233,19 @@ export function BreadcrumbNav({
       ]
 
   return (
-    <div className="flex h-14 flex-wrap items-center justify-between gap-2 border-b border-border bg-card px-4 py-2">
-      <div className="flex min-w-0 flex-shrink items-center gap-1">
+    <div className="flex h-14 flex-nowrap items-center justify-between gap-2 border-b border-border bg-card px-4 py-2 overflow-hidden">
+      <div className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
+        {!isPublic && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => openMobileMenu('folders')}
+            className="md:hidden h-8 w-8 text-foreground hover:bg-accent shrink-0 -ml-2 mr-1"
+            aria-label="Open navigation menu"
+          >
+            <Menu className="h-5 w-5" />
+          </Button>
+        )}
         {breadcrumbs.map((breadcrumb, index) => (
           <div key={index} className="flex items-center gap-1">
             {index > 0 && <span className="text-muted-foreground">/</span>}
@@ -493,7 +507,7 @@ export function BreadcrumbNav({
         )}
       </div>
 
-      <div className="flex items-center gap-2">
+      <div className="hidden md:flex items-center gap-2">
         <div className="flex flex-shrink-0 items-center gap-1 rounded-md border border-border bg-background p-1">
           {/* Left Sidebar Toggle */}
           {!fileId && !isPublic && onLeftSidebarToggle && (

--- a/packages/webui/components/dual-sidebar.test.tsx
+++ b/packages/webui/components/dual-sidebar.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DualSidebar, DualSidebarItem } from './dual-sidebar'
+import { useDualSidebarStore } from '@/ui/stores/dual-sidebar'
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouterState: () => '/projects/proj-1',
+}))
+
+vi.mock('./user-menu', () => ({
+  UserMenu: () => <div data-testid="user-menu">User</div>,
+}))
+
+describe('DualSidebar component', () => {
+  beforeEach(() => {
+    useDualSidebarStore.setState({
+      isMobileMenuOpen: false,
+      activeItem: null,
+      activeItemId: null,
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders Level 1 icons and UserMenu', () => {
+    render(
+      <DualSidebar>
+        <DualSidebarItem icon={<span>HomeIcon</span>} label="Home" />
+        <DualSidebarItem icon={<span>NotifIcon</span>} label="Notifications">
+          <div>Notification List</div>
+        </DualSidebarItem>
+      </DualSidebar>,
+    )
+
+    expect(screen.getByLabelText('Home')).toBeDefined()
+    expect(screen.getByLabelText('Notifications')).toBeDefined()
+    expect(screen.getByTestId('user-menu')).toBeDefined()
+  })
+
+  it('displays defaultMobileContent when mobile menu is open and no active item is selected', () => {
+    useDualSidebarStore.setState({ isMobileMenuOpen: true })
+
+    render(
+      <DualSidebar
+        defaultMobileContent={{
+          label: 'Project Folders',
+          children: <div>Folder Tree Content</div>,
+        }}
+      >
+        <DualSidebarItem icon={<span>HomeIcon</span>} label="Home" />
+        <DualSidebarItem icon={<span>NotifIcon</span>} label="Notifications">
+          <div>Notification List</div>
+        </DualSidebarItem>
+      </DualSidebar>,
+    )
+
+    expect(screen.getByText('Project Folders')).toBeDefined()
+    expect(screen.getByText('Folder Tree Content')).toBeDefined()
+  })
+
+  it('switches to child item content when a Level 1 icon is clicked', () => {
+    useDualSidebarStore.setState({ isMobileMenuOpen: true })
+
+    render(
+      <DualSidebar
+        defaultMobileContent={{
+          label: 'Project Folders',
+          children: <div>Folder Tree Content</div>,
+        }}
+      >
+        <DualSidebarItem icon={<span>HomeIcon</span>} label="Home" />
+        <DualSidebarItem icon={<span>NotifIcon</span>} label="Notifications">
+          <div>Notification List</div>
+        </DualSidebarItem>
+      </DualSidebar>,
+    )
+
+    const notifBtn = screen.getByLabelText('Notifications')
+    act(() => {
+      fireEvent.click(notifBtn)
+    })
+
+    expect(screen.getByText('Notification List')).toBeDefined()
+  })
+
+  it('closes mobile menu when close (X) button is clicked', () => {
+    useDualSidebarStore.setState({ isMobileMenuOpen: true })
+
+    render(
+      <DualSidebar
+        defaultMobileContent={{
+          label: 'Project Folders',
+          children: <div>Folder Tree Content</div>,
+        }}
+      >
+        <DualSidebarItem icon={<span>HomeIcon</span>} label="Home" />
+      </DualSidebar>,
+    )
+
+    const closeButton = screen.getByRole('button', { name: /Close navigation menu/i })
+    act(() => {
+      fireEvent.click(closeButton)
+    })
+
+    expect(useDualSidebarStore.getState().isMobileMenuOpen).toBe(false)
+  })
+})

--- a/packages/webui/components/dual-sidebar.tsx
+++ b/packages/webui/components/dual-sidebar.tsx
@@ -1,7 +1,8 @@
-import { Menu } from 'lucide-react'
+import { Menu, X } from 'lucide-react'
 import React, { useEffect, useMemo } from 'react'
 import { useRouterState } from '@tanstack/react-router'
 import { useDualSidebarStore } from '@/ui/stores/dual-sidebar'
+import { cn } from '@/ui/lib/utils'
 import { Button } from './ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip'
 import { UserMenu } from './user-menu'
@@ -24,17 +25,19 @@ export const DualSidebarItem: React.FC<DualSidebarItemProps> = () => {
 interface DualSidebarProps {
   children: React.ReactNode
   hideMobileButton?: boolean
+  defaultMobileContent?: {
+    label: string
+    children: React.ReactNode
+  }
 }
 
-export const DualSidebar: React.FC<DualSidebarProps> = ({ children, hideMobileButton = false }) => {
-  const {
-    isMobileMenuOpen,
-    activeItem,
-    activeItemId,
-    setActiveItem,
-    toggleMobileMenu,
-    closeMobileMenu,
-  } = useDualSidebarStore()
+export const DualSidebar: React.FC<DualSidebarProps> = ({
+  children,
+  hideMobileButton = false,
+  defaultMobileContent,
+}) => {
+  const { isMobileMenuOpen, activeItem, setActiveItem, toggleMobileMenu, closeMobileMenu } =
+    useDualSidebarStore()
 
   const pathname = useRouterState({ select: (s) => s.location.pathname })
 
@@ -47,22 +50,19 @@ export const DualSidebar: React.FC<DualSidebarProps> = ({ children, hideMobileBu
     [children],
   )
 
-  // Automatically resolve activeItemId to activeItem index if specified
-  useEffect(() => {
-    if (activeItemId) {
-      const foundIndex = sidebarItems.findIndex((item) => item.props.id === activeItemId)
-      if (foundIndex !== -1) {
-        setActiveItem(foundIndex)
-      }
-    }
-  }, [activeItemId, sidebarItems, setActiveItem])
+  const prevPathnameRef = React.useRef(pathname)
 
   // Automatically close mobile menu when navigating to another route
   useEffect(() => {
-    closeMobileMenu()
+    if (prevPathnameRef.current !== pathname) {
+      prevPathnameRef.current = pathname
+      closeMobileMenu()
+    }
   }, [pathname, closeMobileMenu])
 
   const activeItemContent = activeItem !== null ? sidebarItems[activeItem]?.props : null
+  const displayContent = activeItemContent ?? (isMobileMenuOpen ? defaultMobileContent : null)
+  const isLevel2Open = Boolean(activeItemContent || (isMobileMenuOpen && defaultMobileContent))
 
   const handleItemClick = (index: number) => {
     const item = sidebarItems[index]
@@ -161,19 +161,30 @@ export const DualSidebar: React.FC<DualSidebarProps> = ({ children, hideMobileBu
 
         {/* Level 2: Content Panel */}
         <div
-          className={`transition-all duration-300 ease-in-out bg-sidebar/95 backdrop-blur-sm shadow-lg overflow-hidden ${
-            activeItem !== null
-              ? 'w-[calc(100vw-4rem)] md:w-100 border-r border-sidebar-border'
-              : 'w-0'
-          }`}
+          className={cn(
+            'transition-all duration-300 ease-in-out bg-sidebar/95 backdrop-blur-sm shadow-lg overflow-hidden',
+            isLevel2Open ? 'w-[calc(100vw-4rem)] border-r border-sidebar-border' : 'w-0',
+            activeItemContent
+              ? 'md:w-100 md:border-r md:border-sidebar-border'
+              : 'md:w-0 md:border-r-0',
+          )}
         >
           <div className="w-[calc(100vw-4rem)] md:w-100 h-full flex flex-col">
-            {activeItemContent && (
+            {displayContent && (
               <>
-                <header className="h-16 flex items-center px-4 font-bold text-lg border-b border-sidebar-border flex-shrink-0">
-                  <h2>{activeItemContent.label}</h2>
+                <header className="h-16 flex items-center justify-between px-4 font-bold text-lg border-b border-sidebar-border flex-shrink-0">
+                  <h2 className="truncate">{displayContent.label}</h2>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={closeMobileMenu}
+                    className="h-8 w-8 text-sidebar-foreground hover:bg-sidebar-accent"
+                    aria-label="Close navigation menu"
+                  >
+                    <X className="h-5 w-5" />
+                  </Button>
                 </header>
-                <div className="flex-1 overflow-y-auto p-2">{activeItemContent.children}</div>
+                <div className="flex-1 overflow-y-auto p-2">{displayContent.children}</div>
               </>
             )}
           </div>

--- a/packages/webui/components/dual-sidebar.tsx
+++ b/packages/webui/components/dual-sidebar.tsx
@@ -1,10 +1,13 @@
 import { Menu } from 'lucide-react'
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo } from 'react'
+import { useRouterState } from '@tanstack/react-router'
+import { useDualSidebarStore } from '@/ui/stores/dual-sidebar'
 import { Button } from './ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip'
 import { UserMenu } from './user-menu'
 
-interface DualSidebarItemProps {
+export interface DualSidebarItemProps {
+  id?: string
   icon: React.ReactNode
   label: string
   badge?: React.ReactNode
@@ -20,11 +23,20 @@ export const DualSidebarItem: React.FC<DualSidebarItemProps> = () => {
 
 interface DualSidebarProps {
   children: React.ReactNode
+  hideMobileButton?: boolean
 }
 
-export const DualSidebar: React.FC<DualSidebarProps> = ({ children }) => {
-  const [activeItem, setActiveItem] = useState<number | null>(null)
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+export const DualSidebar: React.FC<DualSidebarProps> = ({ children, hideMobileButton = false }) => {
+  const {
+    isMobileMenuOpen,
+    activeItem,
+    activeItemId,
+    setActiveItem,
+    toggleMobileMenu,
+    closeMobileMenu,
+  } = useDualSidebarStore()
+
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
 
   const sidebarItems = useMemo(
     () =>
@@ -34,6 +46,21 @@ export const DualSidebar: React.FC<DualSidebarProps> = ({ children }) => {
       ),
     [children],
   )
+
+  // Automatically resolve activeItemId to activeItem index if specified
+  useEffect(() => {
+    if (activeItemId) {
+      const foundIndex = sidebarItems.findIndex((item) => item.props.id === activeItemId)
+      if (foundIndex !== -1) {
+        setActiveItem(foundIndex)
+      }
+    }
+  }, [activeItemId, sidebarItems, setActiveItem])
+
+  // Automatically close mobile menu when navigating to another route
+  useEffect(() => {
+    closeMobileMenu()
+  }, [pathname, closeMobileMenu])
 
   const activeItemContent = activeItem !== null ? sidebarItems[activeItem]?.props : null
 
@@ -46,39 +73,31 @@ export const DualSidebar: React.FC<DualSidebarProps> = ({ children }) => {
       return
     }
 
-    setActiveItem((prev) => {
-      if (prev === index) {
-        return null
-      }
+    if (activeItem === index) {
+      setActiveItem(null)
+    } else {
       if (item && item.props.onItemClick) {
         item.props.onItemClick()
       }
-      return index
-    })
-  }
-
-  const toggleMobileMenu = () => {
-    setIsMobileMenuOpen((prev) => !prev)
-  }
-
-  const closeMobileMenu = () => {
-    setIsMobileMenuOpen(false)
-    setActiveItem(null)
+      setActiveItem(index)
+    }
   }
 
   return (
     <>
-      {/* Mobile Hamburger Button */}
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={toggleMobileMenu}
-        className="md:hidden fixed top-4 left-4 z-50 rounded-md bg-sidebar/50 backdrop-blur-sm text-sidebar-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
-        aria-label="Open navigation menu"
-        aria-expanded={isMobileMenuOpen}
-      >
-        <Menu />
-      </Button>
+      {/* Mobile Hamburger Button (Optional if header provides its own menu button) */}
+      {!hideMobileButton && (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={toggleMobileMenu}
+          className="md:hidden fixed top-4 left-4 z-50 rounded-md bg-sidebar/50 backdrop-blur-sm text-sidebar-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+          aria-label="Open navigation menu"
+          aria-expanded={isMobileMenuOpen}
+        >
+          <Menu />
+        </Button>
+      )}
 
       {/* Mobile Overlay */}
       {isMobileMenuOpen && (

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -12,6 +12,7 @@ import type {
   AssetInfo,
   CollectionInfo,
   CreateUploadTaskRequest,
+  PresignedUrl,
   SearchCondition,
   SearchSort,
   ShareLinkInfo,
@@ -558,9 +559,7 @@ export function FileBrowser({
         queryKey: ['teams', teamId, 'upload', 'tasks'],
       })
 
-      // The RPC client returns an object that we cast to the expected type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await uploadFiles(currentFiles, data.presignedUrls as any, data.taskId!)
+      await uploadFiles(currentFiles, data.presignedUrls, data.taskId!)
       queryClient.invalidateQueries({
         queryKey: ['search', teamId, assetId],
       })
@@ -731,14 +730,11 @@ export function FileBrowser({
 
   const uploadFiles = async (
     files: FileWithId[],
-    presignedUrls: { id?: string; url?: string; fileId?: string }[],
+    presignedUrls: PresignedUrl[] | undefined,
     taskId: string,
   ) => {
     const uploadUrlMap = presignedUrls?.reduce(
-      (
-        acc: Record<string, { url: string; fileId: string }>,
-        item: { id?: string; url?: string; fileId?: string },
-      ) => {
+      (acc: Record<string, { url: string; fileId: string }>, item: PresignedUrl) => {
         if (item.id) {
           acc[item.id] = {
             url: item.url || '',

--- a/packages/webui/components/file-browser/folder-card.tsx
+++ b/packages/webui/components/file-browser/folder-card.tsx
@@ -277,7 +277,7 @@ export function FolderCard({
           : undefined
       }
       className={cn(
-        'group relative w-full max-w-[340px] select-none cursor-pointer isolate flex flex-col items-center h-full outline-none focus:outline-none focus-visible:outline-none',
+        'group relative w-full select-none cursor-pointer isolate flex flex-col items-center h-full outline-none focus:outline-none focus-visible:outline-none',
       )}
     >
       <div className="absolute inset-0 z-10 pointer-events-none">

--- a/packages/webui/components/file-browser/folder-card.tsx
+++ b/packages/webui/components/file-browser/folder-card.tsx
@@ -277,7 +277,7 @@ export function FolderCard({
           : undefined
       }
       className={cn(
-        'group relative w-full select-none cursor-pointer isolate flex flex-col items-center h-full outline-none focus:outline-none focus-visible:outline-none',
+        'group relative w-full md:max-w-[340px] select-none cursor-pointer isolate flex flex-col items-center h-full outline-none focus:outline-none focus-visible:outline-none',
       )}
     >
       <div className="absolute inset-0 z-10 pointer-events-none">

--- a/packages/webui/components/file-browser/mobile-file-browser.test.tsx
+++ b/packages/webui/components/file-browser/mobile-file-browser.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MobileFileBrowser } from './mobile-file-browser'
+import type { AssetInfo } from '@shumai/dtos'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('@dnd-kit/react', () => ({
+  useDraggable: () => ({
+    ref: vi.fn(),
+    isDragging: false,
+  }),
+  useDroppable: () => ({
+    ref: vi.fn(),
+    isOver: false,
+  }),
+}))
+
+vi.mock('@/ui/hooks/use-permissions', () => ({
+  usePermissions: () => ({
+    canEdit: true,
+    canAdmin: true,
+    canView: true,
+  }),
+}))
+
+vi.mock('@/ui/api/client', () => ({
+  client: {
+    api: {
+      files: {
+        $delete: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+        'download-links': {
+          $post: vi.fn().mockResolvedValue({ ok: true, json: async () => ({ files: [] }) }),
+        },
+        restore: {
+          $post: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+        },
+        ':fileId': {
+          $get: vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({}),
+          }),
+          $put: vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({}),
+          }),
+        },
+      },
+      folders: {
+        $post: vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ id: 'new-folder-id' }),
+        }),
+        $delete: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+        restore: {
+          $post: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+        },
+        ':folderId': {
+          $put: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+        },
+      },
+      teams: {
+        ':teamId': {
+          upload: {
+            tasks: {
+              $post: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+              ':taskId': {
+                $patch: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+              },
+            },
+          },
+        },
+      },
+      projects: {
+        ':projectId': {
+          'empty-trash': {
+            $post: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+          },
+        },
+      },
+    },
+  },
+}))
+
+describe('MobileFileBrowser', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  const mockFolder: AssetInfo = {
+    id: 'folder-1',
+    name: 'Test Folder',
+    type: 'folder',
+    fileCount: 3,
+    sizeByte: 0,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    status: 'processed',
+  } as AssetInfo
+
+  const mockFile: AssetInfo = {
+    id: 'file-1',
+    name: 'test_document.pdf',
+    type: 'file',
+    sizeByte: 1024 * 100,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    status: 'processed',
+  } as AssetInfo
+
+  const defaultProps = {
+    teamId: 'team-1',
+    projectId: 'project-1',
+    assetId: 'root-folder',
+    folders: [mockFolder],
+    files: [mockFile],
+    selectedItem: null,
+    selectedIds: new Set<string>(),
+    onItemSelect: vi.fn(),
+    onItemDoubleClick: vi.fn(),
+    onClearSelection: vi.fn(),
+    fetchNextFoldersPage: vi.fn(),
+    hasNextFoldersPage: false,
+    isFetchingNextFoldersPage: false,
+    fetchNextFilesPage: vi.fn(),
+    hasNextFilesPage: false,
+    isFetchingNextFilesPage: false,
+  }
+
+  const renderComponent = (props: Partial<React.ComponentProps<typeof MobileFileBrowser>> = {}) => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <MobileFileBrowser {...defaultProps} {...props} />
+      </QueryClientProvider>,
+    )
+  }
+
+  it('renders folders and files in mobile grid', () => {
+    renderComponent()
+
+    expect(screen.getByText('Test Folder')).toBeDefined()
+    expect(screen.getByText('test_document.pdf')).toBeDefined()
+  })
+
+  it('triggers onItemSelect when an item is clicked', () => {
+    const onItemSelect = vi.fn()
+    renderComponent({ onItemSelect })
+
+    const folderElement = screen.getByText('Test Folder')
+    fireEvent.click(folderElement)
+
+    expect(onItemSelect).toHaveBeenCalled()
+  })
+
+  it('triggers onItemDoubleClick when an item is double-clicked', () => {
+    const onItemDoubleClick = vi.fn()
+    renderComponent({ onItemDoubleClick })
+
+    const folderElement = screen.getByText('Test Folder')
+    fireEvent.doubleClick(folderElement)
+
+    expect(onItemDoubleClick).toHaveBeenCalledWith(mockFolder)
+  })
+
+  it('renders empty state when there are no folders and files', () => {
+    renderComponent({ folders: [], files: [] })
+
+    expect(screen.getByText(/This folder is empty|此文件夹为空/i)).toBeDefined()
+  })
+
+  it('renders Floating Action Button when canEdit is true', () => {
+    renderComponent()
+
+    expect(screen.getByRole('button', { name: /actions/i })).toBeDefined()
+  })
+
+  it('hides Floating Action Button in public share mode', () => {
+    renderComponent({ isPublic: true })
+
+    expect(screen.queryByRole('button', { name: /actions/i })).toBeNull()
+  })
+})

--- a/packages/webui/components/file-browser/mobile-file-browser.test.tsx
+++ b/packages/webui/components/file-browser/mobile-file-browser.test.tsx
@@ -177,6 +177,43 @@ describe('MobileFileBrowser', () => {
     expect(screen.getByText(/This folder is empty|此文件夹为空/i)).toBeDefined()
   })
 
+  it('renders collapsible section headers for folders and files with count and size', () => {
+    renderComponent({
+      totalFoldersSize: 50000,
+      totalFilesSize: 100000,
+    })
+
+    expect(screen.getByText(/1 Folder • 50 KB/i)).toBeDefined()
+    expect(screen.getByText(/1 Asset • 100 KB/i)).toBeDefined()
+  })
+
+  it('collapses and expands folders and files when clicking section headers', () => {
+    renderComponent()
+
+    expect(screen.getByText('Test Folder')).toBeDefined()
+    expect(screen.getByText('test_document.pdf')).toBeDefined()
+
+    // Collapse folders
+    const folderHeaderBtn = screen.getByRole('button', { name: /Folder/i })
+    fireEvent.click(folderHeaderBtn)
+
+    expect(screen.queryByText('Test Folder')).toBeNull()
+
+    // Expand folders back
+    fireEvent.click(folderHeaderBtn)
+    expect(screen.getByText('Test Folder')).toBeDefined()
+
+    // Collapse files
+    const fileHeaderBtn = screen.getByRole('button', { name: /Asset/i })
+    fireEvent.click(fileHeaderBtn)
+
+    expect(screen.queryByText('test_document.pdf')).toBeNull()
+
+    // Expand files back
+    fireEvent.click(fileHeaderBtn)
+    expect(screen.getByText('test_document.pdf')).toBeDefined()
+  })
+
   it('renders Floating Action Button when canEdit is true', () => {
     renderComponent()
 

--- a/packages/webui/components/file-browser/mobile-file-browser.test.tsx
+++ b/packages/webui/components/file-browser/mobile-file-browser.test.tsx
@@ -220,6 +220,202 @@ describe('MobileFileBrowser', () => {
     expect(screen.getByRole('button', { name: /actions/i })).toBeDefined()
   })
 
+  it('completes upload and confirms upload on 2xx response', async () => {
+    const originalXhr = window.XMLHttpRequest
+    const patchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+
+    const { client } = await import('@/ui/api/client')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(client.api.teams[':teamId'].upload.tasks as any)['$post'] = vi
+      .fn()
+      .mockImplementation(async (req) => {
+        const json = req.json
+        return {
+          ok: true,
+          json: async () => ({
+            taskId: 'task-1',
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            presignedUrls: json.files.map((f: any) => ({
+              id: f.id,
+              url: 'https://upload.example.com',
+              fileId: 'server-file-1',
+            })),
+          }),
+        }
+      })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(client.api.teams[':teamId'].upload.tasks[':taskId'] as any)['$patch'] = patchMock
+
+    class MockXhr {
+      open = vi.fn()
+      setRequestHeader = vi.fn()
+      send = vi.fn(() => {
+        this.status = 200
+        this.onload?.()
+      })
+      status = 200
+      upload = { onprogress: null as unknown }
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      onabort: (() => void) | null = null
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    window.XMLHttpRequest = MockXhr as any
+
+    const { container } = renderComponent()
+    const fileInput = container.querySelector(
+      'input[type="file"]:not([webkitdirectory])',
+    ) as HTMLInputElement
+    expect(fileInput).toBeDefined()
+
+    const testFile = new File(['content'], 'hello.txt', { type: 'text/plain' })
+    fireEvent.change(fileInput, { target: { files: [testFile] } })
+
+    // Wait for mutation to finish
+    await vi.waitFor(() => {
+      expect(patchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          param: { teamId: 'team-1', taskId: 'task-1' },
+          json: { fileId: 'server-file-1' },
+        }),
+      )
+    })
+
+    window.XMLHttpRequest = originalXhr
+  })
+
+  it('fails upload and confirms with error on non-2xx status', async () => {
+    const originalXhr = window.XMLHttpRequest
+    const patchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+
+    const { client } = await import('@/ui/api/client')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(client.api.teams[':teamId'].upload.tasks as any)['$post'] = vi
+      .fn()
+      .mockImplementation(async (req) => {
+        const json = req.json
+        return {
+          ok: true,
+          json: async () => ({
+            taskId: 'task-2',
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            presignedUrls: json.files.map((f: any) => ({
+              id: f.id,
+              url: 'https://upload.example.com',
+              fileId: 'server-file-2',
+            })),
+          }),
+        }
+      })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(client.api.teams[':teamId'].upload.tasks[':taskId'] as any)['$patch'] = patchMock
+
+    class MockXhr500 {
+      open = vi.fn()
+      setRequestHeader = vi.fn()
+      send = vi.fn(() => {
+        this.status = 500
+        this.onload?.()
+      })
+      status = 500
+      upload = { onprogress: null as unknown }
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      onabort: (() => void) | null = null
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    window.XMLHttpRequest = MockXhr500 as any
+
+    const { container } = renderComponent()
+    const fileInput = container.querySelector(
+      'input[type="file"]:not([webkitdirectory])',
+    ) as HTMLInputElement
+
+    const testFile = new File(['content'], 'error.txt', { type: 'text/plain' })
+    fireEvent.change(fileInput, { target: { files: [testFile] } })
+
+    await vi.waitFor(() => {
+      expect(patchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          param: { teamId: 'team-1', taskId: 'task-2' },
+          json: {
+            fileId: 'server-file-2',
+            errorMessage: 'upload failed with status: 500',
+          },
+        }),
+      )
+    })
+
+    window.XMLHttpRequest = originalXhr
+  })
+
+  it('fails upload and confirms with error on network failure', async () => {
+    const originalXhr = window.XMLHttpRequest
+    const patchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+
+    const { client } = await import('@/ui/api/client')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(client.api.teams[':teamId'].upload.tasks as any)['$post'] = vi
+      .fn()
+      .mockImplementation(async (req) => {
+        const json = req.json
+        return {
+          ok: true,
+          json: async () => ({
+            taskId: 'task-3',
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            presignedUrls: json.files.map((f: any) => ({
+              id: f.id,
+              url: 'https://upload.example.com',
+              fileId: 'server-file-3',
+            })),
+          }),
+        }
+      })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(client.api.teams[':teamId'].upload.tasks[':taskId'] as any)['$patch'] = patchMock
+
+    class MockXhrError {
+      open = vi.fn()
+      setRequestHeader = vi.fn()
+      send = vi.fn(() => {
+        this.onerror?.()
+      })
+      status = 0
+      upload = { onprogress: null as unknown }
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      onabort: (() => void) | null = null
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    window.XMLHttpRequest = MockXhrError as any
+
+    const { container } = renderComponent()
+    const fileInput = container.querySelector(
+      'input[type="file"]:not([webkitdirectory])',
+    ) as HTMLInputElement
+
+    const testFile = new File(['content'], 'network-error.txt', { type: 'text/plain' })
+    fireEvent.change(fileInput, { target: { files: [testFile] } })
+
+    await vi.waitFor(() => {
+      expect(patchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          param: { teamId: 'team-1', taskId: 'task-3' },
+          json: {
+            fileId: 'server-file-3',
+            errorMessage: 'upload failed with error: Network error',
+          },
+        }),
+      )
+    })
+
+    window.XMLHttpRequest = originalXhr
+  })
+
   it('hides Floating Action Button in public share mode', () => {
     renderComponent({ isPublic: true })
 

--- a/packages/webui/components/file-browser/mobile-file-browser.tsx
+++ b/packages/webui/components/file-browser/mobile-file-browser.tsx
@@ -7,8 +7,11 @@ import { useUploadStore } from '@/ui/stores/upload'
 import type { AssetInfo, CreateUploadTaskRequest } from '@shumai/dtos'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import type { InferRequestType, InferResponseType } from 'hono/client'
+import { formatSize } from '@/ui/lib/format'
 import {
   AlertTriangle,
+  ChevronDown,
+  ChevronRight,
   Download,
   FolderClock,
   FolderPlus,
@@ -94,6 +97,10 @@ export function MobileFileBrowser({
   assetId,
   folders,
   files,
+  totalFolders,
+  totalFiles,
+  totalFoldersSize,
+  totalFilesSize,
   selectedItem,
   selectedIds,
   onItemSelect,
@@ -118,9 +125,29 @@ export function MobileFileBrowser({
   const fileInputRef = useRef<HTMLInputElement>(null)
   const folderInputRef = useRef<HTMLInputElement>(null)
 
+  const [foldersExpanded, setFoldersExpanded] = useState(true)
+  const [filesExpanded, setFilesExpanded] = useState(true)
   const [isNewFolderDialogOpen, setIsNewFolderDialogOpen] = useState(false)
   const [newFolderName, setNewFolderName] = useState('')
   const [isEmptyTrashDialogOpen, setIsEmptyTrashDialogOpen] = useState(false)
+
+  const foldersCount = totalFolders ?? folders.length
+  const filesCount = totalFiles ?? files.length
+  const foldersSizeVal =
+    totalFoldersSize ??
+    (folders.length > 0 ? folders.reduce((acc, f) => acc + (f.sizeByte || 0), 0) : -1)
+  const filesSizeVal =
+    totalFilesSize ?? (files.length > 0 ? files.reduce((acc, f) => acc + (f.sizeByte || 0), 0) : -1)
+  const showFoldersSize = foldersSizeVal > -1
+  const showFilesSize = filesSizeVal > -1
+
+  const formatCount = (count: number, isFile: boolean) => {
+    if (isFile) {
+      return count === 1 ? m.n_assets_singular({ count }) : m.n_assets_plural({ count })
+    } else {
+      return count === 1 ? m.n_folders_singular({ count }) : m.n_folders_plural({ count })
+    }
+  }
 
   const {
     editingItemId,
@@ -488,64 +515,109 @@ export function MobileFileBrowser({
 
       {/* Main scroll area */}
       <div className="flex-1 overflow-y-auto min-h-0 p-3 pb-24">
-        {/* 1-Column Grid */}
-        <div className="grid grid-cols-1 gap-4 max-w-lg mx-auto w-full">
-          {/* Folders */}
-          {folders.map((folder) => (
-            <FolderCard
-              key={folder.id}
-              item={folder}
-              isSelected={selectedItem?.id === folder.id}
-              isChecked={selectedIds.has(folder.id!)}
-              isEditing={editingItemId === folder.id}
-              onSelect={onItemSelect}
-              onDoubleClick={onItemDoubleClick}
-              onContextMenu={() => {}}
-              onDragStart={() => {}}
-              onDrop={() => {}}
-              onRename={(newName) => onRenameSubmit(folder, newName)}
-              onFinishEditing={() => setEditingItemId(null)}
-              onAction={(action, item) =>
-                handleAction(action as 'rename' | 'delete' | 'download' | 'restore', item)
-              }
-              isRecentlyDeleted={isRecentlyDeleted}
-              isRecents={isRecents}
-              selectedCount={selectedIds.size}
-              canEdit={canEdit}
-              isShareView={isShareView}
-              allowDownload={allowDownload}
-            />
-          ))}
+        <div className="max-w-lg mx-auto w-full">
+          {/* Folders Section */}
+          {foldersCount > 0 && (
+            <div className="mb-4">
+              <button
+                onClick={() => setFoldersExpanded(!foldersExpanded)}
+                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-3 font-medium select-none cursor-pointer"
+              >
+                {foldersExpanded ? (
+                  <ChevronDown className="h-4 w-4" />
+                ) : (
+                  <ChevronRight className="h-4 w-4" />
+                )}
+                <span>
+                  {formatCount(foldersCount, false)}
+                  {showFoldersSize ? ` • ${formatSize(foldersSizeVal)}` : ''}
+                </span>
+              </button>
 
-          {/* Files */}
-          {files.map((file) => (
-            <FileCard
-              key={file.id}
-              teamId={teamId}
-              item={file}
-              isSelected={selectedItem?.id === file.id}
-              isChecked={selectedIds.has(file.id!)}
-              isEditing={editingItemId === file.id}
-              onSelect={onItemSelect}
-              onDoubleClick={onItemDoubleClick}
-              onContextMenu={() => {}}
-              onDragStart={() => {}}
-              onDrop={() => {}}
-              onRename={(newName) => onRenameSubmit(file, newName)}
-              onFinishEditing={() => setEditingItemId(null)}
-              onSaveField={(fieldId, value) => onSaveField?.(file.id!, fieldId, value)}
-              fields={[]}
-              onAction={(action, item) =>
-                handleAction(action as 'rename' | 'delete' | 'download' | 'restore', item)
-              }
-              isRecentlyDeleted={isRecentlyDeleted}
-              isRecents={isRecents}
-              selectedCount={selectedIds.size}
-              canEdit={canEdit}
-              isShareView={isShareView}
-              allowDownload={allowDownload}
-            />
-          ))}
+              {foldersExpanded && (
+                <div className="grid grid-cols-1 gap-4 w-full">
+                  {folders.map((folder) => (
+                    <FolderCard
+                      key={folder.id}
+                      item={folder}
+                      isSelected={selectedItem?.id === folder.id}
+                      isChecked={selectedIds.has(folder.id!)}
+                      isEditing={editingItemId === folder.id}
+                      onSelect={onItemSelect}
+                      onDoubleClick={onItemDoubleClick}
+                      onContextMenu={() => {}}
+                      onDragStart={() => {}}
+                      onDrop={() => {}}
+                      onRename={(newName) => onRenameSubmit(folder, newName)}
+                      onFinishEditing={() => setEditingItemId(null)}
+                      onAction={(action, item) =>
+                        handleAction(action as 'rename' | 'delete' | 'download' | 'restore', item)
+                      }
+                      isRecentlyDeleted={isRecentlyDeleted}
+                      isRecents={isRecents}
+                      selectedCount={selectedIds.size}
+                      canEdit={canEdit}
+                      isShareView={isShareView}
+                      allowDownload={allowDownload}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Files Section */}
+          {filesCount > 0 && (
+            <div className="mb-4">
+              <button
+                onClick={() => setFilesExpanded(!filesExpanded)}
+                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-3 font-medium select-none cursor-pointer"
+              >
+                {filesExpanded ? (
+                  <ChevronDown className="h-4 w-4" />
+                ) : (
+                  <ChevronRight className="h-4 w-4" />
+                )}
+                <span>
+                  {formatCount(filesCount, true)}
+                  {showFilesSize ? ` • ${formatSize(filesSizeVal)}` : ''}
+                </span>
+              </button>
+
+              {filesExpanded && (
+                <div className="grid grid-cols-1 gap-4 w-full">
+                  {files.map((file) => (
+                    <FileCard
+                      key={file.id}
+                      teamId={teamId}
+                      item={file}
+                      isSelected={selectedItem?.id === file.id}
+                      isChecked={selectedIds.has(file.id!)}
+                      isEditing={editingItemId === file.id}
+                      onSelect={onItemSelect}
+                      onDoubleClick={onItemDoubleClick}
+                      onContextMenu={() => {}}
+                      onDragStart={() => {}}
+                      onDrop={() => {}}
+                      onRename={(newName) => onRenameSubmit(file, newName)}
+                      onFinishEditing={() => setEditingItemId(null)}
+                      onSaveField={(fieldId, value) => onSaveField?.(file.id!, fieldId, value)}
+                      fields={[]}
+                      onAction={(action, item) =>
+                        handleAction(action as 'rename' | 'delete' | 'download' | 'restore', item)
+                      }
+                      isRecentlyDeleted={isRecentlyDeleted}
+                      isRecents={isRecents}
+                      selectedCount={selectedIds.size}
+                      canEdit={canEdit}
+                      isShareView={isShareView}
+                      allowDownload={allowDownload}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Empty state */}

--- a/packages/webui/components/file-browser/mobile-file-browser.tsx
+++ b/packages/webui/components/file-browser/mobile-file-browser.tsx
@@ -4,7 +4,7 @@ import { client } from '@/ui/api/client'
 import { usePermissions } from '@/ui/hooks/use-permissions'
 import { m } from '@/ui/paraglide/messages.js'
 import { useUploadStore } from '@/ui/stores/upload'
-import type { AssetInfo, CreateUploadTaskRequest } from '@shumai/dtos'
+import type { AssetInfo, CreateUploadTaskRequest, PresignedUrl } from '@shumai/dtos'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import type { InferRequestType, InferResponseType } from 'hono/client'
 import { formatSize } from '@/ui/lib/format'
@@ -216,14 +216,11 @@ export function MobileFileBrowser({
 
   const uploadFiles = async (
     filesList: FileWithId[],
-    presignedUrls: { id?: string; url?: string; fileId?: string }[],
+    presignedUrls: PresignedUrl[] | undefined,
     taskId: string,
   ) => {
     const uploadUrlMap = presignedUrls?.reduce(
-      (
-        acc: Record<string, { url: string; fileId: string }>,
-        item: { id?: string; url?: string; fileId?: string },
-      ) => {
+      (acc: Record<string, { url: string; fileId: string }>, item: PresignedUrl) => {
         if (item.id) {
           acc[item.id] = {
             url: item.url || '',
@@ -341,9 +338,7 @@ export function MobileFileBrowser({
       const currentFiles = context?.files || []
       const filesProgressInfo = currentFiles
         .map((f) => {
-          const urlInfo = (
-            data.presignedUrls as { id?: string; url?: string; fileId?: string }[] | undefined
-          )?.find((p) => p.id === f.id)
+          const urlInfo = data.presignedUrls?.find((p) => p.id === f.id)
           return {
             fileId: urlInfo?.fileId || f.id,
             name: f.file.name,
@@ -363,8 +358,7 @@ export function MobileFileBrowser({
       queryClient.invalidateQueries({ queryKey: ['search', teamId, assetId] })
       queryClient.invalidateQueries({ queryKey: ['teams', teamId, 'upload', 'tasks'] })
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await uploadFiles(currentFiles, data.presignedUrls as any, data.taskId!)
+      await uploadFiles(currentFiles, data.presignedUrls, data.taskId!)
       queryClient.invalidateQueries({ queryKey: ['search', teamId, assetId] })
       queryClient.invalidateQueries({ queryKey: ['teams', teamId, 'upload', 'tasks'] })
     },

--- a/packages/webui/components/file-browser/mobile-file-browser.tsx
+++ b/packages/webui/components/file-browser/mobile-file-browser.tsx
@@ -1,0 +1,747 @@
+'use client'
+
+import { client } from '@/ui/api/client'
+import { usePermissions } from '@/ui/hooks/use-permissions'
+import { m } from '@/ui/paraglide/messages.js'
+import { useUploadStore } from '@/ui/stores/upload'
+import type { AssetInfo, CreateUploadTaskRequest } from '@shumai/dtos'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { InferRequestType, InferResponseType } from 'hono/client'
+import {
+  AlertTriangle,
+  Download,
+  FolderClock,
+  FolderPlus,
+  Loader2,
+  Plus,
+  Upload,
+} from 'lucide-react'
+import React, { useRef, useState } from 'react'
+import { useInView } from 'react-intersection-observer'
+import { toast } from 'sonner'
+import { ulid } from 'ulid'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../ui/alert-dialog'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu'
+import { Input } from '../ui/input'
+import { FileCard } from './file-card'
+import { FolderCard } from './folder-card'
+import { useFileActions } from './use-file-actions'
+
+export interface MobileFileBrowserProps {
+  teamId: string
+  projectId: string
+  assetId: string
+  folders: AssetInfo[]
+  files: AssetInfo[]
+  totalFolders?: number
+  totalFiles?: number
+  totalFoldersSize?: number
+  totalFilesSize?: number
+  selectedItem: AssetInfo | null
+  selectedIds: Set<string>
+  onItemSelect: (item: AssetInfo, event: React.MouseEvent) => void
+  onItemDoubleClick: (item: AssetInfo) => void
+  onSaveField?: (fileId: string, fieldId: string, value: unknown) => void
+  onClearSelection: () => void
+  fetchNextFoldersPage: () => void
+  hasNextFoldersPage: boolean
+  isFetchingNextFoldersPage: boolean
+  fetchNextFilesPage: () => void
+  hasNextFilesPage: boolean
+  isFetchingNextFilesPage: boolean
+  isRecentlyDeleted?: boolean
+  isRecents?: boolean
+  isShareView?: boolean
+  isPublic?: boolean
+  shareId?: string
+  allowDownload?: boolean
+  rootFolderId?: string
+}
+
+type FileWithId = {
+  file: File
+  id: string
+}
+
+let pendingFilesToUpload: FileWithId[] = []
+
+export function MobileFileBrowser({
+  teamId,
+  projectId,
+  assetId,
+  folders,
+  files,
+  selectedItem,
+  selectedIds,
+  onItemSelect,
+  onItemDoubleClick,
+  onSaveField,
+  onClearSelection,
+  fetchNextFoldersPage,
+  hasNextFoldersPage,
+  isFetchingNextFoldersPage,
+  fetchNextFilesPage,
+  hasNextFilesPage,
+  isFetchingNextFilesPage,
+  isRecentlyDeleted = false,
+  isRecents = false,
+  isShareView = false,
+  isPublic = false,
+  shareId,
+  allowDownload = true,
+}: MobileFileBrowserProps) {
+  const queryClient = useQueryClient()
+  const { canEdit, canAdmin } = usePermissions(projectId)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const folderInputRef = useRef<HTMLInputElement>(null)
+
+  const [isNewFolderDialogOpen, setIsNewFolderDialogOpen] = useState(false)
+  const [newFolderName, setNewFolderName] = useState('')
+  const [isEmptyTrashDialogOpen, setIsEmptyTrashDialogOpen] = useState(false)
+
+  const {
+    editingItemId,
+    setEditingItemId,
+    handleAction,
+    onRenameSubmit,
+    isDeleteDialogOpen,
+    setIsDeleteDialogOpen,
+    confirmDelete,
+    isDownloadDialogOpen,
+    setIsDownloadDialogOpen,
+    isLoadingLinks,
+    resolvedFiles,
+    startDownload,
+  } = useFileActions({
+    teamId,
+    projectId,
+    assetId,
+    folders,
+    files,
+    selectedIds,
+    isPublic,
+    shareId,
+  })
+
+  // Infinite scroll trigger
+  const { ref: loadMoreRef, inView } = useInView()
+  React.useEffect(() => {
+    if (inView) {
+      if (hasNextFoldersPage && !isFetchingNextFoldersPage) {
+        fetchNextFoldersPage()
+      } else if (hasNextFilesPage && !isFetchingNextFilesPage) {
+        fetchNextFilesPage()
+      }
+    }
+  }, [
+    inView,
+    hasNextFoldersPage,
+    isFetchingNextFoldersPage,
+    hasNextFilesPage,
+    isFetchingNextFilesPage,
+    fetchNextFoldersPage,
+    fetchNextFilesPage,
+  ])
+
+  // Upload actions
+  const incrementUploading = useUploadStore((state) => state.increment)
+  const decrementUploading = useUploadStore((state) => state.decrement)
+  const startTask = useUploadStore((state) => state.startTask)
+  const updateFileProgress = useUploadStore((state) => state.updateFileProgress)
+  const failFile = useUploadStore((state) => state.failFile)
+
+  const $confirmUpload = client.api.teams[':teamId'].upload.tasks[':taskId'].$patch
+  const { mutateAsync: confirmUpload } = useMutation<
+    InferResponseType<typeof $confirmUpload>,
+    Error,
+    InferRequestType<typeof $confirmUpload>
+  >({
+    mutationFn: async (request) => {
+      const res = await $confirmUpload(request)
+      if (!res.ok) throw new Error('Failed to confirm upload')
+      return (await res.json()) as InferResponseType<typeof $confirmUpload>
+    },
+  })
+
+  const uploadFiles = async (
+    filesList: FileWithId[],
+    presignedUrls: { id?: string; url?: string; fileId?: string }[],
+    taskId: string,
+  ) => {
+    const uploadUrlMap = presignedUrls?.reduce(
+      (
+        acc: Record<string, { url: string; fileId: string }>,
+        item: { id?: string; url?: string; fileId?: string },
+      ) => {
+        if (item.id) {
+          acc[item.id] = {
+            url: item.url || '',
+            fileId: item.fileId || '',
+          }
+        }
+        return acc
+      },
+      {},
+    )
+    if (!uploadUrlMap) return
+
+    const concurrencyLimit = 5
+    const queue = [...filesList]
+
+    const uploadNext = async () => {
+      while (queue.length > 0) {
+        const item = queue.shift()
+        if (item) {
+          const uploadInfo = uploadUrlMap[item.id]
+          if (uploadInfo && uploadInfo.url) {
+            incrementUploading()
+            try {
+              const xhr = new XMLHttpRequest()
+              const uploadPromise = new Promise<{ ok: boolean; status: number }>(
+                (resolve, reject) => {
+                  xhr.open('PUT', uploadInfo.url)
+                  xhr.setRequestHeader('Content-Type', item.file.type)
+
+                  xhr.upload.onprogress = (event) => {
+                    if (event.lengthComputable) {
+                      updateFileProgress(taskId, uploadInfo.fileId, event.loaded)
+                    }
+                  }
+
+                  xhr.onload = () => {
+                    if (xhr.status >= 200 && xhr.status < 300) {
+                      resolve({ ok: true, status: xhr.status })
+                    } else {
+                      resolve({ ok: false, status: xhr.status })
+                    }
+                  }
+
+                  xhr.onerror = () => reject(new Error('Network error'))
+                  xhr.onabort = () => reject(new Error('Upload aborted'))
+                  xhr.send(item.file)
+                },
+              )
+
+              const resp = await uploadPromise
+              if (!resp.ok) {
+                failFile(taskId, uploadInfo.fileId)
+                toast.error(`Failed to upload file: ${item.file.name}`)
+              }
+            } catch (error) {
+              failFile(taskId, uploadInfo.fileId)
+              toast.error(`Failed to upload file: ${item.file.name}`)
+              await confirmUpload({
+                param: { teamId: teamId!, taskId: taskId },
+                json: {
+                  fileId: uploadInfo.fileId,
+                  errorMessage: `upload failed with error: ${error instanceof Error ? error.message : String(error)}`,
+                },
+              })
+            } finally {
+              decrementUploading()
+              queryClient.invalidateQueries({
+                queryKey: ['search', teamId, assetId],
+              })
+            }
+          }
+        }
+      }
+    }
+
+    const activeUploaders = Array(concurrencyLimit)
+      .fill(null)
+      .map(() => uploadNext())
+    await Promise.all(activeUploaders)
+  }
+
+  const $createUploadTask = client.api.teams[':teamId'].upload.tasks.$post
+  const { mutate: createUploadTaskMutation } = useMutation<
+    InferResponseType<typeof $createUploadTask>,
+    Error,
+    InferRequestType<typeof $createUploadTask>,
+    { files: FileWithId[] }
+  >({
+    mutationFn: async (request) => {
+      const res = await $createUploadTask(request)
+      if (!res.ok) throw new Error('Failed to create upload task')
+      return (await res.json()) as InferResponseType<typeof $createUploadTask>
+    },
+    onMutate: () => {
+      return { files: [...pendingFilesToUpload] }
+    },
+    onSuccess: async (data, _variables, context) => {
+      const currentFiles = context?.files || []
+      const filesProgressInfo = currentFiles
+        .map((f) => {
+          const urlInfo = (
+            data.presignedUrls as { id?: string; url?: string; fileId?: string }[] | undefined
+          )?.find((p) => p.id === f.id)
+          return {
+            fileId: urlInfo?.fileId || f.id,
+            name: f.file.name,
+            size: f.file.size,
+          }
+        })
+        .filter((info) => !!info.fileId)
+
+      const visibleFiles = currentFiles.filter((f) => !f.file.name.startsWith('.'))
+      const taskName =
+        visibleFiles.length === 1 ? visibleFiles[0].file.name : `${visibleFiles.length} Items`
+
+      if (data.taskId) {
+        startTask(data.taskId, taskName, filesProgressInfo)
+      }
+
+      queryClient.invalidateQueries({ queryKey: ['search', teamId, assetId] })
+      queryClient.invalidateQueries({ queryKey: ['teams', teamId, 'upload', 'tasks'] })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await uploadFiles(currentFiles, data.presignedUrls as any, data.taskId!)
+      queryClient.invalidateQueries({ queryKey: ['search', teamId, assetId] })
+      queryClient.invalidateQueries({ queryKey: ['teams', teamId, 'upload', 'tasks'] })
+    },
+  })
+
+  const processAndUploadFiles = (selectedFiles: FileList | File[]) => {
+    if (!selectedFiles || selectedFiles.length === 0) return
+
+    const fileWithIds: FileWithId[] = []
+    const root: CreateUploadTaskRequest['files'] = []
+    const directories = new Map<string, CreateUploadTaskRequest['files']>()
+
+    for (const file of selectedFiles) {
+      const path = (file.webkitRelativePath || file.name).split('/')
+      if (path.some((part) => part.startsWith('.'))) {
+        continue
+      }
+      const fileName = path.pop()!
+      let currentLevel = root
+      let currentPath = ''
+      for (const dir of path) {
+        currentPath = `${currentPath}/${dir}`
+        if (!directories.has(currentPath)) {
+          const newDir: CreateUploadTaskRequest['files'] = []
+          const parentDir = {
+            name: dir,
+            type: 'folder' as const,
+            id: ulid(),
+            children: newDir,
+            size: 0,
+          }
+          currentLevel.push(parentDir)
+          directories.set(currentPath, newDir)
+          currentLevel = newDir
+        } else {
+          currentLevel = directories.get(currentPath)!
+        }
+      }
+      const fileWithId = { file, id: ulid() }
+      fileWithIds.push(fileWithId)
+      let mediaType = file.type
+      if (fileName.toLowerCase().endsWith('.wma') && mediaType?.startsWith('video/')) {
+        mediaType = mediaType.replace(/^video\//, 'audio/')
+      }
+      currentLevel.push({
+        name: fileName,
+        size: file.size,
+        type: 'file',
+        id: fileWithId.id,
+        children: [],
+        mediaType,
+      })
+    }
+    pendingFilesToUpload = fileWithIds
+    createUploadTaskMutation({
+      param: { teamId: teamId },
+      json: {
+        parentId: assetId,
+        files: root,
+      },
+    })
+  }
+
+  const $createFolder = client.api.folders.$post
+  const { mutate: createFolderMutation, isPending: isCreatingFolder } = useMutation({
+    mutationFn: async (name: string) => {
+      const res = await $createFolder({
+        json: { name, parentId: assetId },
+      })
+      if (!res.ok) throw new Error('Failed to create folder')
+      return await res.json()
+    },
+    onSuccess: () => {
+      toast.success(m.new_folder())
+      setIsNewFolderDialogOpen(false)
+      setNewFolderName('')
+      queryClient.invalidateQueries({ queryKey: ['search', teamId, assetId] })
+      queryClient.invalidateQueries({ queryKey: ['folders'] })
+    },
+    onError: (err) => {
+      toast.error(`Error: ${err.message}`)
+    },
+  })
+
+  const { mutate: emptyTrash, isPending: isEmptyingTrash } = useMutation({
+    mutationFn: async () => {
+      const res = await client.api.projects[':projectId']['empty-trash'].$post({
+        param: { projectId },
+      })
+      if (!res.ok) throw new Error('Failed to empty trash')
+      return await res.json()
+    },
+    onSuccess: () => {
+      toast.success(m.trash_emptied_successfully())
+      queryClient.invalidateQueries({
+        queryKey: ['projects', projectId, 'recently-deleted'],
+      })
+      onClearSelection()
+      setIsEmptyTrashDialogOpen(false)
+    },
+    onError: (err) => {
+      toast.error(`Error: ${err.message}`)
+    },
+  })
+
+  const handleCreateFolderSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!newFolderName.trim()) return
+    createFolderMutation(newFolderName.trim())
+  }
+
+  const isFolderEmpty =
+    folders.length === 0 &&
+    files.length === 0 &&
+    !isFetchingNextFoldersPage &&
+    !isFetchingNextFilesPage
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0 bg-background overflow-hidden relative">
+      {/* Hidden file inputs for upload actions */}
+      {canEdit && (
+        <>
+          <input
+            type="file"
+            ref={fileInputRef}
+            multiple
+            className="hidden"
+            onChange={(e) => {
+              if (e.target.files) processAndUploadFiles(e.target.files)
+            }}
+          />
+          <input
+            type="file"
+            ref={folderInputRef}
+            multiple
+            /* @ts-expect-error - webkitdirectory is not in standard input type */
+            webkitdirectory="true"
+            className="hidden"
+            onChange={(e) => {
+              if (e.target.files) processAndUploadFiles(e.target.files)
+            }}
+          />
+        </>
+      )}
+
+      {/* Recently Deleted banner */}
+      {isRecentlyDeleted && (
+        <div className="flex items-center justify-between px-4 py-2.5 bg-muted/20 border-b border-border text-sm shrink-0">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <AlertTriangle className="h-4 w-4 text-amber-500 shrink-0" />
+            <span className="text-xs">{m.recently_deleted_notice()}</span>
+          </div>
+          {canAdmin && (
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={isEmptyingTrash || (folders.length === 0 && files.length === 0)}
+              onClick={() => setIsEmptyTrashDialogOpen(true)}
+              className="h-7 px-2.5 text-xs font-medium bg-destructive/10 text-destructive border border-destructive/20 hover:bg-destructive hover:text-destructive-foreground"
+            >
+              Delete
+            </Button>
+          )}
+        </div>
+      )}
+
+      {/* Main scroll area */}
+      <div className="flex-1 overflow-y-auto min-h-0 p-3 pb-24">
+        {/* 2-Column Grid */}
+        <div className="grid grid-cols-2 gap-3">
+          {/* Folders */}
+          {folders.map((folder) => (
+            <FolderCard
+              key={folder.id}
+              item={folder}
+              isSelected={selectedItem?.id === folder.id}
+              isChecked={selectedIds.has(folder.id!)}
+              isEditing={editingItemId === folder.id}
+              onSelect={onItemSelect}
+              onDoubleClick={onItemDoubleClick}
+              onContextMenu={() => {}}
+              onDragStart={() => {}}
+              onDrop={() => {}}
+              onRename={(newName) => onRenameSubmit(folder, newName)}
+              onFinishEditing={() => setEditingItemId(null)}
+              onAction={(action, item) =>
+                handleAction(action as 'rename' | 'delete' | 'download' | 'restore', item)
+              }
+              isRecentlyDeleted={isRecentlyDeleted}
+              isRecents={isRecents}
+              selectedCount={selectedIds.size}
+              canEdit={canEdit}
+              isShareView={isShareView}
+              allowDownload={allowDownload}
+            />
+          ))}
+
+          {/* Files */}
+          {files.map((file) => (
+            <FileCard
+              key={file.id}
+              teamId={teamId}
+              item={file}
+              isSelected={selectedItem?.id === file.id}
+              isChecked={selectedIds.has(file.id!)}
+              isEditing={editingItemId === file.id}
+              onSelect={onItemSelect}
+              onDoubleClick={onItemDoubleClick}
+              onContextMenu={() => {}}
+              onDragStart={() => {}}
+              onDrop={() => {}}
+              onRename={(newName) => onRenameSubmit(file, newName)}
+              onFinishEditing={() => setEditingItemId(null)}
+              onSaveField={(fieldId, value) => onSaveField?.(file.id!, fieldId, value)}
+              fields={[]}
+              onAction={(action, item) =>
+                handleAction(action as 'rename' | 'delete' | 'download' | 'restore', item)
+              }
+              isRecentlyDeleted={isRecentlyDeleted}
+              isRecents={isRecents}
+              selectedCount={selectedIds.size}
+              canEdit={canEdit}
+              isShareView={isShareView}
+              allowDownload={allowDownload}
+            />
+          ))}
+        </div>
+
+        {/* Empty state */}
+        {isFolderEmpty && (
+          <div className="flex flex-col items-center justify-center h-64 text-sm text-muted-foreground p-6 text-center">
+            {isRecents ? (
+              <div className="flex flex-col items-center gap-2">
+                <FolderClock className="h-10 w-10 text-muted-foreground/40 mb-1" />
+                <p className="font-medium text-foreground">{m.no_recent_files()}</p>
+                <p className="text-xs text-muted-foreground">{m.no_recent_files_description()}</p>
+              </div>
+            ) : (
+              <span>{m.this_folder_is_empty()}</span>
+            )}
+          </div>
+        )}
+
+        {/* Infinite scroll loader / trigger */}
+        <div ref={loadMoreRef} className="py-4 flex justify-center items-center min-h-6">
+          {(isFetchingNextFoldersPage || isFetchingNextFilesPage) && (
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          )}
+        </div>
+      </div>
+
+      {/* Floating Action Button (+) for users with edit permissions */}
+      {canEdit && !isRecentlyDeleted && !isRecents && !isShareView && !isPublic && (
+        <div className="fixed bottom-6 right-6 z-30">
+          <DropdownMenu modal={false}>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size="icon"
+                className="h-14 w-14 rounded-full bg-primary text-primary-foreground shadow-lg shadow-primary/25 hover:bg-primary/90 flex items-center justify-center transition-all active:scale-95"
+                aria-label="Actions"
+              >
+                <Plus className="h-6 w-6" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" side="top" className="w-48 mb-2">
+              <DropdownMenuItem
+                onClick={() => fileInputRef.current?.click()}
+                className="flex items-center gap-2.5 py-2 cursor-pointer"
+              >
+                <Upload className="h-4 w-4" />
+                <span>{m.upload_file()}</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => folderInputRef.current?.click()}
+                className="flex items-center gap-2.5 py-2 cursor-pointer"
+              >
+                <Upload className="h-4 w-4" />
+                <span>{m.upload_folder()}</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => setIsNewFolderDialogOpen(true)}
+                className="flex items-center gap-2.5 py-2 cursor-pointer"
+              >
+                <FolderPlus className="h-4 w-4" />
+                <span>{m.new_folder()}</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      )}
+
+      {/* New Folder Dialog */}
+      <Dialog open={isNewFolderDialogOpen} onOpenChange={setIsNewFolderDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <form onSubmit={handleCreateFolderSubmit}>
+            <DialogHeader>
+              <DialogTitle>{m.new_folder()}</DialogTitle>
+              <DialogDescription>{m.folder_name()}</DialogDescription>
+            </DialogHeader>
+            <div className="py-4">
+              <Input
+                autoFocus
+                placeholder={m.folder_name()}
+                value={newFolderName}
+                onChange={(e) => setNewFolderName(e.target.value)}
+              />
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setIsNewFolderDialogOpen(false)}
+              >
+                {m.cancel()}
+              </Button>
+              <Button type="submit" disabled={!newFolderName.trim() || isCreatingFolder}>
+                {isCreatingFolder ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
+                {m.confirm()}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Alert Dialog */}
+      <AlertDialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{m.delete_asset_title()}</AlertDialogTitle>
+            <AlertDialogDescription>{m.delete_asset_description()}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{m.cancel()}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => confirmDelete()}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {m.delete()}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Empty Trash Confirmation Alert Dialog */}
+      <AlertDialog open={isEmptyTrashDialogOpen} onOpenChange={setIsEmptyTrashDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{m.empty_trash_title()}</AlertDialogTitle>
+            <AlertDialogDescription>{m.empty_trash_description()}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{m.cancel()}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => emptyTrash()}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={isEmptyingTrash}
+            >
+              {isEmptyingTrash ? 'Deleting...' : m.delete()}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Download Dialog */}
+      <Dialog open={isDownloadDialogOpen} onOpenChange={setIsDownloadDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {isLoadingLinks ? m.preparing_download() : m.confirm_download()}
+            </DialogTitle>
+            <DialogDescription>
+              {isLoadingLinks ? m.resolving_files_wait() : m.folder_files_download_description()}
+            </DialogDescription>
+          </DialogHeader>
+
+          {isLoadingLinks ? (
+            <div className="space-y-4 py-6 flex flex-col items-center justify-center">
+              <Loader2 className="h-8 w-8 animate-spin text-primary" />
+              <span className="text-sm font-medium text-muted-foreground mt-2">
+                {m.preparing_download_links()}
+              </span>
+            </div>
+          ) : (
+            <div className="space-y-4 py-2">
+              <div className="text-sm text-muted-foreground">
+                {m.download_includes_files({ count: resolvedFiles.length })}
+              </div>
+              <div className="flex items-start gap-3 p-3 text-sm rounded-lg bg-amber-50 dark:bg-amber-950/30 text-amber-800 dark:text-amber-300 border border-amber-200 dark:border-amber-900/30">
+                <AlertTriangle className="h-5 w-5 shrink-0 mt-0.5" />
+                <div>
+                  <p className="font-semibold">{m.no_folder_structure()}</p>
+                  <p className="mt-0.5 text-xs text-amber-700/90 dark:text-amber-400/90">
+                    {m.folder_structure_warning()}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <DialogFooter>
+            {!isLoadingLinks ? (
+              <>
+                <Button variant="outline" onClick={() => setIsDownloadDialogOpen(false)}>
+                  {m.cancel()}
+                </Button>
+                <Button
+                  onClick={startDownload}
+                  className="gap-2"
+                  disabled={resolvedFiles.length === 0}
+                >
+                  <Download className="h-4 w-4" />
+                  {m.start_download()}
+                </Button>
+              </>
+            ) : (
+              <Button variant="outline" onClick={() => setIsDownloadDialogOpen(false)}>
+                {m.cancel()}
+              </Button>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/packages/webui/components/file-browser/mobile-file-browser.tsx
+++ b/packages/webui/components/file-browser/mobile-file-browser.tsx
@@ -668,7 +668,7 @@ export function MobileFileBrowser({
             <DropdownMenuTrigger asChild>
               <Button
                 size="icon"
-                className="h-14 w-14 rounded-full bg-primary text-primary-foreground shadow-lg shadow-primary/25 hover:bg-primary/90 flex items-center justify-center transition-all active:scale-95"
+                className="h-14 w-14 rounded-full bg-primary text-primary-foreground shadow-lg shadow-primary/25 hover:bg-primary/90 flex items-center justify-center"
                 aria-label="Actions"
               >
                 <Plus className="h-6 w-6" />

--- a/packages/webui/components/file-browser/mobile-file-browser.tsx
+++ b/packages/webui/components/file-browser/mobile-file-browser.tsx
@@ -198,6 +198,7 @@ export function MobileFileBrowser({
   const decrementUploading = useUploadStore((state) => state.decrement)
   const startTask = useUploadStore((state) => state.startTask)
   const updateFileProgress = useUploadStore((state) => state.updateFileProgress)
+  const completeFile = useUploadStore((state) => state.completeFile)
   const failFile = useUploadStore((state) => state.failFile)
 
   const $confirmUpload = client.api.teams[':teamId'].upload.tasks[':taskId'].$patch
@@ -273,9 +274,25 @@ export function MobileFileBrowser({
               )
 
               const resp = await uploadPromise
-              if (!resp.ok) {
+              if (resp.ok) {
+                completeFile(taskId, uploadInfo.fileId)
+                await confirmUpload({
+                  param: { teamId: teamId!, taskId: taskId },
+                  json: {
+                    fileId: uploadInfo.fileId,
+                  },
+                })
+              } else {
                 failFile(taskId, uploadInfo.fileId)
                 toast.error(`Failed to upload file: ${item.file.name}`)
+                await confirmUpload({
+                  param: { teamId: teamId!, taskId: taskId },
+                  json: {
+                    fileId: uploadInfo.fileId,
+                    errorMessage: `upload failed with status: ${resp.status}`,
+                  },
+                })
+                return
               }
             } catch (error) {
               failFile(taskId, uploadInfo.fileId)
@@ -287,6 +304,7 @@ export function MobileFileBrowser({
                   errorMessage: `upload failed with error: ${error instanceof Error ? error.message : String(error)}`,
                 },
               })
+              return
             } finally {
               decrementUploading()
               queryClient.invalidateQueries({

--- a/packages/webui/components/file-browser/mobile-file-browser.tsx
+++ b/packages/webui/components/file-browser/mobile-file-browser.tsx
@@ -488,8 +488,8 @@ export function MobileFileBrowser({
 
       {/* Main scroll area */}
       <div className="flex-1 overflow-y-auto min-h-0 p-3 pb-24">
-        {/* 2-Column Grid */}
-        <div className="grid grid-cols-2 gap-3">
+        {/* 1-Column Grid */}
+        <div className="grid grid-cols-1 gap-4 max-w-lg mx-auto w-full">
           {/* Folders */}
           {folders.map((folder) => (
             <FolderCard

--- a/packages/webui/components/file-system-manager.tsx
+++ b/packages/webui/components/file-system-manager.tsx
@@ -25,9 +25,11 @@ import { useNavigate } from '@tanstack/react-router'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { cn } from '../lib/utils'
 import { getSelectedRangeIds } from '../lib/selection-utils'
+import { useIsMobile } from '@/ui/hooks/use-mobile'
 import { ChatbotSidebar } from './chatbot-sidebar'
 import { SnapToPointer } from './dnd-modifiers'
 import { FileBrowser } from './file-browser/file-browser'
+import { MobileFileBrowser } from './file-browser/mobile-file-browser'
 import { FileViewerRightSidebar } from './file-viewer-right-sidebar'
 import { FolderTree } from './folder-tree'
 import { ResizeHandle } from './resize-handle'
@@ -162,6 +164,7 @@ export default function FileSystemManager({
       teamId,
       projectId,
       projectName,
+      rootFolderId,
       ancestorFolders: folderInfo?.ancestorFolders ?? [],
       currentAsset: isRecentlyDeleted
         ? { name: m.recently_deleted(), type: 'folder' }
@@ -415,6 +418,39 @@ export default function FileSystemManager({
           })
         },
       },
+    )
+  }
+
+  const isMobile = useIsMobile()
+
+  if (isMobile) {
+    return (
+      <MobileFileBrowser
+        teamId={teamId}
+        projectId={projectId}
+        assetId={assetId}
+        folders={folders}
+        files={files}
+        totalFolders={totalFolders}
+        totalFiles={totalFiles}
+        totalFoldersSize={totalFoldersSize}
+        totalFilesSize={totalFilesSize}
+        selectedItem={selectedItem}
+        selectedIds={selectedIds}
+        onItemSelect={handleItemSelect}
+        onItemDoubleClick={handleItemDoubleClick}
+        onSaveField={handleSaveField}
+        onClearSelection={handleClearSelection}
+        fetchNextFoldersPage={fetchNextFoldersPage}
+        hasNextFoldersPage={hasNextPageFolders || false}
+        isFetchingNextFoldersPage={isFetchingNextFoldersPage}
+        fetchNextFilesPage={fetchNextFilesPage}
+        hasNextFilesPage={hasNextPageFiles || false}
+        isFetchingNextFilesPage={isFetchingNextFilesPage}
+        isRecentlyDeleted={isRecentlyDeleted}
+        isRecents={isRecents}
+        rootFolderId={rootFolderId}
+      />
     )
   }
 

--- a/packages/webui/components/public-share-manager.tsx
+++ b/packages/webui/components/public-share-manager.tsx
@@ -297,6 +297,11 @@ export function PublicShareManager({
     [filesData],
   )
 
+  const totalFolders = foldersData?.pages[0]?.pageInfo?.total
+  const totalFiles = filesData?.pages[0]?.pageInfo?.total
+  const totalFoldersSize = foldersData?.pages[0]?.pageInfo?.totalSize
+  const totalFilesSize = filesData?.pages[0]?.pageInfo?.totalSize
+
   const currentSelectedItem = useMemo(() => {
     if (viewingFileData) return viewingFileData
     if (selectedIds.size !== 1) return null
@@ -602,6 +607,10 @@ export function PublicShareManager({
               assetId={currentFolderId}
               folders={folders}
               files={files}
+              totalFolders={totalFolders}
+              totalFiles={totalFiles}
+              totalFoldersSize={totalFoldersSize}
+              totalFilesSize={totalFilesSize}
               selectedItem={null}
               selectedIds={selectedIds}
               onItemSelect={(item, e) => {

--- a/packages/webui/components/public-share-manager.tsx
+++ b/packages/webui/components/public-share-manager.tsx
@@ -5,8 +5,10 @@ import { useTopNavStore } from '@/ui/stores/top-nav'
 import { m } from '@/ui/paraglide/messages.js'
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import { useEffect, useState, useMemo, useRef } from 'react'
+import { useIsMobile } from '@/ui/hooks/use-mobile'
 import { TopNav } from './top-nav'
 import { FileBrowser } from './file-browser/file-browser'
+import { MobileFileBrowser } from './file-browser/mobile-file-browser'
 import { FileViewerRightSidebar } from './file-viewer-right-sidebar'
 import { ResizeHandle } from './resize-handle'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
@@ -61,6 +63,7 @@ export function PublicShareManager({
   compareActiveSide = 'left',
 }: PublicShareManagerProps) {
   const navigate = useNavigate()
+  const isMobile = useIsMobile()
   const isCompareMode = !!compare && !!compareLeftId && !!compareRightId
   const [password, setPassword] = useState(() => {
     return localStorage.getItem(`share_pwd_${shareId}`) || ''
@@ -591,7 +594,40 @@ export function PublicShareManager({
             )}
           </div>
         ) : (
-          currentFolderId && (
+          currentFolderId &&
+          (isMobile ? (
+            <MobileFileBrowser
+              teamId=""
+              projectId={shareInfo.projectId}
+              assetId={currentFolderId}
+              folders={folders}
+              files={files}
+              selectedItem={null}
+              selectedIds={selectedIds}
+              onItemSelect={(item, e) => {
+                if (e.metaKey || e.ctrlKey) {
+                  const next = new Set(selectedIds)
+                  if (next.has(item.id!)) next.delete(item.id!)
+                  else next.add(item.id!)
+                  setSelectedIds(next)
+                } else {
+                  setSelectedIds(new Set([item.id!]))
+                }
+              }}
+              onItemDoubleClick={handleItemDoubleClick}
+              onClearSelection={() => setSelectedIds(new Set())}
+              fetchNextFoldersPage={fetchNextFoldersPage}
+              hasNextFoldersPage={hasNextPageFolders}
+              isFetchingNextFoldersPage={isFetchingNextFoldersPage}
+              fetchNextFilesPage={fetchNextFilesPage}
+              hasNextFilesPage={hasNextPageFiles}
+              isFetchingNextFilesPage={isFetchingNextFilesPage}
+              isShareView={true}
+              isPublic={true}
+              shareId={shareId}
+              allowDownload={shareInfo.allowDownload}
+            />
+          ) : (
             <FileBrowser
               teamId=""
               projectId={shareInfo.projectId}
@@ -625,10 +661,10 @@ export function PublicShareManager({
               shareId={shareId}
               allowDownload={shareInfo.allowDownload}
             />
-          )
+          ))
         )}
 
-        {!isRightSidebarCollapsed && (
+        {!isRightSidebarCollapsed && !isMobile && (
           <>
             <ResizeHandle
               onResize={(delta) =>

--- a/packages/webui/components/top-nav.tsx
+++ b/packages/webui/components/top-nav.tsx
@@ -134,10 +134,27 @@ export function TopNav() {
   )
 }
 
+import { Menu } from 'lucide-react'
+import { Button } from '@/ui/components/ui/button'
+import { useDualSidebarStore } from '@/ui/stores/dual-sidebar'
+
 function TeamHeader() {
+  const { toggleMobileMenu } = useDualSidebarStore()
   return (
-    <div className="flex h-14 flex-wrap items-center justify-center gap-2 border-b border-border bg-card px-4 py-2 flex-shrink-0">
-      <ShumaiLogo className="w-10 h-10 text-orange-600" />
+    <div className="flex h-14 items-center justify-between border-b border-border bg-card px-4 py-2 flex-shrink-0">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={toggleMobileMenu}
+        className="md:hidden text-foreground hover:bg-accent -ml-2"
+        aria-label="Open navigation menu"
+      >
+        <Menu className="h-5 w-5" />
+      </Button>
+      <div className="flex flex-1 items-center justify-center">
+        <ShumaiLogo className="w-10 h-10 text-orange-600" />
+      </div>
+      <div className="w-9 md:hidden" />
     </div>
   )
 }

--- a/packages/webui/routes/__root.tsx
+++ b/packages/webui/routes/__root.tsx
@@ -1,5 +1,6 @@
 import { client } from '@/ui/api/client'
 import { DualSidebar, DualSidebarItem } from '@/ui/components/dual-sidebar'
+import { FolderTree } from '@/ui/components/folder-tree'
 import { NotificationList } from '@/ui/components/notification-list'
 import { TopNav } from '@/ui/components/top-nav'
 import {
@@ -15,9 +16,11 @@ import { m } from '@/ui/paraglide/messages.js'
 import { getLocale, setLocale } from '@/ui/paraglide/runtime.js'
 import { useAuthStore } from '@/ui/stores/auth'
 import { useTeamContextStore } from '@/ui/stores/team-context'
+import { useTopNavStore } from '@/ui/stores/top-nav'
 import { useUploadStore } from '@/ui/stores/upload'
 import { useUserMetadataStore } from '@/ui/stores/user-metadata'
 import { useQuery } from '@tanstack/react-query'
+import { Folder } from 'lucide-react'
 import {
   createRootRouteWithContext,
   Outlet,
@@ -47,6 +50,7 @@ function RootComponent() {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const navigate = useNavigate()
   const { teamId: storedTeamId, setTeamId } = useTeamContextStore()
+  const { projectState } = useTopNavStore()
 
   const showSidebar = user && (pathname.startsWith('/teams/') || pathname.startsWith('/projects/'))
 
@@ -90,7 +94,7 @@ function RootComponent() {
   return (
     <div className="flex h-screen w-full bg-background overflow-hidden">
       <Toaster />
-      <DualSidebar>
+      <DualSidebar hideMobileButton={true}>
         <DualSidebarItem
           icon={<HomeIcon />}
           label={m.home()}
@@ -103,6 +107,21 @@ function RootComponent() {
             }
           }}
         />
+        {projectState && projectState.projectId && (
+          <DualSidebarItem
+            id="folders"
+            icon={<Folder className="size-6 text-foreground" />}
+            label={m.folder_tree_assets()}
+          >
+            <FolderTree
+              teamId={projectState.teamId}
+              projectId={projectState.projectId}
+              projectName={projectState.projectName}
+              rootFolderId={projectState.rootFolderId || ''}
+              ancestorFolders={projectState.ancestorFolders}
+            />
+          </DualSidebarItem>
+        )}
         <DualSidebarItem icon={<NotificationFillIcon />} label={m.notifications()} badge={badge}>
           <NotificationList />
         </DualSidebarItem>

--- a/packages/webui/routes/__root.tsx
+++ b/packages/webui/routes/__root.tsx
@@ -20,7 +20,6 @@ import { useTopNavStore } from '@/ui/stores/top-nav'
 import { useUploadStore } from '@/ui/stores/upload'
 import { useUserMetadataStore } from '@/ui/stores/user-metadata'
 import { useQuery } from '@tanstack/react-query'
-import { Folder } from 'lucide-react'
 import {
   createRootRouteWithContext,
   Outlet,
@@ -94,7 +93,25 @@ function RootComponent() {
   return (
     <div className="flex h-screen w-full bg-background overflow-hidden">
       <Toaster />
-      <DualSidebar hideMobileButton={true}>
+      <DualSidebar
+        hideMobileButton={true}
+        defaultMobileContent={
+          projectState?.projectId
+            ? {
+                label: m.folder_tree_assets(),
+                children: (
+                  <FolderTree
+                    teamId={projectState.teamId}
+                    projectId={projectState.projectId}
+                    projectName={projectState.projectName}
+                    rootFolderId={projectState.rootFolderId || ''}
+                    ancestorFolders={projectState.ancestorFolders}
+                  />
+                ),
+              }
+            : undefined
+        }
+      >
         <DualSidebarItem
           icon={<HomeIcon />}
           label={m.home()}
@@ -107,21 +124,6 @@ function RootComponent() {
             }
           }}
         />
-        {projectState && projectState.projectId && (
-          <DualSidebarItem
-            id="folders"
-            icon={<Folder className="size-6 text-foreground" />}
-            label={m.folder_tree_assets()}
-          >
-            <FolderTree
-              teamId={projectState.teamId}
-              projectId={projectState.projectId}
-              projectName={projectState.projectName}
-              rootFolderId={projectState.rootFolderId || ''}
-              ancestorFolders={projectState.ancestorFolders}
-            />
-          </DualSidebarItem>
-        )}
         <DualSidebarItem icon={<NotificationFillIcon />} label={m.notifications()} badge={badge}>
           <NotificationList />
         </DualSidebarItem>

--- a/packages/webui/stores/dual-sidebar.ts
+++ b/packages/webui/stores/dual-sidebar.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand'
+
+interface DualSidebarStore {
+  isMobileMenuOpen: boolean
+  activeItem: number | null
+  activeItemId: string | null
+  openMobileMenu: (defaultActiveIdOrIndex?: string | number | null) => void
+  closeMobileMenu: () => void
+  toggleMobileMenu: () => void
+  setActiveItem: (item: number | null) => void
+  setActiveItemId: (id: string | null) => void
+}
+
+export const useDualSidebarStore = create<DualSidebarStore>((set) => ({
+  isMobileMenuOpen: false,
+  activeItem: null,
+  activeItemId: null,
+  openMobileMenu: (defaultActiveIdOrIndex = null) =>
+    set({
+      isMobileMenuOpen: true,
+      activeItemId: typeof defaultActiveIdOrIndex === 'string' ? defaultActiveIdOrIndex : null,
+      activeItem: typeof defaultActiveIdOrIndex === 'number' ? defaultActiveIdOrIndex : null,
+    }),
+  closeMobileMenu: () =>
+    set({
+      isMobileMenuOpen: false,
+      activeItem: null,
+      activeItemId: null,
+    }),
+  toggleMobileMenu: () =>
+    set((state) => ({
+      isMobileMenuOpen: !state.isMobileMenuOpen,
+      activeItem: state.isMobileMenuOpen ? null : state.activeItem,
+      activeItemId: state.isMobileMenuOpen ? null : state.activeItemId,
+    })),
+  setActiveItem: (item) => set({ activeItem: item, activeItemId: null }),
+  setActiveItemId: (id) => set({ activeItemId: id }),
+}))

--- a/packages/webui/stores/top-nav.ts
+++ b/packages/webui/stores/top-nav.ts
@@ -5,6 +5,7 @@ export interface TopNavProjectState {
   teamId: string
   projectId: string
   projectName: string
+  rootFolderId?: string
   ancestorFolders: AncestorFolder[]
   currentAsset: {
     id?: string


### PR DESCRIPTION
## Summary

Adds a dedicated, simplified mobile layout for project file lists, recents, recently deleted, and public share pages. It features a streamlined top header `[menu button] breadcrumb bar`, an integrated folder tree drawer in the dual sidebar, a 2-column mobile grid view, and a Floating Action Button (+) for uploading and folder creation.

## Changes

- **Dual Sidebar & Drawer**: Added [`useDualSidebarStore`](packages/webui/stores/dual-sidebar.ts) and updated [`DualSidebar`](packages/webui/components/dual-sidebar.tsx) to support opening drawer panels on demand (such as expanding the folder tree) and automatically closing when navigating.
- **Root Route & Folder Tree Integration**: Updated [`routes/__root.tsx`](packages/webui/routes/__root.tsx) to register the Project Folders item in the `DualSidebar` Level 2 drawer when in project context.
- **Top Navigation & Breadcrumbs**: Updated [`BreadcrumbNav`](packages/webui/components/breadcrumb-nav.tsx) and [`TopNav`](packages/webui/components/top-nav.tsx) to render a menu button directly in the breadcrumb bar on mobile and hide desktop dock sidebar toggles.
- **Mobile File Browser**: Implemented [`MobileFileBrowser`](packages/webui/components/file-browser/mobile-file-browser.tsx) with a responsive 2-column grid layout, single-tap selection / double-tap open, empty folder states, infinite scrolling, and bottom-right Floating Action Button (+) for upload and folder creation.
- **Integration with Managers**: Integrated [`MobileFileBrowser`](packages/webui/components/file-browser/mobile-file-browser.tsx) into [`FileSystemManager`](packages/webui/components/file-system-manager.tsx) and [`PublicShareManager`](packages/webui/components/public-share-manager.tsx).
- **Tests**: Added unit tests in [`mobile-file-browser.test.tsx`](packages/webui/components/file-browser/mobile-file-browser.test.tsx) and updated [`breadcrumb-nav.test.tsx`](packages/webui/components/breadcrumb-nav.test.tsx).

## Verification

- `bun run lint` (passed)
- `bun run format` (passed)
- `bun run typecheck` (passed)
- `bun run test` (135 files, 1327 tests passed)
- `bun run test:e2e:app` (38 tests passed)
- `bun run test:e2e:webui` (9 tests passed)
- `bun run test:e2e:workflow` (14 files, 58 tests passed)

## Notes

None.