### PR TITLE
feat(webui): redesign comment attachment display into compact rows

### DIFF
--- a/packages/webui/components/chat/message-card.test.tsx
+++ b/packages/webui/components/chat/message-card.test.tsx
@@ -58,19 +58,12 @@ describe('MessageCard component', () => {
       completionLastChangedBy: null,
     }
 
-    const onViewAttachment = vi.fn()
     const onReply = vi.fn()
     const getUser = vi.fn().mockReturnValue({ id: 'u-1', name: 'Bob Reviewer' })
 
-    render(
-      <MessageCard
-        message={mockMessage}
-        getUser={getUser}
-        onReply={onReply}
-        onViewAttachment={onViewAttachment}
-      />,
-      { wrapper: createWrapper() },
-    )
+    render(<MessageCard message={mockMessage} getUser={getUser} onReply={onReply} />, {
+      wrapper: createWrapper(),
+    })
 
     expect(screen.getByText('Here is the feedback on design')).toBeDefined()
     expect(screen.getByText('screenshot.png')).toBeDefined()
@@ -91,9 +84,9 @@ describe('MessageCard component', () => {
     const psdRow = psdEl.closest('.group')
     expect(psdRow?.className).toContain('h-9')
 
-    // Clicking image row triggers onViewAttachment
+    // Clicking image row opens image preview dialog
     fireEvent.click(imgRow!)
-    expect(onViewAttachment).toHaveBeenCalledWith(mockMessage.attachments[0])
+    expect(screen.getAllByAltText('screenshot.png').length).toBeGreaterThanOrEqual(2)
 
     // Clicking file row opens URL in a new tab
     const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null)

--- a/packages/webui/components/chat/message-card.test.tsx
+++ b/packages/webui/components/chat/message-card.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+import React from 'react'
+import { cleanup, render, screen, fireEvent } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { CommentInfo } from '@shumai/dtos'
+import { MessageCard } from './message-card'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('MessageCard component', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('renders message text and attachment rows with 2x height for image and standard height for other files', () => {
+    const mockMessage: CommentInfo = {
+      id: 'msg-1',
+      assetId: 'asset-1',
+      message: 'Here is the feedback on design',
+      annotations: null,
+      second: null,
+      creator: { id: 'u-1', name: 'Bob Reviewer' },
+      replies: [],
+      attachments: [
+        {
+          id: 'att-img-1',
+          assetId: 'asset-1',
+          url: 'https://example.com/screenshot.png',
+          proxyType: 'image',
+        },
+        {
+          id: 'att-doc-2',
+          assetId: 'asset-1',
+          url: 'https://example.com/notes.pdf',
+          proxyType: 'pdf',
+        },
+      ],
+      mentions: [],
+      createdAt: '2026-08-20T10:30:00.000Z',
+      updatedAt: '2026-08-20T10:30:00.000Z',
+      sessionId: null,
+      isCompleted: false,
+      completionLastChangedBy: null,
+    }
+
+    const onViewAttachment = vi.fn()
+    const onReply = vi.fn()
+    const getUser = vi.fn().mockReturnValue({ id: 'u-1', name: 'Bob Reviewer' })
+
+    render(
+      <MessageCard
+        message={mockMessage}
+        getUser={getUser}
+        onReply={onReply}
+        onViewAttachment={onViewAttachment}
+      />,
+      { wrapper: createWrapper() },
+    )
+
+    expect(screen.getByText('Here is the feedback on design')).toBeDefined()
+    expect(screen.getByText('screenshot.png')).toBeDefined()
+    expect(screen.getByText('notes.pdf')).toBeDefined()
+
+    // Verify row height classes: image row is h-18 (72px), file row is h-9 (36px)
+    const imgEl = screen.getByAltText('screenshot.png')
+    const imgRow = imgEl.closest('.group')
+    expect(imgRow?.className).toContain('h-18')
+
+    const fileEl = screen.getByText('notes.pdf')
+    const fileRow = fileEl.closest('.group')
+    expect(fileRow?.className).toContain('h-9')
+
+    // Clicking image row triggers onViewAttachment
+    fireEvent.click(imgRow!)
+    expect(onViewAttachment).toHaveBeenCalledWith(mockMessage.attachments[0])
+
+    // Clicking file row opens URL in a new tab
+    const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    fireEvent.click(fileRow!)
+    expect(windowOpenSpy).toHaveBeenCalledWith(
+      'https://example.com/notes.pdf',
+      '_blank',
+      'noreferrer',
+    )
+    windowOpenSpy.mockRestore()
+  })
+})

--- a/packages/webui/components/chat/message-card.test.tsx
+++ b/packages/webui/components/chat/message-card.test.tsx
@@ -34,14 +34,20 @@ describe('MessageCard component', () => {
         {
           id: 'att-img-1',
           assetId: 'asset-1',
-          url: 'https://example.com/screenshot.png',
-          proxyType: 'image',
+          url: 'https://example.com/screenshot.png?AWSAccessKeyId=123',
+          proxyType: null,
         },
         {
           id: 'att-doc-2',
           assetId: 'asset-1',
-          url: 'https://example.com/notes.pdf',
-          proxyType: 'pdf',
+          url: 'https://example.com/notes.pdf?AWSAccessKeyId=123',
+          proxyType: null,
+        },
+        {
+          id: 'att-psd-3',
+          assetId: 'asset-1',
+          url: 'https://example.com/mockup.psd',
+          proxyType: null,
         },
       ],
       mentions: [],
@@ -69,6 +75,7 @@ describe('MessageCard component', () => {
     expect(screen.getByText('Here is the feedback on design')).toBeDefined()
     expect(screen.getByText('screenshot.png')).toBeDefined()
     expect(screen.getByText('notes.pdf')).toBeDefined()
+    expect(screen.getByText('mockup.psd')).toBeDefined()
 
     // Verify row height classes: image row is h-18 (72px), file row is h-9 (36px)
     const imgEl = screen.getByAltText('screenshot.png')
@@ -79,6 +86,11 @@ describe('MessageCard component', () => {
     const fileRow = fileEl.closest('.group')
     expect(fileRow?.className).toContain('h-9')
 
+    // PSD should NOT be an image row (web browsers cannot render PSD in <img>)
+    const psdEl = screen.getByText('mockup.psd')
+    const psdRow = psdEl.closest('.group')
+    expect(psdRow?.className).toContain('h-9')
+
     // Clicking image row triggers onViewAttachment
     fireEvent.click(imgRow!)
     expect(onViewAttachment).toHaveBeenCalledWith(mockMessage.attachments[0])
@@ -87,7 +99,7 @@ describe('MessageCard component', () => {
     const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
     fireEvent.click(fileRow!)
     expect(windowOpenSpy).toHaveBeenCalledWith(
-      'https://example.com/notes.pdf',
+      'https://example.com/notes.pdf?AWSAccessKeyId=123',
       '_blank',
       'noreferrer',
     )

--- a/packages/webui/components/chat/message-card.tsx
+++ b/packages/webui/components/chat/message-card.tsx
@@ -17,7 +17,7 @@ import {
   AlertDialogTitle,
 } from '@/ui/components/ui/alert-dialog'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/ui/components/ui/dialog'
-import type { AttachmentInfo, CommentInfo, UserInfo } from '@shumai/dtos'
+import type { CommentInfo, UserInfo } from '@shumai/dtos'
 import type { MemberInfo } from '@/ui/stores/members'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Download, FileText, MoreHorizontal, Trash2 } from 'lucide-react'
@@ -41,7 +41,6 @@ interface MessageCardProps {
   isLastReply?: boolean
   getUser: (id: string) => MemberInfo | UserInfo
   onReply: (message: CommentInfo) => void
-  onViewAttachment: (attachment: AttachmentInfo) => void
   isSelected?: boolean
   onSelect?: () => void
   frameRate?: number
@@ -102,7 +101,6 @@ export const MessageCard: React.FC<MessageCardProps> = ({
   isLastReply,
   getUser,
   onReply,
-  onViewAttachment,
   isSelected,
   onSelect,
   frameRate,
@@ -342,7 +340,6 @@ export const MessageCard: React.FC<MessageCardProps> = ({
                   onClick={() => {
                     if (isImage) {
                       setPreviewImage({ url: att.url, name })
-                      onViewAttachment?.(att)
                     } else {
                       window.open(att.url, '_blank', 'noreferrer')
                     }
@@ -376,7 +373,7 @@ export const MessageCard: React.FC<MessageCardProps> = ({
                     download={name}
                     className="p-1 text-muted-foreground hover:text-foreground shrink-0 rounded-md hover:bg-muted transition-colors opacity-0 group-hover:opacity-100"
                     onClick={(e) => e.stopPropagation()}
-                    title="Download"
+                    title={m.download()}
                   >
                     <Download className="w-3.5 h-3.5" />
                   </a>

--- a/packages/webui/components/chat/message-card.tsx
+++ b/packages/webui/components/chat/message-card.tsx
@@ -480,20 +480,20 @@ export const MessageCard: React.FC<MessageCardProps> = ({
       {/* Image Preview Dialog */}
       <Dialog open={!!previewImage} onOpenChange={(open) => !open && setPreviewImage(null)}>
         <DialogContent
-          className="max-w-4xl p-2 sm:p-4 bg-background/95 backdrop-blur-sm border-border flex flex-col items-center justify-center"
+          className="w-auto max-w-[80vw] sm:max-w-[80vw] max-h-[80vh] p-2 sm:p-3 bg-background/95 backdrop-blur-sm border-border flex flex-col items-center justify-center overflow-hidden"
           onClick={(e) => e.stopPropagation()}
         >
           <DialogHeader className="sr-only">
             <DialogTitle>{previewImage?.name || 'Image Preview'}</DialogTitle>
           </DialogHeader>
           {previewImage && (
-            <div className="w-full flex flex-col items-center justify-center gap-2">
+            <div className="flex flex-col items-center justify-center max-w-[80vw] max-h-[80vh] overflow-hidden">
               <img
                 src={previewImage.url}
                 alt={previewImage.name}
-                className="max-w-full max-h-[80vh] object-contain rounded-md"
+                className="max-w-[80vw] max-h-[calc(80vh-2.5rem)] w-auto h-auto object-contain rounded-md"
               />
-              <p className="text-xs text-muted-foreground truncate max-w-full px-2">
+              <p className="text-xs text-muted-foreground truncate max-w-full px-2 pt-1.5 text-center">
                 {previewImage.name}
               </p>
             </div>

--- a/packages/webui/components/chat/message-card.tsx
+++ b/packages/webui/components/chat/message-card.tsx
@@ -19,7 +19,7 @@ import {
 import type { AttachmentInfo, CommentInfo, UserInfo } from '@shumai/dtos'
 import type { MemberInfo } from '@/ui/stores/members'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Download, File, MoreHorizontal, Trash2 } from 'lucide-react'
+import { Download, FileText, MoreHorizontal, Trash2 } from 'lucide-react'
 import React from 'react'
 import Markdown from 'react-markdown'
 import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar'
@@ -325,39 +325,52 @@ export const MessageCard: React.FC<MessageCardProps> = ({
 
         {/* Attachments */}
         {message.attachments && message.attachments.length > 0 && (
-          <div className="flex flex-wrap gap-2 mt-3">
+          <div className="flex flex-col gap-1.5 mt-3 w-full">
             {message.attachments.map((att) => {
               const isImage = att.proxyType === 'image'
               const name = att.url?.split('/').pop()?.split('?')[0] || 'file'
               return (
                 <div
                   key={att.id}
-                  className="relative group rounded-lg overflow-hidden border bg-white shadow-sm hover:shadow-md transition-shadow w-48 h-32"
-                  onClick={() => isImage && onViewAttachment(att)}
+                  className={`group relative flex items-center w-full rounded-lg border border-border bg-card hover:bg-muted/40 transition-colors ${
+                    isImage ? 'h-18 p-1.5 gap-2.5 cursor-pointer' : 'h-9 px-2.5 gap-2.5'
+                  }`}
+                  onClick={() => {
+                    if (isImage) {
+                      onViewAttachment(att)
+                    } else {
+                      window.open(att.url, '_blank', 'noreferrer')
+                    }
+                  }}
                 >
                   {isImage ? (
-                    <img
-                      src={att.url}
-                      alt={name}
-                      className="w-full h-full object-cover cursor-pointer"
-                    />
-                  ) : (
-                    <div className="w-full h-full bg-gray-100 flex flex-col items-center justify-center p-2 text-center">
-                      <File className="w-8 h-8 text-gray-500 mb-2" />
-                      <span className="text-xs font-medium text-gray-700 break-all line-clamp-2">
-                        {name}
-                      </span>
+                    <div className="h-full aspect-square rounded-md overflow-hidden bg-muted/40 shrink-0">
+                      <img
+                        src={att.url}
+                        alt={name}
+                        className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-200"
+                      />
                     </div>
+                  ) : (
+                    <FileText className="w-4 h-4 text-muted-foreground shrink-0" />
                   )}
+
+                  <div className="min-w-0 flex-1">
+                    <p className="text-xs font-medium text-foreground truncate" title={name}>
+                      {name}
+                    </p>
+                  </div>
+
                   <a
                     href={att.url}
                     target="_blank"
                     rel="noreferrer"
                     download={name}
-                    className="absolute right-2 bottom-2 bg-black/60 text-white hover:bg-black/80 p-1.5 rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
+                    className="p-1 text-muted-foreground hover:text-foreground shrink-0 rounded-md hover:bg-muted transition-colors opacity-0 group-hover:opacity-100"
                     onClick={(e) => e.stopPropagation()}
+                    title="Download"
                   >
-                    <Download className="w-4 h-4" />
+                    <Download className="w-3.5 h-3.5" />
                   </a>
                 </div>
               )

--- a/packages/webui/components/chat/message-card.tsx
+++ b/packages/webui/components/chat/message-card.tsx
@@ -328,7 +328,7 @@ export const MessageCard: React.FC<MessageCardProps> = ({
 
         {/* Attachments */}
         {message.attachments && message.attachments.length > 0 && (
-          <div className="flex flex-col gap-1.5 mt-3 w-full">
+          <div className="flex flex-col gap-1.5 mt-3 w-full max-w-full overflow-hidden">
             {message.attachments.map((att) => {
               const rawName = att.url?.split('/').pop()?.split('?')[0] || 'file'
               const name = decodeURIComponent(rawName)
@@ -336,7 +336,7 @@ export const MessageCard: React.FC<MessageCardProps> = ({
               return (
                 <div
                   key={att.id}
-                  className={`group relative flex items-center w-full rounded-lg border border-border bg-card hover:bg-muted/40 transition-colors ${
+                  className={`group relative flex items-center w-full max-w-full rounded-lg border border-border bg-card hover:bg-muted/40 transition-colors overflow-hidden ${
                     isImage ? 'h-18 p-1.5 gap-2.5 cursor-pointer' : 'h-9 px-2.5 gap-2.5'
                   }`}
                   onClick={() => {
@@ -360,8 +360,11 @@ export const MessageCard: React.FC<MessageCardProps> = ({
                     <FileText className="w-4 h-4 text-muted-foreground shrink-0" />
                   )}
 
-                  <div className="min-w-0 flex-1">
-                    <p className="text-xs font-medium text-foreground truncate" title={name}>
+                  <div className="min-w-0 flex-1 overflow-hidden">
+                    <p
+                      className="text-xs font-medium text-foreground truncate block w-full"
+                      title={name}
+                    >
                       {name}
                     </p>
                   </div>

--- a/packages/webui/components/chat/message-card.tsx
+++ b/packages/webui/components/chat/message-card.tsx
@@ -16,6 +16,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/ui/components/ui/alert-dialog'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/ui/components/ui/dialog'
 import type { AttachmentInfo, CommentInfo, UserInfo } from '@shumai/dtos'
 import type { MemberInfo } from '@/ui/stores/members'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -30,6 +31,7 @@ import { m } from '@/ui/paraglide/messages.js'
 import { useUiStore } from '@/ui/stores/ui'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import { AgentSessionLogsDialog } from '../agent/agent-session-logs-dialog'
+import { isImageFileName } from '@/ui/lib/media'
 
 interface MessageCardProps {
   teamId?: string
@@ -116,6 +118,7 @@ export const MessageCard: React.FC<MessageCardProps> = ({
   const loadingText = (message.message && AI_PLACEHOLDERS[message.message]) || 'Generating...'
 
   const [isLogsOpen, setIsLogsOpen] = React.useState(false)
+  const [previewImage, setPreviewImage] = React.useState<{ url: string; name: string } | null>(null)
 
   const { videoTimeDisplayMode } = useUiStore()
   const displayTime = React.useMemo(() => {
@@ -327,8 +330,9 @@ export const MessageCard: React.FC<MessageCardProps> = ({
         {message.attachments && message.attachments.length > 0 && (
           <div className="flex flex-col gap-1.5 mt-3 w-full">
             {message.attachments.map((att) => {
-              const isImage = att.proxyType === 'image'
-              const name = att.url?.split('/').pop()?.split('?')[0] || 'file'
+              const rawName = att.url?.split('/').pop()?.split('?')[0] || 'file'
+              const name = decodeURIComponent(rawName)
+              const isImage = isImageFileName(name)
               return (
                 <div
                   key={att.id}
@@ -337,7 +341,8 @@ export const MessageCard: React.FC<MessageCardProps> = ({
                   }`}
                   onClick={() => {
                     if (isImage) {
-                      onViewAttachment(att)
+                      setPreviewImage({ url: att.url, name })
+                      onViewAttachment?.(att)
                     } else {
                       window.open(att.url, '_blank', 'noreferrer')
                     }
@@ -471,6 +476,30 @@ export const MessageCard: React.FC<MessageCardProps> = ({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Image Preview Dialog */}
+      <Dialog open={!!previewImage} onOpenChange={(open) => !open && setPreviewImage(null)}>
+        <DialogContent
+          className="max-w-4xl p-2 sm:p-4 bg-background/95 backdrop-blur-sm border-border flex flex-col items-center justify-center"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <DialogHeader className="sr-only">
+            <DialogTitle>{previewImage?.name || 'Image Preview'}</DialogTitle>
+          </DialogHeader>
+          {previewImage && (
+            <div className="w-full flex flex-col items-center justify-center gap-2">
+              <img
+                src={previewImage.url}
+                alt={previewImage.name}
+                className="max-w-full max-h-[80vh] object-contain rounded-md"
+              />
+              <p className="text-xs text-muted-foreground truncate max-w-full px-2">
+                {previewImage.name}
+              </p>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/packages/webui/components/file-viewer-right-sidebar.tsx
+++ b/packages/webui/components/file-viewer-right-sidebar.tsx
@@ -1,4 +1,4 @@
-import type { AssetInfo, AttachmentInfo, CommentInfo, FieldValueInfo } from '@shumai/dtos'
+import type { AssetInfo, CommentInfo, FieldValueInfo } from '@shumai/dtos'
 import { type FieldInfo as MetadataFieldInfo } from '@shumai/dtos'
 import type { MemberInfo } from '@/ui/stores/members'
 import { client } from '@/ui/api/client'
@@ -7,7 +7,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/components/ui/tab
 import { useFieldStore } from '@/ui/stores/fields'
 import type { Annotation } from '@/ui/types'
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { XIcon } from 'lucide-react'
 import React, { useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { MessageCard } from './chat/message-card'
@@ -56,7 +55,6 @@ export function FileViewerRightSidebar({
   const queryClient = useQueryClient()
   const { ref, inView } = useInView()
   const [replyingTo, setReplyingTo] = useState<CommentInfo | null>(null)
-  const [viewingAttachment, setViewingAttachment] = useState<AttachmentInfo | null>(null)
   const [isGuestPopupOpen, setIsGuestPopupOpen] = useState(false)
   const [pendingComment, setPendingComment] = useState<{
     text: string
@@ -290,26 +288,6 @@ export function FileViewerRightSidebar({
 
   return (
     <div className="bg-background h-full flex flex-col overflow-hidden">
-      {/* Lightbox */}
-      {viewingAttachment && viewingAttachment.proxyType === 'image' && (
-        <div
-          className="fixed inset-0 z-[100] bg-black/95 flex flex-col items-center justify-center p-4 animate-in fade-in duration-200"
-          onClick={() => setViewingAttachment(null)}
-        >
-          <button className="absolute top-4 right-4 text-white/70 hover:text-white bg-white/10 hover:bg-white/20 rounded-full p-2 transition-colors z-50">
-            <XIcon className="w-8 h-8" />
-          </button>
-
-          <div className="w-full h-full flex items-center justify-center p-2">
-            <img
-              src={viewingAttachment.url}
-              alt="Enlarged view"
-              className="max-w-full max-h-[85vh] object-contain rounded shadow-2xl cursor-zoom-out"
-              onClick={() => setViewingAttachment(null)}
-            />
-          </div>
-        </div>
-      )}
       <Tabs defaultValue="comments" className="p-1 flex-1 flex flex-col px-2 min-h-0">
         <TabsList className="w-full shrink-0">
           <TabsTrigger value="comments" className="flex-1">
@@ -329,7 +307,6 @@ export function FileViewerRightSidebar({
                     message={comment}
                     getUser={getUser}
                     onReply={setReplyingTo}
-                    onViewAttachment={setViewingAttachment}
                     hasReplies={!!comment.replies?.length}
                     formatTimestamp={viewerDef?.commentsConfig?.formatTimestamp}
                     frameRate={
@@ -355,7 +332,6 @@ export function FileViewerRightSidebar({
                         message={reply}
                         getUser={getUser}
                         onReply={setReplyingTo}
-                        onViewAttachment={setViewingAttachment}
                         hasReplies={false}
                         isLastReply={index === (comment.replies?.length ?? 0) - 1}
                         formatTimestamp={viewerDef?.commentsConfig?.formatTimestamp}

--- a/packages/webui/components/file-viewer/mobile-file-bottom-sheet.tsx
+++ b/packages/webui/components/file-viewer/mobile-file-bottom-sheet.tsx
@@ -12,10 +12,9 @@ import { m } from '@/ui/paraglide/messages.js'
 import { useFieldStore } from '@/ui/stores/fields'
 import type { MemberInfo } from '@/ui/stores/members'
 import type { Annotation } from '@/ui/types'
-import type { AssetInfo, AttachmentInfo, CommentInfo, FieldValueInfo } from '@shumai/dtos'
+import type { AssetInfo, CommentInfo, FieldValueInfo } from '@shumai/dtos'
 import { type FieldInfo as MetadataFieldInfo } from '@shumai/dtos'
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { XIcon } from 'lucide-react'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { toast } from 'sonner'
@@ -62,7 +61,6 @@ export function MobileFileBottomSheet({
   const queryClient = useQueryClient()
   const { ref, inView } = useInView()
   const [replyingTo, setReplyingTo] = useState<CommentInfo | null>(null)
-  const [viewingAttachment, setViewingAttachment] = useState<AttachmentInfo | null>(null)
   const [isGuestPopupOpen, setIsGuestPopupOpen] = useState(false)
   const [pendingComment, setPendingComment] = useState<{
     text: string
@@ -326,30 +324,6 @@ export function MobileFileBottomSheet({
       className="shrink-0 flex flex-col bg-background border-t border-border shadow-2xl rounded-t-2xl overflow-hidden select-none z-20"
       data-testid="mobile-bottom-sheet"
     >
-      {/* Lightbox for attachment viewing */}
-      {viewingAttachment && (
-        <div
-          className="fixed inset-0 z-[100] bg-black/95 flex flex-col items-center justify-center p-4 animate-in fade-in duration-200"
-          onClick={() => setViewingAttachment(null)}
-        >
-          <button
-            className="absolute top-4 right-4 text-white/70 hover:text-white bg-white/10 hover:bg-white/20 rounded-full p-2 transition-colors z-50"
-            aria-label={m.close()}
-          >
-            <XIcon className="w-8 h-8" />
-          </button>
-
-          <div className="w-full h-full flex items-center justify-center p-2">
-            <img
-              src={viewingAttachment.url}
-              alt={m.preview()}
-              className="max-w-full max-h-[85vh] object-contain rounded shadow-2xl cursor-zoom-out"
-              onClick={() => setViewingAttachment(null)}
-            />
-          </div>
-        </div>
-      )}
-
       {/* Drag Handle Bar */}
       <div
         onPointerDown={handlePointerDown}
@@ -405,7 +379,6 @@ export function MobileFileBottomSheet({
                       message={comment}
                       getUser={getUser}
                       onReply={setReplyingTo}
-                      onViewAttachment={setViewingAttachment}
                       hasReplies={!!comment.replies?.length}
                       formatTimestamp={viewerDef?.commentsConfig?.formatTimestamp}
                       frameRate={
@@ -431,7 +404,6 @@ export function MobileFileBottomSheet({
                           message={reply}
                           getUser={getUser}
                           onReply={setReplyingTo}
-                          onViewAttachment={setViewingAttachment}
                           hasReplies={false}
                           isLastReply={index === (comment.replies?.length ?? 0) - 1}
                           formatTimestamp={viewerDef?.commentsConfig?.formatTimestamp}

--- a/packages/webui/components/file-viewer/mobile-file-bottom-sheet.tsx
+++ b/packages/webui/components/file-viewer/mobile-file-bottom-sheet.tsx
@@ -327,7 +327,7 @@ export function MobileFileBottomSheet({
       data-testid="mobile-bottom-sheet"
     >
       {/* Lightbox for attachment viewing */}
-      {viewingAttachment && viewingAttachment.proxyType === 'image' && (
+      {viewingAttachment && (
         <div
           className="fixed inset-0 z-[100] bg-black/95 flex flex-col items-center justify-center p-4 animate-in fade-in duration-200"
           onClick={() => setViewingAttachment(null)}

--- a/packages/webui/components/kanban/edit-task-dialog/task-comment-card.tsx
+++ b/packages/webui/components/kanban/edit-task-dialog/task-comment-card.tsx
@@ -27,7 +27,7 @@ import {
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/ui/components/ui/dialog'
 import { formatSize } from '@/ui/lib/format'
 import { isImageFileName } from '@/ui/lib/media'
-import type { KanbanAttachmentInfo, KanbanCommentInfo } from '@shumai/dtos'
+import type { KanbanCommentInfo } from '@shumai/dtos'
 
 interface TaskCommentCardProps {
   teamId: string
@@ -35,7 +35,6 @@ interface TaskCommentCardProps {
   comment: KanbanCommentInfo
   currentUserId?: string
   isOwnerOrAdmin?: boolean
-  onViewAttachment?: (attachment: KanbanAttachmentInfo) => void
 }
 
 export function TaskCommentCard({
@@ -44,7 +43,6 @@ export function TaskCommentCard({
   comment,
   currentUserId,
   isOwnerOrAdmin,
-  onViewAttachment,
 }: TaskCommentCardProps) {
   const queryClient = useQueryClient()
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
@@ -158,7 +156,6 @@ export function TaskCommentCard({
                   onClick={() => {
                     if (isImage) {
                       setPreviewImage({ url: att.url, name: att.name })
-                      onViewAttachment?.(att)
                     } else {
                       window.open(att.url, '_blank', 'noreferrer')
                     }
@@ -197,7 +194,7 @@ export function TaskCommentCard({
                     rel="noreferrer"
                     className="p-1 text-muted-foreground hover:text-foreground shrink-0 rounded-md hover:bg-muted transition-colors opacity-0 group-hover/att:opacity-100"
                     onClick={(e) => e.stopPropagation()}
-                    title="Download"
+                    title={m.download()}
                   >
                     <Download className="w-3.5 h-3.5" />
                   </a>

--- a/packages/webui/components/kanban/edit-task-dialog/task-comment-card.tsx
+++ b/packages/webui/components/kanban/edit-task-dialog/task-comment-card.tsx
@@ -91,7 +91,7 @@ export function TaskCommentCard({
     .toUpperCase()
 
   return (
-    <div className="relative flex gap-3 p-3 rounded-xl border border-transparent bg-foreground/[0.03] dark:bg-foreground/[0.08] hover:bg-foreground/[0.06] dark:hover:bg-foreground/[0.12] transition-colors group">
+    <div className="relative flex gap-3 p-3 rounded-xl border border-transparent bg-foreground/[0.03] dark:bg-foreground/[0.08] hover:bg-foreground/[0.06] dark:hover:bg-foreground/[0.12] transition-colors group w-full max-w-full overflow-hidden">
       {/* Left Avatar */}
       <Avatar className="w-7 h-7 shrink-0 mt-0.5 border border-border">
         {comment.author.image && (
@@ -103,7 +103,7 @@ export function TaskCommentCard({
       </Avatar>
 
       {/* Main Content Area */}
-      <div className="flex-1 min-w-0 space-y-1.5">
+      <div className="flex-1 min-w-0 space-y-1.5 overflow-hidden">
         {/* Header: Author + Timestamp + Actions */}
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-2 min-w-0">
@@ -146,13 +146,13 @@ export function TaskCommentCard({
 
         {/* Attachments Section */}
         {comment.attachments && comment.attachments.length > 0 && (
-          <div className="flex flex-col gap-1.5 pt-1.5 w-full">
+          <div className="flex flex-col gap-1.5 pt-1.5 w-full max-w-full overflow-hidden">
             {comment.attachments.map((att) => {
               const isImage = isImageFileName(att.name || att.url)
               return (
                 <div
                   key={att.id}
-                  className={`group/att relative flex items-center w-full rounded-lg border border-border bg-card hover:bg-muted/40 transition-colors ${
+                  className={`group/att relative flex items-center w-full max-w-full rounded-lg border border-border bg-card hover:bg-muted/40 transition-colors overflow-hidden ${
                     isImage ? 'h-18 p-1.5 gap-2.5 cursor-pointer' : 'h-9 px-2.5 gap-2.5'
                   }`}
                   onClick={() => {
@@ -176,12 +176,15 @@ export function TaskCommentCard({
                     <FileText className="w-4 h-4 text-muted-foreground shrink-0" />
                   )}
 
-                  <div className="min-w-0 flex-1">
-                    <p className="text-xs font-medium text-foreground truncate" title={att.name}>
+                  <div className="min-w-0 flex-1 overflow-hidden">
+                    <p
+                      className="text-xs font-medium text-foreground truncate block w-full"
+                      title={att.name}
+                    >
                       {att.name}
                     </p>
                     {att.sizeByte !== undefined && att.sizeByte > 0 && (
-                      <p className="text-[10px] text-muted-foreground font-mono">
+                      <p className="text-[10px] text-muted-foreground font-mono truncate">
                         {formatSize(att.sizeByte)}
                       </p>
                     )}

--- a/packages/webui/components/kanban/edit-task-dialog/task-comment-card.tsx
+++ b/packages/webui/components/kanban/edit-task-dialog/task-comment-card.tsx
@@ -228,20 +228,20 @@ export function TaskCommentCard({
       {/* Image Preview Dialog */}
       <Dialog open={!!previewImage} onOpenChange={(open) => !open && setPreviewImage(null)}>
         <DialogContent
-          className="max-w-4xl p-2 sm:p-4 bg-background/95 backdrop-blur-sm border-border flex flex-col items-center justify-center"
+          className="w-auto max-w-[80vw] sm:max-w-[80vw] max-h-[80vh] p-2 sm:p-3 bg-background/95 backdrop-blur-sm border-border flex flex-col items-center justify-center overflow-hidden"
           onClick={(e) => e.stopPropagation()}
         >
           <DialogHeader className="sr-only">
             <DialogTitle>{previewImage?.name || 'Image Preview'}</DialogTitle>
           </DialogHeader>
           {previewImage && (
-            <div className="w-full flex flex-col items-center justify-center gap-2">
+            <div className="flex flex-col items-center justify-center max-w-[80vw] max-h-[80vh] overflow-hidden">
               <img
                 src={previewImage.url}
                 alt={previewImage.name}
-                className="max-w-full max-h-[80vh] object-contain rounded-md"
+                className="max-w-[80vw] max-h-[calc(80vh-2.5rem)] w-auto h-auto object-contain rounded-md"
               />
-              <p className="text-xs text-muted-foreground truncate max-w-full px-2">
+              <p className="text-xs text-muted-foreground truncate max-w-full px-2 pt-1.5 text-center">
                 {previewImage.name}
               </p>
             </div>

--- a/packages/webui/components/kanban/edit-task-dialog/task-comment-card.tsx
+++ b/packages/webui/components/kanban/edit-task-dialog/task-comment-card.tsx
@@ -143,62 +143,57 @@ export function TaskCommentCard({
 
         {/* Attachments Section */}
         {comment.attachments && comment.attachments.length > 0 && (
-          <div className="flex flex-wrap gap-2 pt-1.5">
+          <div className="flex flex-col gap-1.5 pt-1.5 w-full">
             {comment.attachments.map((att) => {
               const isImage = att.proxyType === 'image' || att.contentType?.startsWith('image/')
               return (
                 <div
                   key={att.id}
-                  className="relative group/att rounded-lg border border-border bg-card overflow-hidden transition-all duration-200"
+                  className={`group/att relative flex items-center w-full rounded-lg border border-border bg-card hover:bg-muted/40 transition-colors ${
+                    isImage ? 'h-18 p-1.5 gap-2.5 cursor-pointer' : 'h-9 px-2.5 gap-2.5'
+                  }`}
+                  onClick={() => {
+                    if (isImage) {
+                      onViewAttachment?.(att)
+                    } else {
+                      window.open(att.url, '_blank', 'noreferrer')
+                    }
+                  }}
                 >
                   {isImage ? (
-                    <div
-                      className="w-40 h-28 relative cursor-pointer overflow-hidden bg-muted/40"
-                      onClick={() => onViewAttachment?.(att)}
-                    >
+                    <div className="h-full aspect-square rounded-md overflow-hidden bg-muted/40 shrink-0">
                       <img
                         src={att.url}
                         alt={att.name}
                         className="w-full h-full object-cover group-hover/att:scale-105 transition-transform duration-200"
                       />
-                      <a
-                        href={att.url}
-                        download={att.name}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="absolute right-1.5 bottom-1.5 bg-black/60 hover:bg-black/80 text-white p-1 rounded-md opacity-0 group-hover/att:opacity-100 transition-opacity shadow-xs"
-                        onClick={(e) => e.stopPropagation()}
-                        title="Download"
-                      >
-                        <Download className="w-3.5 h-3.5" />
-                      </a>
                     </div>
                   ) : (
-                    <div className="flex items-center gap-2.5 p-2.5 max-w-[240px] bg-card hover:bg-muted/40 transition-colors">
-                      <FileText className="w-7 h-7 text-primary/80 shrink-0" />
-                      <div className="min-w-0 flex-1">
-                        <p
-                          className="text-xs font-medium text-foreground truncate"
-                          title={att.name}
-                        >
-                          {att.name}
-                        </p>
-                        <p className="text-[10px] text-muted-foreground font-mono">
-                          {formatSize(att.sizeByte)}
-                        </p>
-                      </div>
-                      <a
-                        href={att.url}
-                        download={att.name}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="p-1 text-muted-foreground hover:text-foreground shrink-0 rounded-md hover:bg-muted transition-colors"
-                        title="Download"
-                      >
-                        <Download className="w-3.5 h-3.5" />
-                      </a>
-                    </div>
+                    <FileText className="w-4 h-4 text-muted-foreground shrink-0" />
                   )}
+
+                  <div className="min-w-0 flex-1">
+                    <p className="text-xs font-medium text-foreground truncate" title={att.name}>
+                      {att.name}
+                    </p>
+                    {att.sizeByte !== undefined && att.sizeByte > 0 && (
+                      <p className="text-[10px] text-muted-foreground font-mono">
+                        {formatSize(att.sizeByte)}
+                      </p>
+                    )}
+                  </div>
+
+                  <a
+                    href={att.url}
+                    download={att.name}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="p-1 text-muted-foreground hover:text-foreground shrink-0 rounded-md hover:bg-muted transition-colors opacity-0 group-hover/att:opacity-100"
+                    onClick={(e) => e.stopPropagation()}
+                    title="Download"
+                  >
+                    <Download className="w-3.5 h-3.5" />
+                  </a>
                 </div>
               )
             })}

--- a/packages/webui/components/kanban/edit-task-dialog/task-comment-card.tsx
+++ b/packages/webui/components/kanban/edit-task-dialog/task-comment-card.tsx
@@ -24,7 +24,9 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/ui/components/ui/alert-dialog'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/ui/components/ui/dialog'
 import { formatSize } from '@/ui/lib/format'
+import { isImageFileName } from '@/ui/lib/media'
 import type { KanbanAttachmentInfo, KanbanCommentInfo } from '@shumai/dtos'
 
 interface TaskCommentCardProps {
@@ -46,6 +48,7 @@ export function TaskCommentCard({
 }: TaskCommentCardProps) {
   const queryClient = useQueryClient()
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+  const [previewImage, setPreviewImage] = useState<{ url: string; name: string } | null>(null)
 
   const canDelete = isOwnerOrAdmin || comment.author.id === currentUserId
 
@@ -145,7 +148,7 @@ export function TaskCommentCard({
         {comment.attachments && comment.attachments.length > 0 && (
           <div className="flex flex-col gap-1.5 pt-1.5 w-full">
             {comment.attachments.map((att) => {
-              const isImage = att.proxyType === 'image' || att.contentType?.startsWith('image/')
+              const isImage = isImageFileName(att.name || att.url)
               return (
                 <div
                   key={att.id}
@@ -154,6 +157,7 @@ export function TaskCommentCard({
                   }`}
                   onClick={() => {
                     if (isImage) {
+                      setPreviewImage({ url: att.url, name: att.name })
                       onViewAttachment?.(att)
                     } else {
                       window.open(att.url, '_blank', 'noreferrer')
@@ -220,6 +224,30 @@ export function TaskCommentCard({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Image Preview Dialog */}
+      <Dialog open={!!previewImage} onOpenChange={(open) => !open && setPreviewImage(null)}>
+        <DialogContent
+          className="max-w-4xl p-2 sm:p-4 bg-background/95 backdrop-blur-sm border-border flex flex-col items-center justify-center"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <DialogHeader className="sr-only">
+            <DialogTitle>{previewImage?.name || 'Image Preview'}</DialogTitle>
+          </DialogHeader>
+          {previewImage && (
+            <div className="w-full flex flex-col items-center justify-center gap-2">
+              <img
+                src={previewImage.url}
+                alt={previewImage.name}
+                className="max-w-full max-h-[80vh] object-contain rounded-md"
+              />
+              <p className="text-xs text-muted-foreground truncate max-w-full px-2">
+                {previewImage.name}
+              </p>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/packages/webui/components/kanban/edit-task-dialog/task-comment-thread.tsx
+++ b/packages/webui/components/kanban/edit-task-dialog/task-comment-thread.tsx
@@ -1,13 +1,12 @@
-import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { client } from '@/ui/api/client'
 import { m } from '@/ui/paraglide/messages.js'
 import { ScrollArea } from '@/ui/components/ui/scroll-area'
 import { toast } from 'sonner'
-import { Loader2, MessageSquare, X } from 'lucide-react'
+import { Loader2, MessageSquare } from 'lucide-react'
 import { TaskCommentCard } from './task-comment-card'
 import { TaskCommentInput } from './task-comment-input'
-import type { KanbanAttachmentInfo, KanbanAttachmentPayload, KanbanCommentInfo } from '@shumai/dtos'
+import type { KanbanAttachmentPayload, KanbanCommentInfo } from '@shumai/dtos'
 
 interface TaskCommentThreadProps {
   teamId: string
@@ -17,7 +16,6 @@ interface TaskCommentThreadProps {
 
 export function TaskCommentThread({ teamId, taskId, initialComments }: TaskCommentThreadProps) {
   const queryClient = useQueryClient()
-  const [viewingAttachment, setViewingAttachment] = useState<KanbanAttachmentInfo | null>(null)
 
   // Query Current User Info
   const { data: me } = useQuery({
@@ -92,32 +90,6 @@ export function TaskCommentThread({ teamId, taskId, initialComments }: TaskComme
 
   return (
     <div className="flex flex-col h-full overflow-hidden bg-background">
-      {/* Lightbox / Full-screen Attachment Viewer */}
-      {viewingAttachment && (
-        <div
-          className="fixed inset-0 z-50 bg-black/90 flex flex-col items-center justify-center p-4 animate-in fade-in duration-150"
-          onClick={() => setViewingAttachment(null)}
-        >
-          <button
-            type="button"
-            onClick={() => setViewingAttachment(null)}
-            className="absolute top-4 right-4 text-white/80 hover:text-white bg-white/10 hover:bg-white/20 rounded-full p-2 transition-colors z-50 cursor-pointer"
-            title="Close"
-          >
-            <X className="w-6 h-6" />
-          </button>
-
-          <div className="w-full h-full flex items-center justify-center p-2">
-            <img
-              src={viewingAttachment.url}
-              alt={viewingAttachment.name}
-              className="max-w-full max-h-[85vh] object-contain rounded-lg shadow-2xl"
-              onClick={(e) => e.stopPropagation()}
-            />
-          </div>
-        </div>
-      )}
-
       {/* Comments List */}
       <ScrollArea className="flex-1 min-h-0 p-3.5 [&>div>div]:block!">
         <div className="space-y-3 pr-1 pb-2 w-full max-w-full">
@@ -141,7 +113,6 @@ export function TaskCommentThread({ teamId, taskId, initialComments }: TaskComme
                 comment={comment}
                 currentUserId={me?.id}
                 isOwnerOrAdmin={isOwnerOrAdmin}
-                onViewAttachment={(att) => setViewingAttachment(att)}
               />
             ))
           )}

--- a/packages/webui/components/kanban/edit-task-dialog/task-comment-thread.tsx
+++ b/packages/webui/components/kanban/edit-task-dialog/task-comment-thread.tsx
@@ -119,8 +119,8 @@ export function TaskCommentThread({ teamId, taskId, initialComments }: TaskComme
       )}
 
       {/* Comments List */}
-      <ScrollArea className="flex-1 p-3.5">
-        <div className="space-y-3 pr-1 pb-2">
+      <ScrollArea className="flex-1 min-h-0 p-3.5 [&>div>div]:block!">
+        <div className="space-y-3 pr-1 pb-2 w-full max-w-full">
           {isLoading ? (
             <div className="flex items-center justify-center py-12">
               <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />

--- a/packages/webui/components/kanban/kanban.test.tsx
+++ b/packages/webui/components/kanban/kanban.test.tsx
@@ -464,12 +464,31 @@ describe('Kanban UI Unit & Component Tests', () => {
 
       expect(screen.getByText('Alice Author')).toBeDefined()
       expect(screen.getByText('bold')).toBeDefined()
+      expect(screen.getByText('preview.png')).toBeDefined()
       expect(screen.getByText('specs.pdf')).toBeDefined()
 
-      // Click image attachment
-      const img = screen.getByAltText('preview.png')
-      fireEvent.click(img)
+      // Verify row classes for 2x image height (h-18) vs standard file height (h-9)
+      const previewImg = screen.getByAltText('preview.png')
+      const imageRow = previewImg.closest('.group\\/att')
+      expect(imageRow?.className).toContain('h-18')
+
+      const pdfText = screen.getByText('specs.pdf')
+      const pdfRow = pdfText.closest('.group\\/att')
+      expect(pdfRow?.className).toContain('h-9')
+
+      // Click image attachment row
+      fireEvent.click(imageRow!)
       expect(onViewAttachment).toHaveBeenCalledWith(mockComment.attachments[0])
+
+      // Click PDF attachment row
+      const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+      fireEvent.click(pdfRow!)
+      expect(windowOpenSpy).toHaveBeenCalledWith(
+        'https://example.com/specs.pdf',
+        '_blank',
+        'noreferrer',
+      )
+      windowOpenSpy.mockRestore()
     })
 
     it('renders TaskCommentInput and triggers send on button click', async () => {

--- a/packages/webui/components/kanban/kanban.test.tsx
+++ b/packages/webui/components/kanban/kanban.test.tsx
@@ -449,7 +449,6 @@ describe('Kanban UI Unit & Component Tests', () => {
         updatedAt: '2026-08-20T00:00:00.000Z',
       }
 
-      const onViewAttachment = vi.fn()
       render(
         <TaskCommentCard
           teamId="team-1"
@@ -457,7 +456,6 @@ describe('Kanban UI Unit & Component Tests', () => {
           comment={mockComment}
           currentUserId="u-1"
           isOwnerOrAdmin={true}
-          onViewAttachment={onViewAttachment}
         />,
         { wrapper: createWrapper() },
       )
@@ -476,9 +474,9 @@ describe('Kanban UI Unit & Component Tests', () => {
       const pdfRow = pdfText.closest('.group\\/att')
       expect(pdfRow?.className).toContain('h-9')
 
-      // Click image attachment row
+      // Click image attachment row opens preview dialog
       fireEvent.click(imageRow!)
-      expect(onViewAttachment).toHaveBeenCalledWith(mockComment.attachments[0])
+      expect(screen.getAllByAltText('preview.png').length).toBeGreaterThanOrEqual(2)
 
       // Click PDF attachment row
       const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null)

--- a/packages/webui/lib/media.test.ts
+++ b/packages/webui/lib/media.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { isImageFileName, getBestTranscode } from './media'
+
+describe('isImageFileName', () => {
+  it('identifies web-supported image formats as images', () => {
+    expect(isImageFileName('photo.png')).toBe(true)
+    expect(isImageFileName('photo.jpg')).toBe(true)
+    expect(isImageFileName('photo.jpeg')).toBe(true)
+    expect(isImageFileName('photo.webp')).toBe(true)
+    expect(isImageFileName('animation.gif')).toBe(true)
+    expect(isImageFileName('icon.svg')).toBe(true)
+    expect(isImageFileName('image.avif')).toBe(true)
+    expect(isImageFileName('bitmap.bmp')).toBe(true)
+    expect(isImageFileName('favicon.ico')).toBe(true)
+  })
+
+  it('handles uppercase extensions and paths/urls with query params', () => {
+    expect(isImageFileName('PHOTO.PNG')).toBe(true)
+    expect(isImageFileName('PHOTO.JPEG')).toBe(true)
+    expect(isImageFileName('/path/to/my-image.webp')).toBe(true)
+  })
+
+  it('does not treat non-web-renderable or non-image files as images', () => {
+    expect(isImageFileName('design.psd')).toBe(false)
+    expect(isImageFileName('photo.raw')).toBe(false)
+    expect(isImageFileName('document.pdf')).toBe(false)
+    expect(isImageFileName('video.mp4')).toBe(false)
+    expect(isImageFileName('archive.zip')).toBe(false)
+    expect(isImageFileName('notes.txt')).toBe(false)
+    expect(isImageFileName('')).toBe(false)
+    expect(isImageFileName(null)).toBe(false)
+    expect(isImageFileName(undefined)).toBe(false)
+  })
+})
+
+describe('getBestTranscode', () => {
+  it('returns null if transcodes array is empty or undefined', () => {
+    expect(getBestTranscode(undefined, 800)).toBeNull()
+    expect(getBestTranscode([], 800)).toBeNull()
+  })
+
+  it('picks smallest transcode >= screenWidth or falls back to largest', () => {
+    const transcodes = [
+      { id: '1', width: 400, height: 300, url: '', key: '', size: 100 },
+      { id: '2', width: 800, height: 600, url: '', key: '', size: 200 },
+      { id: '3', width: 1200, height: 900, url: '', key: '', size: 300 },
+    ]
+    expect(getBestTranscode(transcodes, 700)?.width).toBe(800)
+    expect(getBestTranscode(transcodes, 1500)?.width).toBe(1200)
+  })
+})

--- a/packages/webui/lib/media.ts
+++ b/packages/webui/lib/media.ts
@@ -2,6 +2,13 @@ import type { ImageTranscode, VideoTranscode } from '@shumai/dtos'
 
 type Transcode = ImageTranscode | VideoTranscode
 
+const WEB_IMAGE_EXTENSION_REGEX = /\.(png|jpe?g|webp|gif|svg|avif|bmp|ico)$/i
+
+export function isImageFileName(filename?: string | null): boolean {
+  if (!filename) return false
+  return WEB_IMAGE_EXTENSION_REGEX.test(filename)
+}
+
 export function getBestTranscode(
   transcodes: Transcode[] | undefined,
   screenWidth: number,


### PR DESCRIPTION
## Summary

Redesigns attachment display in comment cards across both Kanban task comments and Media/File comments from large cards into a compact vertical list of row items with 2x height for web-supported images, file icons for other attachments, and a self-contained image preview dialog on click.

## Changes

- **Row-based Layout**: Replaced `w-48 h-32` and `w-40 h-28` cards with a clean `flex flex-col gap-1.5 w-full` vertical row layout in `MessageCard` and `TaskCommentCard`.
- **Image Rows**: Standardized image attachment rows to `h-18` (72px, exactly 2x of `h-9` 36px standard file rows) with a padded rounded image thumbnail on the left, truncated filename, and download button.
- **File Rows**: Standardized non-image file rows to `h-9` (36px) with a `FileText` icon on the left, truncated filename, size indicator (when available), and download button.
- **Pure Frontend Web-Supported Image Matching**: Added `isImageFileName` in `@/ui/lib/media` to detect web-displayable formats (`.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.svg`, `.avif`, `.bmp`, `.ico`) directly from filename/URL, correctly ignoring non-web image formats like `.psd`.
- **Image Preview Dialog**: Built self-contained `<Dialog>` modal preview into `MessageCard` and `TaskCommentCard` so clicking any web image row immediately displays the image in a modal viewer across all contexts.
- **Unit Tests**: Added unit test suites in `packages/webui/lib/media.test.ts` and `packages/webui/components/chat/message-card.test.tsx`, and updated `packages/webui/components/kanban/kanban.test.tsx`.

## Verification

- `bun run lint` (passed with 0 warnings)
- `bun run format` (passed)
- `bun run typecheck` (passed)
- `bun run test` (146 test files passed, 1381 tests passed)
- `bun run test:e2e:webui` (9 passed)
- `bun run test:e2e:workflow` (13 test files passed, 56 tests passed)
- `bun run test:e2e:app` (38 passed)

## Notes

No backend schema or migration changes needed. Works seamlessly with both existing and newly created comments and attachments.