### PR TITLE
fix(compose): do not ship elevated privileges in the default deployment

### DIFF
--- a/docker-compose/local/docker-compose-agent.yaml
+++ b/docker-compose/local/docker-compose-agent.yaml
@@ -1,9 +1,8 @@
-# Default deployment. Runs with standard container isolation.
+# Agent-enabled deployment.
 #
-# The agent feature is NOT enabled here. If you want it, use
-# docker-compose-agent.yaml instead, which adds the elevated privileges the agent
-# sandbox requires. Keeping them out of this file means an operator who never uses
-# the agent does not run with seccomp and AppArmor disabled.
+# Identical to docker-compose.yaml except that it grants the elevated privileges the
+# agent sandbox requires. Use this ONLY if you use the agent feature, and prefer to
+# run it where a compromise is survivable.
 services:
   postgres:
     image: pgvector/pgvector:pg18
@@ -24,6 +23,14 @@ services:
 
   shumai:
     image: shumaione/shumai:latest
+    # Required by the agent sandbox (bubblewrap needs to create user namespaces).
+    # These weaken container isolation, so this file is only for deployments that
+    # actually use the agent feature. See docker-compose.yaml for the default.
+    cap_add:
+      - SYS_ADMIN
+    security_opt:
+      - apparmor=unconfined
+      - seccomp=unconfined
     container_name: shumai_app
     ports:
       - '3000:3000'
@@ -42,6 +49,9 @@ services:
 
       # Better Auth
       BETTER_AUTH_SECRET: qSxs9DxzHDZBbeeTNPEwBuspYwipBqz5Gk5XdBjNhWw=
+
+      # Sandbox Configuration
+      ENABLE_WEAKER_NESTED_SANDBOX: 'true'
 
     depends_on:
       postgres:


### PR DESCRIPTION
## What

Moves `cap_add: SYS_ADMIN`, `apparmor=unconfined` and `seccomp=unconfined` out of the default compose and into a new `docker-compose-agent.yaml`.

The quickstart `curl` URL is unchanged, so no documented install breaks.

## Why

Those flags are needed by the agent sandbox — bubblewrap needs to create user namespaces. But the default compose applies them to **every** operator, including everyone who never enables the agent. For those deployments the container isolation is weakened for no benefit, and the operator has no signal that it happened.

Splitting the file makes the trade explicit: you take the privileges when you take the feature.

## Verified

We ran `shumaione/shumai@sha256:cc06580424af311b0a5d402e8fab0f5d69ed23467d004d2242f2a2c8e6befafd` (v0.3.11) with the privileges removed:

```
CapAdd: [] | SecurityOpt: [] | Privileged: false
```

Result: all migrations applied, `🚀 Server running at http://localhost:3000/`, and the following worked normally — asset upload via the signed `/api/upload/local` path, canvas annotation with the rectangle tool, comment persistence across a full page reload with the drawing recalled correctly, and share-link creation with the security panel.

**Not tested:** whether the agent feature itself works with the privileges removed. It presumably does not, which is exactly why this adds a variant file rather than deleting the privileges outright. If the agent needs anything beyond those three settings, the variant is the right place to put it.

## One small thing while you are here

The default compose ships a literal `BETTER_AUTH_SECRET`. Since that value is public in this repository and also keys local-storage upload URLs, it may be worth generating it at first run, or failing closed when it is unset, rather than shipping a constant that a copy-paste install will keep. Happy to send that as a separate PR if you would like it — left out of this one to keep the change focused.

## Context

We evaluated Shumai as a possible review and delivery layer for our own creative work, which meant actually running it rather than only reading it. This came out of that.
