### PR TITLE
fix(webui): fix breadcrumb file dropdown trigger stretching and alignment

### DIFF
--- a/packages/webui/components/breadcrumb-nav.tsx
+++ b/packages/webui/components/breadcrumb-nav.tsx
@@ -229,15 +229,10 @@ export function BreadcrumbNav({
       ? mobileAncestorItems[mobileAncestorItems.length - 1]
       : null
 
-  const renderTerminal = (isMobile = false) => {
+  const renderTerminal = () => {
     if (customTerminalBreadcrumb) {
       return (
-        <span
-          className={cn(
-            'truncate rounded px-2 py-1 text-sm font-medium text-foreground',
-            isMobile && 'min-w-0 flex-1',
-          )}
-        >
+        <span className="truncate rounded px-2 py-1 text-sm font-medium text-foreground">
           {customTerminalBreadcrumb}
         </span>
       )
@@ -246,12 +241,7 @@ export function BreadcrumbNav({
     if (!isRootFolder && !compareMode) {
       if (currentAsset.type === 'folder') {
         return (
-          <span
-            className={cn(
-              'truncate rounded px-2 py-1 text-sm font-medium text-foreground',
-              isMobile && 'min-w-0 flex-1',
-            )}
-          >
+          <span className="truncate rounded px-2 py-1 text-sm font-medium text-foreground">
             {currentAsset.name}
           </span>
         )
@@ -259,12 +249,7 @@ export function BreadcrumbNav({
 
       return (
         <DropdownMenu modal={false}>
-          <DropdownMenuTrigger
-            className={cn(
-              'flex items-center gap-1 truncate rounded px-2 py-1 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground',
-              isMobile && 'min-w-0 flex-1',
-            )}
-          >
+          <DropdownMenuTrigger className="flex items-center gap-1 truncate rounded px-2 py-1 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground">
             <span className="truncate">{currentAsset.name}</span>
             {currentAsset.version !== undefined && (
               <Badge variant="outline" className="px-1 py-0 text-xs shrink-0">
@@ -273,7 +258,7 @@ export function BreadcrumbNav({
             )}
             <ChevronDown className="h-4 w-4 shrink-0" />
           </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-56">
+          <DropdownMenuContent className="w-56" align="start">
             {allowDownload &&
               (hasVideoTranscodes ? (
                 <DropdownMenuSub>
@@ -550,7 +535,7 @@ export function BreadcrumbNav({
 
         {/* Terminal Item (Desktop & Mobile) */}
         {(hasTerminal || (!hasTerminal && ancestorFolders.length > 0)) && (
-          <div className="flex items-center gap-1 min-w-0 flex-1 overflow-hidden">
+          <div className="flex items-center gap-1 min-w-0 shrink overflow-hidden">
             <span
               className={cn(
                 'text-muted-foreground shrink-0',
@@ -560,9 +545,9 @@ export function BreadcrumbNav({
               /
             </span>
             {hasTerminal
-              ? renderTerminal(true)
+              ? renderTerminal()
               : mobileTerminalDirect && (
-                  <span className="min-w-0 flex-1 truncate rounded px-2 py-1 text-sm font-medium text-foreground">
+                  <span className="min-w-0 truncate rounded px-2 py-1 text-sm font-medium text-foreground">
                     {mobileTerminalDirect.name}
                   </span>
                 )}


### PR DESCRIPTION
## Summary

Fixes an issue where the file name trigger in the top bar breadcrumb expanded to occupy all available horizontal space, causing a full-width hover highlight and centering the dropdown menu in the middle of the top bar rather than anchoring it to the file name.

## Changes

- Removed `flex-1` / `min-w-0 flex-1` from the terminal item container, `DropdownMenuTrigger`, and `renderTerminal` in `BreadcrumbNav`.
- Used `min-w-0 shrink` so the terminal item sizes to its content and gracefully truncates when horizontal space is constrained.
- Added `align="start"` to `DropdownMenuContent` to align the dropdown menu with the file trigger.

## Verification

- `bun run lint` (passed)
- `bun run format` (passed)
- `bun run typecheck` (passed)
- `bun run test` (140 test files, 1349 tests passed)
- `bun run test:e2e:app` (38 tests passed)
- `bun run test:e2e:webui` (9 tests passed)
- `bun run test:e2e:workflow` (14 test files, 58 tests passed)

## Notes

Fixes a regression introduced in PR #356.