### PR TITLE
feat(webui): add manage versions option to file card context menu

### DIFF
--- a/packages/webui/components/file-browser/context-menu.test.tsx
+++ b/packages/webui/components/file-browser/context-menu.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { FileBrowserContextMenu } from './context-menu'
+import { ContextMenu, ContextMenuTrigger } from '@/ui/components/ui/context-menu'
+import type { AssetInfo } from '@shumai/dtos'
+
+describe('FileBrowserContextMenu', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  const stackItem: AssetInfo = {
+    id: 'stack-123',
+    name: 'version_stack_test',
+    type: 'version_stack',
+    status: 'processed',
+    fileCount: 2,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  } as AssetInfo
+
+  const fileItem: AssetInfo = {
+    id: 'file-123',
+    name: 'regular_file.png',
+    type: 'file',
+    status: 'processed',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  } as AssetInfo
+
+  const renderWithMenu = (
+    item: AssetInfo,
+    props: Partial<React.ComponentProps<typeof FileBrowserContextMenu>> = {},
+  ) => {
+    return render(
+      <ContextMenu>
+        <ContextMenuTrigger data-testid="context-trigger">Trigger</ContextMenuTrigger>
+        <FileBrowserContextMenu
+          item={item}
+          selectedIds={new Set()}
+          folders={[]}
+          files={[item]}
+          onRename={vi.fn()}
+          onDelete={vi.fn()}
+          onDownload={vi.fn()}
+          onRestore={vi.fn()}
+          onNewFolder={vi.fn()}
+          onUploadFile={vi.fn()}
+          onUploadFolder={vi.fn()}
+          onNewVersion={vi.fn()}
+          onManageVersions={vi.fn()}
+          onMoveTo={vi.fn()}
+          onCopyTo={vi.fn()}
+          canEdit={true}
+          {...props}
+        />
+      </ContextMenu>,
+    )
+  }
+
+  it('renders Manage versions for version_stack item when canEdit is true', () => {
+    const onManageVersions = vi.fn()
+    renderWithMenu(stackItem, { onManageVersions })
+
+    fireEvent.contextMenu(screen.getByTestId('context-trigger'))
+
+    const manageOption = screen.getByText(/Manage versions|管理版本/i)
+    expect(manageOption).toBeTruthy()
+
+    fireEvent.click(manageOption)
+    expect(onManageVersions).toHaveBeenCalledWith(stackItem)
+  })
+
+  it('does not render Manage versions for regular file item', () => {
+    renderWithMenu(fileItem)
+
+    fireEvent.contextMenu(screen.getByTestId('context-trigger'))
+
+    expect(screen.queryByText(/Manage versions|管理版本/i)).toBeNull()
+  })
+})

--- a/packages/webui/components/file-browser/context-menu.tsx
+++ b/packages/webui/components/file-browser/context-menu.tsx
@@ -22,6 +22,7 @@ import {
   Plus,
   ArrowRight,
   Copy,
+  Layers,
 } from 'lucide-react'
 
 interface FileBrowserContextMenuProps {
@@ -36,6 +37,7 @@ interface FileBrowserContextMenuProps {
   onUploadFile: () => void
   onUploadFolder: () => void
   onNewVersion: (item: AssetInfo) => void
+  onManageVersions?: (item: AssetInfo) => void
   onMoveTo: (items: AssetInfo[]) => void
   onCopyTo: (items: AssetInfo[]) => void
   folders: AssetInfo[]
@@ -63,6 +65,7 @@ export function FileBrowserContextMenu({
   onUploadFile,
   onUploadFolder,
   onNewVersion,
+  onManageVersions,
   onMoveTo,
   onCopyTo,
   folders,
@@ -293,6 +296,13 @@ export function FileBrowserContextMenu({
           <ContextMenuItem onSelect={() => onNewVersion(item)}>
             <UploadCloud className="mr-2 h-4 w-4" />
             <span>{m.create_new_version()}</span>
+          </ContextMenuItem>
+        )}
+
+        {canEdit && item.type === 'version_stack' && (
+          <ContextMenuItem onSelect={() => onManageVersions?.(item)}>
+            <Layers className="mr-2 h-4 w-4" />
+            <span>{m.manage_versions()}</span>
           </ContextMenuItem>
         )}
 

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -25,6 +25,7 @@ import { toast } from 'sonner'
 import { ulid } from 'ulid'
 import type { DragState } from '../dnd-types'
 import { MoveCopyDialog } from '../move-copy-dialog'
+import { ManageVersionsDialog } from '../manage-versions-dialog'
 import { FileBrowserContextMenu } from './context-menu'
 
 import {
@@ -146,6 +147,7 @@ export function FileBrowser({
   allowDownload = true,
 }: FileBrowserProps) {
   const [contextMenuItem, setContextMenuItem] = useState<AssetInfo | null>(null)
+  const [manageVersionsStackId, setManageVersionsStackId] = useState<string | null>(null)
   const [moveCopyMode, setMoveCopyMode] = useState<'move' | 'copy' | null>(null)
   const [itemsToMoveCopy, setItemsToMoveCopy] = useState<AssetInfo[]>([])
   const queryClient = useQueryClient()
@@ -671,6 +673,10 @@ export function FileBrowser({
       },
       dragState,
       onAction: (action: string, item: AssetInfo) => {
+        if (action === 'manage-versions') {
+          setManageVersionsStackId(item.id || null)
+          return
+        }
         if (isShareView) {
           if (action === 'remove-from-share') {
             const isSelected = selectedIds.has(item.id!)
@@ -1200,6 +1206,7 @@ export function FileBrowser({
           onUploadFile={handleUploadFilesClick}
           onUploadFolder={handleUploadFolderClick}
           onNewVersion={handleNewVersionClick}
+          onManageVersions={(item) => setManageVersionsStackId(item.id || null)}
           onMoveTo={(items) => {
             setItemsToMoveCopy(items)
             setMoveCopyMode('move')
@@ -1368,6 +1375,20 @@ export function FileBrowser({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {manageVersionsStackId && (
+        <ManageVersionsDialog
+          open={!!manageVersionsStackId}
+          onOpenChange={(open) => {
+            if (!open) setManageVersionsStackId(null)
+          }}
+          stackId={manageVersionsStackId}
+          canEdit={canEdit}
+          onStackDissolved={() => {
+            setManageVersionsStackId(null)
+          }}
+        />
+      )}
     </>
   )
 }

--- a/packages/webui/components/file-browser/file-card.test.tsx
+++ b/packages/webui/components/file-browser/file-card.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FileCard } from './file-card'
+import type { AssetInfo } from '@shumai/dtos'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('@dnd-kit/react', () => ({
+  useDraggable: () => ({
+    ref: vi.fn(),
+    isDragging: false,
+  }),
+  useDroppable: () => ({
+    ref: vi.fn(),
+    isDropTarget: false,
+  }),
+}))
+
+vi.mock('@/ui/api/client', () => ({
+  client: {
+    api: {
+      files: {
+        ':fileId': {
+          $get: vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({}),
+          }),
+        },
+      },
+    },
+  },
+}))
+
+describe('FileCard', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  const stackItem: AssetInfo = {
+    id: 'stack-123',
+    name: 'version_stack_test',
+    type: 'version_stack',
+    status: 'processed',
+    fileCount: 2,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  } as AssetInfo
+
+  const fileItem: AssetInfo = {
+    id: 'file-123',
+    name: 'regular_file.png',
+    type: 'file',
+    status: 'processed',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  } as AssetInfo
+
+  const renderComponent = (props: Partial<React.ComponentProps<typeof FileCard>> = {}) => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <FileCard
+          item={stackItem}
+          isSelected={false}
+          isChecked={false}
+          isEditing={false}
+          onSelect={vi.fn()}
+          onDoubleClick={vi.fn()}
+          onContextMenu={vi.fn()}
+          onDragStart={vi.fn()}
+          onDrop={vi.fn()}
+          onRename={vi.fn()}
+          onFinishEditing={vi.fn()}
+          onSaveField={vi.fn()}
+          fields={[]}
+          canEdit={true}
+          {...props}
+        />
+      </QueryClientProvider>,
+    )
+  }
+
+  it('renders Manage versions in 3-dot dropdown menu for version_stack item', () => {
+    const onAction = vi.fn()
+    renderComponent({ item: stackItem, onAction })
+
+    const moreBtn = screen.getByRole('button', { name: '' })
+    fireEvent.keyDown(moreBtn, { key: 'ArrowDown', code: 'ArrowDown' })
+
+    const manageItem = screen.getByText(/Manage versions|管理版本/i)
+    expect(manageItem).toBeTruthy()
+
+    fireEvent.click(manageItem)
+    expect(onAction).toHaveBeenCalledWith('manage-versions', stackItem)
+  })
+
+  it('does not render Manage versions in 3-dot dropdown menu for regular file item', () => {
+    renderComponent({ item: fileItem })
+
+    const moreBtn = screen.getByRole('button', { name: '' })
+    fireEvent.keyDown(moreBtn, { key: 'ArrowDown', code: 'ArrowDown' })
+
+    expect(screen.queryByText(/Manage versions|管理版本/i)).toBeNull()
+  })
+})

--- a/packages/webui/components/file-browser/file-card.tsx
+++ b/packages/webui/components/file-browser/file-card.tsx
@@ -21,7 +21,7 @@ import { selectFileNameWithoutExtension } from '@/ui/lib/rename-utils'
 import { cn } from '@/ui/lib/utils'
 import { useUploadStore } from '@/ui/stores/upload'
 import { useDraggable, useDroppable } from '@dnd-kit/react'
-import { Download, Edit, History, MoreHorizontal, Trash2 } from 'lucide-react'
+import { Download, Edit, History, Layers, MoreHorizontal, Trash2 } from 'lucide-react'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import type { DragState } from '../dnd-types'
 import FieldRenderer from '../field-renderer'
@@ -48,7 +48,7 @@ interface FileCardProps {
   dragState?: DragState
   disabled?: boolean
   onAction?: (
-    action: 'rename' | 'delete' | 'download' | 'restore' | 'remove-from-share',
+    action: 'rename' | 'delete' | 'download' | 'restore' | 'remove-from-share' | 'manage-versions',
     item: AssetInfo,
   ) => void
   isRecentlyDeleted?: boolean
@@ -373,6 +373,17 @@ export function FileCard({
                     >
                       <Edit className="mr-2 h-4 w-4" />
                       <span>{m.rename()}</span>
+                    </DropdownMenuItem>
+                  )}
+                  {canEdit && item.type === 'version_stack' && (
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onAction?.('manage-versions', item)
+                      }}
+                    >
+                      <Layers className="mr-2 h-4 w-4" />
+                      <span>{m.manage_versions()}</span>
                     </DropdownMenuItem>
                   )}
                   {allowDownload && (

--- a/packages/webui/components/manage-versions-dialog.tsx
+++ b/packages/webui/components/manage-versions-dialog.tsx
@@ -191,6 +191,9 @@ export function ManageVersionsDialog({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['version_stacks'] })
       queryClient.invalidateQueries({ queryKey: ['files'] })
+      queryClient.invalidateQueries({ queryKey: ['file'] })
+      queryClient.invalidateQueries({ queryKey: ['search'] })
+      queryClient.invalidateQueries({ queryKey: ['folders'] })
       queryClient.invalidateQueries({ queryKey: ['projects'] })
       toast.success(m.version_reordered_successfully())
     },
@@ -218,6 +221,9 @@ export function ManageVersionsDialog({
 
       queryClient.invalidateQueries({ queryKey: ['version_stacks'] })
       queryClient.invalidateQueries({ queryKey: ['files'] })
+      queryClient.invalidateQueries({ queryKey: ['file'] })
+      queryClient.invalidateQueries({ queryKey: ['search'] })
+      queryClient.invalidateQueries({ queryKey: ['folders'] })
       queryClient.invalidateQueries({ queryKey: ['projects'] })
 
       if (remaining.length <= 1) {


### PR DESCRIPTION
## Summary

Allows users to manage version stacks directly from the file list / grid page via right-click context menu and 3-dot dropdown menu, and ensures that version reordering / removal immediately updates the file list without requiring a manual page refresh.

## Changes

- **Context Menu**: Added `Manage versions` option to [`FileBrowserContextMenu`](packages/webui/components/file-browser/context-menu.tsx) when right-clicking on a `version_stack` asset.
- **File Card**: Added `Manage versions` option to [`FileCard`](packages/webui/components/file-browser/file-card.tsx) 3-dot action dropdown menu for `version_stack` assets.
- **File Browser**: Integrated [`ManageVersionsDialog`](packages/webui/components/manage-versions-dialog.tsx) into [`FileBrowser`](packages/webui/components/file-browser/file-browser.tsx) with state management.
- **Cache Invalidation Fix**: Added invalidations for `['search']`, `['folders']`, and `['file']` queries in [`ManageVersionsDialog`](packages/webui/components/manage-versions-dialog.tsx) on version reordering and removal mutations, resolving the issue where file list did not update after version changes.
- **Unit Tests**: Added unit tests in `context-menu.test.tsx` and `file-card.test.tsx`.

## Verification

- `bun run lint` passed.
- `bun run format` passed.
- `bun run typecheck` passed.
- `bun run test` passed (144 test files, 1367 tests).
- `bun run test:e2e:app` passed (38 tests).
- `bun run test:e2e:webui` passed (9 tests).
- `bun run test:e2e:workflow` passed (13 test files, 56 tests).

## Notes

None.