### PR TITLE
docs: add SECURITY.md with a private disclosure path

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,58 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities **privately**. Do not open a public issue,
+pull request or Discord message for a suspected vulnerability, as that discloses it
+to everyone before a fix exists.
+
+Use **[GitHub private vulnerability reporting](https://github.com/shumaiOne/shumai/security/advisories/new)**
+(the "Report a vulnerability" button on the Security tab). If that is unavailable,
+contact the maintainer directly rather than in a public channel.
+
+Please include:
+
+- What the issue is, and the impact you believe it has
+- The version or commit you tested (`git rev-parse HEAD`, or the image digest)
+- Steps to reproduce, ideally minimal
+- Your deployment shape: storage backend, whether the agent feature is enabled,
+  and whether the instance is internet-reachable
+
+## Supported Versions
+
+Shumai is pre-1.0 and moves quickly. Security fixes are made against the **latest
+release**. Users are encouraged to track releases rather than pin indefinitely.
+
+## Scope
+
+**In scope** — the application, its API, the shipped Docker images, and the
+deployment manifests under `docker-compose/`.
+
+Deployment manifests are explicitly in scope. A default that is unsafe when
+followed as documented is a real finding, because the documented quickstart is what
+most operators actually run.
+
+**Out of scope**
+
+- Vulnerabilities in third-party dependencies, unless Shumai's use of them is what
+  creates the exposure. Report those upstream.
+- Findings that require an already-compromised host or database.
+- Configurations that deviate from the documented deployment.
+
+## Operator guidance
+
+Shumai is self-hosted, so several controls belong to the operator rather than to the
+project:
+
+- **Set `BETTER_AUTH_SECRET` per deployment.** It signs sessions and, in local
+  storage mode, upload URLs. Never reuse a value from documentation or an example.
+- **Do not expose the instance to the public internet without a reverse proxy**
+  terminating TLS and applying your own access policy.
+- **Do not publish the database port.** Set a real database password.
+- **Treat the agent feature as a code-execution surface.** If you enable it, run it
+  where a compromise is survivable, and review the sandbox network policy.
+
+## Disclosure
+
+Please allow a reasonable period for a fix before public disclosure. The maintainer
+will acknowledge reports and keep reporters informed of progress.


### PR DESCRIPTION
## What

Adds a `SECURITY.md` with a private disclosure path.

## Why

The repository currently has no security policy. Someone who finds an issue today has two options: open a public issue, or post in Discord. **Both disclose the finding to everyone before a fix exists.**

That is a gap worth closing before it matters rather than after.

## Notes on the choices, so they are easy to disagree with

- **Reports route to GitHub private vulnerability reporting** rather than to a public channel. If that is not enabled on the repository, it can be turned on under Settings → Security, and the link in the file will then work.
- **Deployment manifests are named as in scope.** The reasoning: the documented quickstart is what most operators actually run, so a default that is unsafe when followed as written is a real finding rather than a misconfiguration.
- **No response timelines are asserted.** Those are yours to set. The file says reporters will be acknowledged and kept informed, and deliberately does not commit you to a number.
- **Operator guidance** covers the three things a self-hoster owns rather than the project: setting `BETTER_AUTH_SECRET` per deployment, not publishing the database port, and treating the agent as a code-execution surface.

## Context

We evaluated Shumai as a possible review and delivery layer for our own creative work, which meant reading it fairly closely and running it. This PR and the one that follows on the compose privileges are things we would have wanted to exist while doing that.

Happy to adjust the wording, the scope section, or drop anything you would rather say differently — it is your policy, not ours.
