### PR TITLE
fix(webui): align mobile comment cards and thread vertical indicator

### DIFF
--- a/packages/webui/components/file-viewer/mobile-file-bottom-sheet.tsx
+++ b/packages/webui/components/file-viewer/mobile-file-bottom-sheet.tsx
@@ -399,7 +399,7 @@ export function MobileFileBottomSheet({
             ) : (
               <div className="space-y-3">
                 {comments.map((comment) => (
-                  <div key={comment.id} className="space-y-2">
+                  <div key={comment.id}>
                     <MessageCard
                       teamId={teamId}
                       message={comment}
@@ -424,7 +424,7 @@ export function MobileFileBottomSheet({
                       }}
                     />
                     {comment.replies?.map((reply, index) => (
-                      <div key={reply.id} className="pl-4 border-l border-border/60">
+                      <div key={reply.id}>
                         <MessageCard
                           teamId={teamId}
                           isReply={true}


### PR DESCRIPTION
## Summary

Fixes the misalignment between parent comment cards and reply cards in the mobile file detail bottom sheet, ensuring left alignment of comment cards and seamless vertical thread indicator lines.

## Changes

- In `packages/webui/components/file-viewer/mobile-file-bottom-sheet.tsx`:
  - Removed `space-y-2` on the comment container to restore contiguous card border styling.
  - Removed `pl-4 border-l border-border/60` on reply card wrappers, aligning replies with the parent card and matching the desktop implementation in `file-viewer-right-sidebar.tsx`.

## Verification

All workspace checks passed:
- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test` (140 files, 1349 tests passed)
- `bun run test:e2e:webui` (9 tests passed)
- `bun run test:e2e:workflow` (14 files, 58 tests passed)
- `bun run test:e2e:app` (38 tests passed)

## Notes

N/A