### PR TITLE
fix(asset,webui): disallow dropping version stacks onto files and version stacks

### DIFF
--- a/packages/core/src/asset/asset.test.ts
+++ b/packages/core/src/asset/asset.test.ts
@@ -570,6 +570,62 @@ describe('AssetService', () => {
     })
   })
 
+  it('rejects reparenting a version_stack onto a file', async () => {
+    const { user, assets } = await setupBasicAssets()
+    await expect(
+      assetService.reparentAssets({
+        assetIds: [assets.stackB.id],
+        newParentId: assets.fileA1.id,
+        creatorId: user.id,
+      }),
+    ).rejects.toThrow('Source asset must be a file to create a version stack')
+  })
+
+  it('rejects reparenting a version_stack onto another version_stack', async () => {
+    const { user, assets, project } = await setupBasicAssets()
+    const stack2 = await prisma.asset.create({
+      data: {
+        name: 'stack2',
+        type: AssetType.version_stack,
+        projectId: project.id,
+        parentId: assets.folderA.id,
+        creatorId: user.id,
+        fileCount: 2,
+        sizeByte: 100,
+        status: 'uploaded',
+      },
+    })
+    await expect(
+      assetService.reparentAssets({
+        assetIds: [assets.stackB.id],
+        newParentId: stack2.id,
+        creatorId: user.id,
+      }),
+    ).rejects.toThrow('Cannot move version_stack asset into a version stack')
+  })
+
+  it('rejects reparenting a folder onto a version_stack', async () => {
+    const { user, assets } = await setupBasicAssets()
+    await expect(
+      assetService.reparentAssets({
+        assetIds: [assets.folderA.id],
+        newParentId: assets.stackB.id,
+        creatorId: user.id,
+      }),
+    ).rejects.toThrow('Cannot move folder asset into a version stack')
+  })
+
+  it('rejects reparenting multiple files onto a version_stack at once', async () => {
+    const { user, assets } = await setupBasicAssets()
+    await expect(
+      assetService.reparentAssets({
+        assetIds: [assets.fileA1.id, assets.fileA2.id],
+        newParentId: assets.stackB.id,
+        creatorId: user.id,
+      }),
+    ).rejects.toThrow('Can only move one file at a time into a version stack')
+  })
+
   describe('fileCount verification', () => {
     it('createAsset should increment parent fileCount', async () => {
       const { user, assets, project } = await setupBasicAssets()

--- a/packages/core/src/asset/asset.ts
+++ b/packages/core/src/asset/asset.ts
@@ -211,6 +211,12 @@ export class AssetService {
         return this.reparentFileToFile(tx, newParent, req.assetIds, req.creatorId)
       }
 
+      if (newParent.type === AssetType.version_stack) {
+        if (req.assetIds.length !== 1) {
+          throw new Error('Can only move one file at a time into a version stack')
+        }
+      }
+
       const assetsToMove = await tx.asset.findMany({
         where: { id: { in: req.assetIds } },
         include: { project: { include: { team: true } } },
@@ -221,6 +227,14 @@ export class AssetService {
       }
 
       if (assetsToMove.length === 0) return
+
+      if (newParent.type === AssetType.version_stack) {
+        for (const a of assetsToMove) {
+          if (a.type !== AssetType.file) {
+            throw new Error(`Cannot move ${a.type} asset into a version stack`)
+          }
+        }
+      }
 
       let totalSize = 0
       const oldParentId = assetsToMove[0].parentId
@@ -524,6 +538,10 @@ export class AssetService {
     assetIds: string[],
     creatorId?: string,
   ) {
+    if (destFile.type !== AssetType.file) {
+      throw new Error('Destination asset must be a file')
+    }
+
     if (assetIds.length !== 1) {
       throw new Error('Can only reparent one file to another file')
     }
@@ -538,6 +556,10 @@ export class AssetService {
     })
 
     if (!sourceAsset) throw new Error('Source asset not found')
+
+    if (sourceAsset.type !== AssetType.file) {
+      throw new Error('Source asset must be a file to create a version stack')
+    }
 
     if (!sourceAsset.project || !sourceAsset.project.team) {
       throw new Error(`Asset ${sourceAsset.id} is not associated with a team`)

--- a/packages/webui/components/dnd-types.ts
+++ b/packages/webui/components/dnd-types.ts
@@ -2,5 +2,7 @@ export interface DragState {
   isActive: boolean
   draggedIds: Set<string>
   hasFolders: boolean
+  hasVersionStacks: boolean
+  isSingleFile: boolean
   itemCount: number
 }

--- a/packages/webui/components/dnd-types.ts
+++ b/packages/webui/components/dnd-types.ts
@@ -2,7 +2,6 @@ export interface DragState {
   isActive: boolean
   draggedIds: Set<string>
   hasFolders: boolean
-  hasVersionStacks: boolean
   isSingleFile: boolean
   itemCount: number
 }

--- a/packages/webui/components/file-browser/file-card.tsx
+++ b/packages/webui/components/file-browser/file-card.tsx
@@ -133,7 +133,7 @@ export function FileCard({
   const { ref: setDraggableRef, isDragging: isDraggableDragging } = useDraggable({
     id: `browser:${displayItem.id!}`,
     data: {
-      type: 'file',
+      type: displayItem.type,
       id: displayItem.id,
       item: displayItem,
     },
@@ -143,7 +143,7 @@ export function FileCard({
   const { ref: setDroppableRef, isDropTarget: isOver } = useDroppable({
     id: `browser:${displayItem.id!}`,
     data: {
-      type: 'file',
+      type: displayItem.type,
       id: displayItem.id,
       item: displayItem,
     },
@@ -160,14 +160,12 @@ export function FileCard({
     isDraggableDragging || (dragState?.draggedIds.has(displayItem.id!) ?? false)
 
   // Determine if this is a valid drop target
-  // File target is valid ONLY if dragging 1 item AND it is a file (version stack)
+  // File/version stack target is valid ONLY if dragging 1 single regular file
   // And strictly, we shouldn't drop on ourselves
   const isValidDropTarget = useMemo(() => {
     if (!dragState?.isActive) return false
     if (dragState.draggedIds.has(displayItem.id!)) return false // Can't drop on self
-    if (dragState.hasFolders) return false // Can't drag folders onto file
-    if (dragState.itemCount !== 1) return false // Can't drag multiple files onto file
-    return true
+    return dragState.isSingleFile
   }, [dragState, displayItem.id])
 
   const showDropFeedback = isOver && isValidDropTarget

--- a/packages/webui/components/file-browser/file-list-item.tsx
+++ b/packages/webui/components/file-browser/file-list-item.tsx
@@ -108,7 +108,7 @@ export function FileListItem({
   const { ref: setDraggableRef, isDragging: isDraggableDragging } = useDraggable({
     id: `browser:${displayItem.id!}`,
     data: {
-      type: displayItem.type === 'folder' ? 'folder' : 'file',
+      type: displayItem.type,
       id: displayItem.id,
       item: displayItem,
     },

--- a/packages/webui/components/file-browser/list-view.tsx
+++ b/packages/webui/components/file-browser/list-view.tsx
@@ -72,7 +72,7 @@ function ListRow({
   const { ref: setRowRef, isDropTarget: isRowOver } = useDroppable({
     id: `browser:${item.id!}`,
     data: {
-      type: item.type === 'folder' ? 'folder' : 'file',
+      type: item.type,
       id: item.id,
       item: item,
     },
@@ -85,10 +85,8 @@ function ListRow({
 
     if (item.type === 'folder') return true
 
-    if (item.type === 'file') {
-      if (dragState.hasFolders) return false
-      if (dragState.itemCount !== 1) return false
-      return true
+    if (item.type === 'file' || item.type === 'version_stack') {
+      return dragState.isSingleFile
     }
 
     return false

--- a/packages/webui/components/use-file-system-dnd.test.tsx
+++ b/packages/webui/components/use-file-system-dnd.test.tsx
@@ -103,13 +103,12 @@ describe('useFileSystemDnd', () => {
         isActive: true,
         draggedIds: new Set(['file-1']),
         hasFolders: false,
-        hasVersionStacks: false,
         isSingleFile: true,
         itemCount: 1,
       })
     })
 
-    it('sets isSingleFile false and hasVersionStacks true when dragging a version stack', () => {
+    it('sets isSingleFile false when dragging a version stack', () => {
       const { result } = renderHook(
         () =>
           useFileSystemDnd({
@@ -139,7 +138,6 @@ describe('useFileSystemDnd', () => {
         isActive: true,
         draggedIds: new Set(['stack-1']),
         hasFolders: false,
-        hasVersionStacks: true,
         isSingleFile: false,
         itemCount: 1,
       })
@@ -175,7 +173,6 @@ describe('useFileSystemDnd', () => {
         isActive: true,
         draggedIds: new Set(['folder-1']),
         hasFolders: true,
-        hasVersionStacks: false,
         isSingleFile: false,
         itemCount: 1,
       })
@@ -212,7 +209,42 @@ describe('useFileSystemDnd', () => {
         isActive: true,
         draggedIds: new Set(['file-1', 'file-2']),
         hasFolders: false,
-        hasVersionStacks: false,
+        isSingleFile: false,
+        itemCount: 2,
+      })
+    })
+
+    it('sets isSingleFile false when draggedIds contains unloaded items outside visible items', () => {
+      const selectedIds = new Set(['file-1', 'file-unloaded'])
+      const { result } = renderHook(
+        () =>
+          useFileSystemDnd({
+            teamId: 'team-1',
+            projectId: 'proj-1',
+            assetId: 'asset-1',
+            folders,
+            files,
+            selectedIds,
+            onClearSelection: vi.fn(),
+          }),
+        { wrapper },
+      )
+
+      act(() => {
+        result.current.handleDragStart({
+          operation: {
+            source: {
+              id: 'browser:file-1',
+              data: { type: 'file', item: files[0] },
+            },
+          },
+        } as never)
+      })
+
+      expect(result.current.dragState).toEqual({
+        isActive: true,
+        draggedIds: new Set(['file-1', 'file-unloaded']),
+        hasFolders: false,
         isSingleFile: false,
         itemCount: 2,
       })
@@ -487,6 +519,47 @@ describe('useFileSystemDnd', () => {
 
     it('does NOT execute reparentAssets when dropping multiple files onto a version stack or file', () => {
       const selectedIds = new Set(['file-1', 'file-2'])
+      const { result } = renderHook(
+        () =>
+          useFileSystemDnd({
+            teamId: 'team-1',
+            projectId: 'proj-1',
+            assetId: 'asset-1',
+            folders,
+            files,
+            selectedIds,
+            onClearSelection: vi.fn(),
+          }),
+        { wrapper },
+      )
+
+      act(() => {
+        result.current.handleDragStart({
+          operation: {
+            source: {
+              id: 'browser:file-1',
+              data: { type: 'file', item: files[0] },
+            },
+          },
+        } as never)
+      })
+
+      act(() => {
+        result.current.handleDragEnd({
+          operation: {
+            target: {
+              id: 'browser:stack-1',
+              data: { type: 'version_stack', item: files[2] },
+            },
+          },
+        } as never)
+      })
+
+      expect(mockReparent).not.toHaveBeenCalled()
+    })
+
+    it('does NOT execute reparentAssets when dragging selection with unloaded items onto a file or version stack', () => {
+      const selectedIds = new Set(['file-1', 'file-unloaded'])
       const { result } = renderHook(
         () =>
           useFileSystemDnd({

--- a/packages/webui/components/use-file-system-dnd.test.tsx
+++ b/packages/webui/components/use-file-system-dnd.test.tsx
@@ -1,0 +1,529 @@
+// @vitest-environment happy-dom
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { useFileSystemDnd } from './use-file-system-dnd'
+import type { AssetInfo } from '@shumai/dtos'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+
+const mockReparent = vi.fn().mockResolvedValue({ ok: true })
+const mockReorderFolder = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+const mockReorderFile = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+const mockAddAssetToShare = vi
+  .fn()
+  .mockResolvedValue({ ok: true, json: async () => ({ addedCount: 1 }) })
+
+vi.mock('@/ui/api/client', () => ({
+  client: {
+    api: {
+      projects: {
+        ':projectId': {
+          reparent: {
+            $post: (...args: unknown[]) => mockReparent(...args),
+          },
+        },
+      },
+      folders: {
+        ':folderId': {
+          order: {
+            $patch: (...args: unknown[]) => mockReorderFolder(...args),
+          },
+        },
+      },
+      files: {
+        ':fileId': {
+          order: {
+            $patch: (...args: unknown[]) => mockReorderFile(...args),
+          },
+        },
+      },
+      shares: {
+        ':shareId': {
+          assets: {
+            $post: (...args: unknown[]) => mockAddAssetToShare(...args),
+          },
+        },
+      },
+    },
+  },
+}))
+
+describe('useFileSystemDnd', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    vi.clearAllMocks()
+  })
+
+  const folders: AssetInfo[] = [
+    { id: 'folder-1', name: 'Folder 1', type: 'folder', status: 'processed' } as AssetInfo,
+  ]
+  const files: AssetInfo[] = [
+    { id: 'file-1', name: 'File 1.png', type: 'file', status: 'processed' } as AssetInfo,
+    { id: 'file-2', name: 'File 2.png', type: 'file', status: 'processed' } as AssetInfo,
+    { id: 'stack-1', name: 'Stack 1', type: 'version_stack', status: 'processed' } as AssetInfo,
+    { id: 'stack-2', name: 'Stack 2', type: 'version_stack', status: 'processed' } as AssetInfo,
+  ]
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  describe('handleDragStart dragState computation', () => {
+    it('sets isSingleFile true when dragging a single regular file', () => {
+      const { result } = renderHook(
+        () =>
+          useFileSystemDnd({
+            teamId: 'team-1',
+            projectId: 'proj-1',
+            assetId: 'asset-1',
+            folders,
+            files,
+            selectedIds: new Set(),
+            onClearSelection: vi.fn(),
+          }),
+        { wrapper },
+      )
+
+      act(() => {
+        result.current.handleDragStart({
+          operation: {
+            source: {
+              id: 'browser:file-1',
+              data: { type: 'file', item: files[0] },
+            },
+          },
+        } as never)
+      })
+
+      expect(result.current.dragState).toEqual({
+        isActive: true,
+        draggedIds: new Set(['file-1']),
+        hasFolders: false,
+        hasVersionStacks: false,
+        isSingleFile: true,
+        itemCount: 1,
+      })
+    })
+
+    it('sets isSingleFile false and hasVersionStacks true when dragging a version stack', () => {
+      const { result } = renderHook(
+        () =>
+          useFileSystemDnd({
+            teamId: 'team-1',
+            projectId: 'proj-1',
+            assetId: 'asset-1',
+            folders,
+            files,
+            selectedIds: new Set(),
+            onClearSelection: vi.fn(),
+          }),
+        { wrapper },
+      )
+
+      act(() => {
+        result.current.handleDragStart({
+          operation: {
+            source: {
+              id: 'browser:stack-1',
+              data: { type: 'version_stack', item: files[2] },
+            },
+          },
+        } as never)
+      })
+
+      expect(result.current.dragState).toEqual({
+        isActive: true,
+        draggedIds: new Set(['stack-1']),
+        hasFolders: false,
+        hasVersionStacks: true,
+        isSingleFile: false,
+        itemCount: 1,
+      })
+    })
+
+    it('sets hasFolders true when dragging a folder', () => {
+      const { result } = renderHook(
+        () =>
+          useFileSystemDnd({
+            teamId: 'team-1',
+            projectId: 'proj-1',
+            assetId: 'asset-1',
+            folders,
+            files,
+            selectedIds: new Set(),
+            onClearSelection: vi.fn(),
+          }),
+        { wrapper },
+      )
+
+      act(() => {
+        result.current.handleDragStart({
+          operation: {
+            source: {
+              id: 'browser:folder-1',
+              data: { type: 'folder', item: folders[0] },
+            },
+          },
+        } as never)
+      })
+
+      expect(result.current.dragState).toEqual({
+        isActive: true,
+        draggedIds: new Set(['folder-1']),
+        hasFolders: true,
+        hasVersionStacks: false,
+        isSingleFile: false,
+        itemCount: 1,
+      })
+    })
+
+    it('sets isSingleFile false when dragging multiple selected files', () => {
+      const selectedIds = new Set(['file-1', 'file-2'])
+      const { result } = renderHook(
+        () =>
+          useFileSystemDnd({
+            teamId: 'team-1',
+            projectId: 'proj-1',
+            assetId: 'asset-1',
+            folders,
+            files,
+            selectedIds,
+            onClearSelection: vi.fn(),
+          }),
+        { wrapper },
+      )
+
+      act(() => {
+        result.current.handleDragStart({
+          operation: {
+            source: {
+              id: 'browser:file-1',
+              data: { type: 'file', item: files[0] },
+            },
+          },
+        } as never)
+      })
+
+      expect(result.current.dragState).toEqual({
+        isActive: true,
+        draggedIds: new Set(['file-1', 'file-2']),
+        hasFolders: false,
+        hasVersionStacks: false,
+        isSingleFile: false,
+        itemCount: 2,
+      })
+    })
+  })
+
+  describe('handleDragEnd drop execution', () => {
+    it('executes reparentAssets when dropping a single file onto another file', async () => {
+      const onClearSelection = vi.fn()
+      const { result } = renderHook(
+        () =>
+          useFileSystemDnd({
+            teamId: 'team-1',
+            projectId: 'proj-1',
+            assetId: 'asset-1',
+            folders,
+            files,
+            selectedIds: new Set(),
+            onClearSelection,
+          }),
+        { wrapper },
+      )
+
+      act(() => {
+        result.current.handleDragStart({
+          operation: {
+            source: {
+              id: 'browser:file-1',
+              data: { type: 'file', item: files[0] },
+            },
+          },
+        } as never)
+      })
+
+      act(() => {
+        result.current.handleDragEnd({
+          operation: {
+            target: {
+              id: 'browser:file-2',
+              data: { type: 'file', item: files[1] },
+            },
+          },
+        } as never)
+      })
+
+      await vi.waitFor(() => {
+        expect(mockReparent).toHaveBeenCalledWith({
+          param: { projectId: 'proj-1' },
+          json: {
+            assetIds: ['file-1'],
+            newParentId: 'file-2',
+          },
+        })
+      })
+    })
+
+    it('executes reparentAssets when dropping a single file onto a version stack', async () => {
+      const { result } = renderHook(
+        () =>
+          useFileSystemDnd({
+            teamId: 'team-1',
+            projectId: 'proj-1',
+            assetId: 'asset-1',
+            folders,
+            files,
+            selectedIds: new Set(),
+            onClearSelection: vi.fn(),
+          }),
+        { wrapper },
+      )
+
+      act(() => {
+        result.current.handleDragStart({
+          operation: {
+            source: {
+              id: 'browser:file-1',
+              data: { type: 'file', item: files[0] },
+            },
+          },
+        } as never)
+      })
+
+      act(() => {
+        result.current.handleDragEnd({
+          operation: {
+            target: {
+              id: 'browser:stack-1',
+              data: { type: 'version_stack', item: files[2] },
+            },
+          },
+        } as never)
+      })
+
+      await vi.waitFor(() => {
+        expect(mockReparent).toHaveBeenCalledWith({
+          param: { projectId: 'proj-1' },
+          json: {
+            assetIds: ['file-1'],
+            newParentId: 'stack-1',
+          },
+        })
+      })
+    })
+
+    it('does NOT execute reparentAssets when dropping a version stack onto a file', () => {
+      const { result } = renderHook(
+        () =>
+          useFileSystemDnd({
+            teamId: 'team-1',
+            projectId: 'proj-1',
+            assetId: 'asset-1',
+            folders,
+            files,
+            selectedIds: new Set(),
+            onClearSelection: vi.fn(),
+          }),
+        { wrapper },
+      )
+
+      act(() => {
+        result.current.handleDragStart({
+          operation: {
+            source: {
+              id: 'browser:stack-1',
+              data: { type: 'version_stack', item: files[2] },
+            },
+          },
+        } as never)
+      })
+
+      act(() => {
+        result.current.handleDragEnd({
+          operation: {
+            target: {
+              id: 'browser:file-1',
+              data: { type: 'file', item: files[0] },
+            },
+          },
+        } as never)
+      })
+
+      expect(mockReparent).not.toHaveBeenCalled()
+    })
+
+    it('does NOT execute reparentAssets when dropping a version stack onto another version stack', () => {
+      const { result } = renderHook(
+        () =>
+          useFileSystemDnd({
+            teamId: 'team-1',
+            projectId: 'proj-1',
+            assetId: 'asset-1',
+            folders,
+            files,
+            selectedIds: new Set(),
+            onClearSelection: vi.fn(),
+          }),
+        { wrapper },
+      )
+
+      act(() => {
+        result.current.handleDragStart({
+          operation: {
+            source: {
+              id: 'browser:stack-1',
+              data: { type: 'version_stack', item: files[2] },
+            },
+          },
+        } as never)
+      })
+
+      act(() => {
+        result.current.handleDragEnd({
+          operation: {
+            target: {
+              id: 'browser:stack-2',
+              data: { type: 'version_stack', item: files[3] },
+            },
+          },
+        } as never)
+      })
+
+      expect(mockReparent).not.toHaveBeenCalled()
+    })
+
+    it('executes reparentAssets when dropping a version stack onto a folder', async () => {
+      const { result } = renderHook(
+        () =>
+          useFileSystemDnd({
+            teamId: 'team-1',
+            projectId: 'proj-1',
+            assetId: 'asset-1',
+            folders,
+            files,
+            selectedIds: new Set(),
+            onClearSelection: vi.fn(),
+          }),
+        { wrapper },
+      )
+
+      act(() => {
+        result.current.handleDragStart({
+          operation: {
+            source: {
+              id: 'browser:stack-1',
+              data: { type: 'version_stack', item: files[2] },
+            },
+          },
+        } as never)
+      })
+
+      act(() => {
+        result.current.handleDragEnd({
+          operation: {
+            target: {
+              id: 'browser:folder-1',
+              data: { type: 'folder', item: folders[0] },
+            },
+          },
+        } as never)
+      })
+
+      await vi.waitFor(() => {
+        expect(mockReparent).toHaveBeenCalledWith({
+          param: { projectId: 'proj-1' },
+          json: {
+            assetIds: ['stack-1'],
+            newParentId: 'folder-1',
+          },
+        })
+      })
+    })
+
+    it('does NOT execute reparentAssets when dropping a folder onto a version stack or file', () => {
+      const { result } = renderHook(
+        () =>
+          useFileSystemDnd({
+            teamId: 'team-1',
+            projectId: 'proj-1',
+            assetId: 'asset-1',
+            folders,
+            files,
+            selectedIds: new Set(),
+            onClearSelection: vi.fn(),
+          }),
+        { wrapper },
+      )
+
+      act(() => {
+        result.current.handleDragStart({
+          operation: {
+            source: {
+              id: 'browser:folder-1',
+              data: { type: 'folder', item: folders[0] },
+            },
+          },
+        } as never)
+      })
+
+      act(() => {
+        result.current.handleDragEnd({
+          operation: {
+            target: {
+              id: 'browser:stack-1',
+              data: { type: 'version_stack', item: files[2] },
+            },
+          },
+        } as never)
+      })
+
+      expect(mockReparent).not.toHaveBeenCalled()
+    })
+
+    it('does NOT execute reparentAssets when dropping multiple files onto a version stack or file', () => {
+      const selectedIds = new Set(['file-1', 'file-2'])
+      const { result } = renderHook(
+        () =>
+          useFileSystemDnd({
+            teamId: 'team-1',
+            projectId: 'proj-1',
+            assetId: 'asset-1',
+            folders,
+            files,
+            selectedIds,
+            onClearSelection: vi.fn(),
+          }),
+        { wrapper },
+      )
+
+      act(() => {
+        result.current.handleDragStart({
+          operation: {
+            source: {
+              id: 'browser:file-1',
+              data: { type: 'file', item: files[0] },
+            },
+          },
+        } as never)
+      })
+
+      act(() => {
+        result.current.handleDragEnd({
+          operation: {
+            target: {
+              id: 'browser:stack-1',
+              data: { type: 'version_stack', item: files[2] },
+            },
+          },
+        } as never)
+      })
+
+      expect(mockReparent).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/webui/components/use-file-system-dnd.ts
+++ b/packages/webui/components/use-file-system-dnd.ts
@@ -173,11 +173,15 @@ export function useFileSystemDnd({
     }
 
     const hasFolders = draggedItems.some((item) => item.type === 'folder')
+    const hasVersionStacks = draggedItems.some((item) => item.type === 'version_stack')
+    const isSingleFile = draggedItems.length === 1 && draggedItems[0].type === 'file'
 
     setDragState({
       isActive: true,
       draggedIds,
       hasFolders,
+      hasVersionStacks,
+      isSingleFile,
       itemCount: draggedIds.size,
     })
   }
@@ -242,9 +246,9 @@ export function useFileSystemDnd({
       if (targetData && !dragState.draggedIds.has(targetId)) {
         if (targetData.type === 'folder' || targetData.type === 'reorder') {
           isValid = true
-        } else if (targetData.type === 'file') {
-          // Can only drop single file onto single file
-          if (!dragState.hasFolders && dragState.itemCount === 1) {
+        } else if (targetData.type === 'file' || targetData.type === 'version_stack') {
+          // Can only drop single regular file onto file or version stack
+          if (dragState.isSingleFile) {
             isValid = true
           }
         }

--- a/packages/webui/components/use-file-system-dnd.ts
+++ b/packages/webui/components/use-file-system-dnd.ts
@@ -173,14 +173,13 @@ export function useFileSystemDnd({
     }
 
     const hasFolders = draggedItems.some((item) => item.type === 'folder')
-    const hasVersionStacks = draggedItems.some((item) => item.type === 'version_stack')
-    const isSingleFile = draggedItems.length === 1 && draggedItems[0].type === 'file'
+    const isSingleFile =
+      draggedIds.size === 1 && draggedItems.length === 1 && draggedItems[0].type === 'file'
 
     setDragState({
       isActive: true,
       draggedIds,
       hasFolders,
-      hasVersionStacks,
       isSingleFile,
       itemCount: draggedIds.size,
     })


### PR DESCRIPTION
## Summary

Disallow dragging and dropping a version stack onto another file or version stack in both WebUI and backend, preventing the creation of nested/corrupted version stacks.

## Changes

- **Backend (`packages/core/src/asset/asset.ts`)**:
  - In `reparentFileToFile`, validate that `sourceAsset.type === AssetType.file` and `destFile.type === AssetType.file`.
  - In `reparentAssets`, when moving into a `version_stack` target, strictly enforce that only 1 item is moved at a time (`assetIds.length === 1`) and the moved asset must be of type `AssetType.file`.
  - Added unit test coverage in `packages/core/src/asset/asset.test.ts` asserting rejections for version stack/folder moves onto files and version stacks.
- **Frontend (`packages/webui`)**:
  - Extended `DragState` in `dnd-types.ts` with `isSingleFile` and `hasVersionStacks`.
  - In `use-file-system-dnd.ts`, compute `isSingleFile` and only allow drop onto `file` or `version_stack` if `isSingleFile` is true.
  - In `file-card.tsx`, `file-list-item.tsx`, and `list-view.tsx`, preserve exact item types and ensure `isValidDropTarget` only activates for single regular file drops on file/version_stack targets.
  - Added comprehensive unit tests in `use-file-system-dnd.test.tsx`.

## Verification

All workspace checks pass simultaneously:
- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test` (142 test files, 1361 tests passed)
- `bun run test:e2e:app` (38 tests passed)
- `bun run test:e2e:webui` (9 tests passed)
- `bun run test:e2e:workflow` (13 test files, 56 tests passed)

## Notes

Moving version stacks into folders (reparenting) remains enabled and functional.