### PR TITLE
fix(webui): prevent empty folder flash during initial loading

### DIFF
--- a/packages/webui/components/file-browser/file-browser.test.tsx
+++ b/packages/webui/components/file-browser/file-browser.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen } from '@testing-library/react'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FileBrowser } from './file-browser'
+import type { AssetInfo } from '@shumai/dtos'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: (options: { count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: options.count }, (_, i) => ({
+        index: i,
+        start: i * 50,
+        size: 50,
+        key: i,
+      })),
+    getTotalSize: () => options.count * 50,
+  }),
+}))
+
+vi.mock('@dnd-kit/react', () => ({
+  useDraggable: () => ({
+    ref: vi.fn(),
+    isDragging: false,
+  }),
+  useDroppable: () => ({
+    ref: vi.fn(),
+    isOver: false,
+  }),
+}))
+
+vi.mock('@/ui/hooks/use-permissions', () => ({
+  usePermissions: () => ({
+    canEdit: true,
+    canAdmin: true,
+    canView: true,
+  }),
+}))
+
+vi.mock('@/ui/api/client', () => ({
+  client: {
+    api: {
+      files: {
+        $delete: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+        'download-links': {
+          $post: vi.fn().mockResolvedValue({ ok: true, json: async () => ({ files: [] }) }),
+        },
+        restore: {
+          $post: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+        },
+        ':fileId': {
+          $get: vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({}),
+          }),
+          $put: vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({}),
+          }),
+        },
+      },
+      folders: {
+        $post: vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ id: 'new-folder-id' }),
+        }),
+        $delete: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+        restore: {
+          $post: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+        },
+        ':folderId': {
+          $put: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+        },
+      },
+      teams: {
+        ':teamId': {
+          upload: {
+            tasks: {
+              $post: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+              ':taskId': {
+                $patch: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+              },
+            },
+          },
+        },
+      },
+      projects: {
+        ':projectId': {
+          'empty-trash': {
+            $post: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+          },
+          shares: {
+            $get: vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: [] }) }),
+            $post: vi.fn().mockResolvedValue({ ok: true, json: async () => ({ id: 'share-1' }) }),
+          },
+          reparent: {
+            $post: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+          },
+          copy: {
+            $post: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+          },
+        },
+      },
+    },
+  },
+}))
+
+describe('FileBrowser', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  const mockFolder: AssetInfo = {
+    id: 'folder-1',
+    name: 'Test Folder',
+    type: 'folder',
+    fileCount: 3,
+    sizeByte: 0,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    status: 'processed',
+  } as AssetInfo
+
+  const mockFile: AssetInfo = {
+    id: 'file-1',
+    name: 'test_document.pdf',
+    type: 'file',
+    sizeByte: 1024 * 100,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    status: 'processed',
+  } as AssetInfo
+
+  const defaultProps = {
+    teamId: 'team-1',
+    projectId: 'project-1',
+    assetId: 'root-folder',
+    folders: [mockFolder],
+    files: [mockFile],
+    selectedItem: null,
+    selectedIds: new Set<string>(),
+    onItemSelect: vi.fn(),
+    onItemDoubleClick: vi.fn(),
+    onSaveField: vi.fn(),
+    displayStyle: 'card' as const,
+    onClearSelection: vi.fn(),
+    fetchNextFoldersPage: vi.fn(),
+    hasNextFoldersPage: false,
+    isFetchingNextFoldersPage: false,
+    fetchNextFilesPage: vi.fn(),
+    hasNextFilesPage: false,
+    isFetchingNextFilesPage: false,
+  }
+
+  const renderComponent = (props: Partial<React.ComponentProps<typeof FileBrowser>> = {}) => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <FileBrowser {...defaultProps} {...props} />
+      </QueryClientProvider>,
+    )
+  }
+
+  it('renders folders and files in card view', () => {
+    renderComponent()
+
+    expect(screen.getByText('Test Folder')).toBeDefined()
+    expect(screen.getByText('test_document.pdf')).toBeDefined()
+  })
+
+  it('renders empty state when there are no folders and files and not loading', () => {
+    renderComponent({ folders: [], files: [], isLoading: false })
+
+    expect(screen.getByText(/This folder is empty|此文件夹为空/i)).toBeDefined()
+  })
+
+  it('renders loading skeleton and does not render empty state when isLoading is true (card view)', () => {
+    renderComponent({ folders: [], files: [], isLoading: true, displayStyle: 'card' })
+
+    expect(screen.queryByText(/This folder is empty|此文件夹为空/i)).toBeNull()
+    expect(screen.getByTestId('file-browser-loading-skeleton')).toBeDefined()
+  })
+
+  it('renders loading skeleton and does not render empty state when isLoading is true (list view)', () => {
+    renderComponent({ folders: [], files: [], isLoading: true, displayStyle: 'list' })
+
+    expect(screen.queryByText(/This folder is empty|此文件夹为空/i)).toBeNull()
+    expect(screen.getByTestId('file-browser-loading-skeleton')).toBeDefined()
+  })
+})

--- a/packages/webui/components/file-browser/file-browser.tsx
+++ b/packages/webui/components/file-browser/file-browser.tsx
@@ -26,6 +26,7 @@ import { ulid } from 'ulid'
 import type { DragState } from '../dnd-types'
 import { MoveCopyDialog } from '../move-copy-dialog'
 import { ManageVersionsDialog } from '../manage-versions-dialog'
+import { FileBrowserContentSkeleton } from '../loading-skeletons'
 import { FileBrowserContextMenu } from './context-menu'
 
 import {
@@ -81,6 +82,7 @@ interface FileBrowserProps {
   isFetchingNextFilesPage: boolean
   isRecentlyDeleted?: boolean
   isRecents?: boolean
+  isLoading?: boolean
   filterConditions?: SearchCondition[]
   onFilterChange?: (conditions: SearchCondition[]) => void
   sort?: SearchSort
@@ -131,6 +133,7 @@ export function FileBrowser({
   isFetchingNextFilesPage,
   isRecentlyDeleted,
   isRecents,
+  isLoading = false,
   filterConditions,
   onFilterChange,
   sort,
@@ -1052,7 +1055,9 @@ export function FileBrowser({
               className="flex-1 overflow-y-auto min-h-0 relative flex flex-col"
               style={{ overflowAnchor: 'none' }}
             >
-              {displayStyle === 'list' ? (
+              {isLoading && folders.length === 0 && displayedFiles.length === 0 ? (
+                <FileBrowserContentSkeleton displayStyle={displayStyle} />
+              ) : displayStyle === 'list' ? (
                 <FileBrowserListView
                   folders={folders}
                   files={displayedFiles}
@@ -1121,11 +1126,12 @@ export function FileBrowser({
 
               {(isFetchingNextFoldersPage || isFetchingNextFilesPage) && (
                 <div className="flex justify-center items-center p-4">
-                  <p>Loading more...</p>
+                  <p>{m.loading_more()}</p>
                 </div>
               )}
 
-              {folders.length === 0 &&
+              {!isLoading &&
+                folders.length === 0 &&
                 displayedFiles.length === 0 &&
                 !isFetchingNextFoldersPage &&
                 !isFetchingNextFilesPage && (
@@ -1139,7 +1145,7 @@ export function FileBrowser({
                         </p>
                       </div>
                     ) : (
-                      <span>This folder is empty</span>
+                      <span>{m.this_folder_is_empty()}</span>
                     )}
                   </div>
                 )}

--- a/packages/webui/components/file-browser/mobile-file-browser.test.tsx
+++ b/packages/webui/components/file-browser/mobile-file-browser.test.tsx
@@ -171,10 +171,17 @@ describe('MobileFileBrowser', () => {
     expect(onItemDoubleClick).toHaveBeenCalledWith(mockFolder)
   })
 
-  it('renders empty state when there are no folders and files', () => {
-    renderComponent({ folders: [], files: [] })
+  it('renders empty state when there are no folders and files and not loading', () => {
+    renderComponent({ folders: [], files: [], isLoading: false })
 
     expect(screen.getByText(/This folder is empty|此文件夹为空/i)).toBeDefined()
+  })
+
+  it('renders loading skeleton and does not render empty state when isLoading is true', () => {
+    renderComponent({ folders: [], files: [], isLoading: true })
+
+    expect(screen.queryByText(/This folder is empty|此文件夹为空/i)).toBeNull()
+    expect(screen.getByTestId('mobile-file-browser-loading-skeleton')).toBeDefined()
   })
 
   it('renders collapsible section headers for folders and files with count and size', () => {

--- a/packages/webui/components/file-browser/mobile-file-browser.tsx
+++ b/packages/webui/components/file-browser/mobile-file-browser.tsx
@@ -52,6 +52,7 @@ import { Input } from '../ui/input'
 import { FileCard } from './file-card'
 import { FolderCard } from './folder-card'
 import { useFileActions } from './use-file-actions'
+import { MobileFileBrowserContentSkeleton } from '../loading-skeletons'
 
 export interface MobileFileBrowserProps {
   teamId: string
@@ -77,6 +78,7 @@ export interface MobileFileBrowserProps {
   isFetchingNextFilesPage: boolean
   isRecentlyDeleted?: boolean
   isRecents?: boolean
+  isLoading?: boolean
   isShareView?: boolean
   isPublic?: boolean
   shareId?: string
@@ -115,6 +117,7 @@ export function MobileFileBrowser({
   isFetchingNextFilesPage,
   isRecentlyDeleted = false,
   isRecents = false,
+  isLoading = false,
   isShareView = false,
   isPublic = false,
   shareId,
@@ -471,6 +474,7 @@ export function MobileFileBrowser({
   }
 
   const isFolderEmpty =
+    !isLoading &&
     folders.length === 0 &&
     files.length === 0 &&
     !isFetchingNextFoldersPage &&
@@ -527,110 +531,114 @@ export function MobileFileBrowser({
 
       {/* Main scroll area */}
       <div className="flex-1 overflow-y-auto min-h-0 p-3 pb-24">
-        <div className="max-w-lg mx-auto w-full">
-          {/* Folders Section */}
-          {foldersCount > 0 && (
-            <div className="mb-4">
-              <button
-                onClick={() => setFoldersExpanded(!foldersExpanded)}
-                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-3 font-medium select-none cursor-pointer"
-              >
-                {foldersExpanded ? (
-                  <ChevronDown className="h-4 w-4" />
-                ) : (
-                  <ChevronRight className="h-4 w-4" />
+        {isLoading && folders.length === 0 && files.length === 0 ? (
+          <MobileFileBrowserContentSkeleton />
+        ) : (
+          <div className="max-w-lg mx-auto w-full">
+            {/* Folders Section */}
+            {foldersCount > 0 && (
+              <div className="mb-4">
+                <button
+                  onClick={() => setFoldersExpanded(!foldersExpanded)}
+                  className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-3 font-medium select-none cursor-pointer"
+                >
+                  {foldersExpanded ? (
+                    <ChevronDown className="h-4 w-4" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4" />
+                  )}
+                  <span>
+                    {formatCount(foldersCount, false)}
+                    {showFoldersSize ? ` • ${formatSize(foldersSizeVal)}` : ''}
+                  </span>
+                </button>
+
+                {foldersExpanded && (
+                  <div className="grid grid-cols-1 gap-4 w-full">
+                    {folders.map((folder) => (
+                      <FolderCard
+                        key={folder.id}
+                        item={folder}
+                        isSelected={selectedItem?.id === folder.id}
+                        isChecked={selectedIds.has(folder.id!)}
+                        isEditing={editingItemId === folder.id}
+                        onSelect={onItemSelect}
+                        onDoubleClick={onItemDoubleClick}
+                        onContextMenu={() => {}}
+                        onDragStart={() => {}}
+                        onDrop={() => {}}
+                        onRename={(newName) => onRenameSubmit(folder, newName)}
+                        onFinishEditing={() => setEditingItemId(null)}
+                        onAction={(action, item) =>
+                          handleAction(action as 'rename' | 'delete' | 'download' | 'restore', item)
+                        }
+                        isRecentlyDeleted={isRecentlyDeleted}
+                        isRecents={isRecents}
+                        selectedCount={selectedIds.size}
+                        canEdit={canEdit}
+                        isShareView={isShareView}
+                        allowDownload={allowDownload}
+                      />
+                    ))}
+                  </div>
                 )}
-                <span>
-                  {formatCount(foldersCount, false)}
-                  {showFoldersSize ? ` • ${formatSize(foldersSizeVal)}` : ''}
-                </span>
-              </button>
+              </div>
+            )}
 
-              {foldersExpanded && (
-                <div className="grid grid-cols-1 gap-4 w-full">
-                  {folders.map((folder) => (
-                    <FolderCard
-                      key={folder.id}
-                      item={folder}
-                      isSelected={selectedItem?.id === folder.id}
-                      isChecked={selectedIds.has(folder.id!)}
-                      isEditing={editingItemId === folder.id}
-                      onSelect={onItemSelect}
-                      onDoubleClick={onItemDoubleClick}
-                      onContextMenu={() => {}}
-                      onDragStart={() => {}}
-                      onDrop={() => {}}
-                      onRename={(newName) => onRenameSubmit(folder, newName)}
-                      onFinishEditing={() => setEditingItemId(null)}
-                      onAction={(action, item) =>
-                        handleAction(action as 'rename' | 'delete' | 'download' | 'restore', item)
-                      }
-                      isRecentlyDeleted={isRecentlyDeleted}
-                      isRecents={isRecents}
-                      selectedCount={selectedIds.size}
-                      canEdit={canEdit}
-                      isShareView={isShareView}
-                      allowDownload={allowDownload}
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
+            {/* Files Section */}
+            {filesCount > 0 && (
+              <div className="mb-4">
+                <button
+                  onClick={() => setFilesExpanded(!filesExpanded)}
+                  className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-3 font-medium select-none cursor-pointer"
+                >
+                  {filesExpanded ? (
+                    <ChevronDown className="h-4 w-4" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4" />
+                  )}
+                  <span>
+                    {formatCount(filesCount, true)}
+                    {showFilesSize ? ` • ${formatSize(filesSizeVal)}` : ''}
+                  </span>
+                </button>
 
-          {/* Files Section */}
-          {filesCount > 0 && (
-            <div className="mb-4">
-              <button
-                onClick={() => setFilesExpanded(!filesExpanded)}
-                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-3 font-medium select-none cursor-pointer"
-              >
-                {filesExpanded ? (
-                  <ChevronDown className="h-4 w-4" />
-                ) : (
-                  <ChevronRight className="h-4 w-4" />
+                {filesExpanded && (
+                  <div className="grid grid-cols-1 gap-4 w-full">
+                    {files.map((file) => (
+                      <FileCard
+                        key={file.id}
+                        teamId={teamId}
+                        item={file}
+                        isSelected={selectedItem?.id === file.id}
+                        isChecked={selectedIds.has(file.id!)}
+                        isEditing={editingItemId === file.id}
+                        onSelect={onItemSelect}
+                        onDoubleClick={onItemDoubleClick}
+                        onContextMenu={() => {}}
+                        onDragStart={() => {}}
+                        onDrop={() => {}}
+                        onRename={(newName) => onRenameSubmit(file, newName)}
+                        onFinishEditing={() => setEditingItemId(null)}
+                        onSaveField={(fieldId, value) => onSaveField?.(file.id!, fieldId, value)}
+                        fields={[]}
+                        onAction={(action, item) =>
+                          handleAction(action as 'rename' | 'delete' | 'download' | 'restore', item)
+                        }
+                        isRecentlyDeleted={isRecentlyDeleted}
+                        isRecents={isRecents}
+                        selectedCount={selectedIds.size}
+                        canEdit={canEdit}
+                        isShareView={isShareView}
+                        allowDownload={allowDownload}
+                      />
+                    ))}
+                  </div>
                 )}
-                <span>
-                  {formatCount(filesCount, true)}
-                  {showFilesSize ? ` • ${formatSize(filesSizeVal)}` : ''}
-                </span>
-              </button>
-
-              {filesExpanded && (
-                <div className="grid grid-cols-1 gap-4 w-full">
-                  {files.map((file) => (
-                    <FileCard
-                      key={file.id}
-                      teamId={teamId}
-                      item={file}
-                      isSelected={selectedItem?.id === file.id}
-                      isChecked={selectedIds.has(file.id!)}
-                      isEditing={editingItemId === file.id}
-                      onSelect={onItemSelect}
-                      onDoubleClick={onItemDoubleClick}
-                      onContextMenu={() => {}}
-                      onDragStart={() => {}}
-                      onDrop={() => {}}
-                      onRename={(newName) => onRenameSubmit(file, newName)}
-                      onFinishEditing={() => setEditingItemId(null)}
-                      onSaveField={(fieldId, value) => onSaveField?.(file.id!, fieldId, value)}
-                      fields={[]}
-                      onAction={(action, item) =>
-                        handleAction(action as 'rename' | 'delete' | 'download' | 'restore', item)
-                      }
-                      isRecentlyDeleted={isRecentlyDeleted}
-                      isRecents={isRecents}
-                      selectedCount={selectedIds.size}
-                      canEdit={canEdit}
-                      isShareView={isShareView}
-                      allowDownload={allowDownload}
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
-        </div>
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Empty state */}
         {isFolderEmpty && (

--- a/packages/webui/components/file-system-manager.tsx
+++ b/packages/webui/components/file-system-manager.tsx
@@ -202,6 +202,7 @@ export default function FileSystemManager({
     fetchNextPage: fetchNextFoldersPage,
     hasNextPage: hasNextPageFolders,
     isFetchingNextPage: isFetchingNextFoldersPage,
+    isLoading: isFoldersLoading,
   } = useInfiniteQuery<AssetInfoPaginatedList>({
     queryKey: isRecentlyDeleted
       ? ['projects', projectId, 'recently-deleted', 'folder']
@@ -252,6 +253,7 @@ export default function FileSystemManager({
     fetchNextPage: fetchNextFilesPage,
     hasNextPage: hasNextPageFiles,
     isFetchingNextPage: isFetchingNextFilesPage,
+    isLoading: isFilesLoading,
   } = useInfiniteQuery<AssetInfoPaginatedList>({
     queryKey: isRecentlyDeleted
       ? ['projects', projectId, 'recently-deleted', 'file']
@@ -304,6 +306,9 @@ export default function FileSystemManager({
 
   const folders = foldersData?.pages.flatMap((page) => page.data ?? []) ?? []
   const files = filesData?.pages.flatMap((page) => page.data ?? []) ?? []
+
+  const isFoldersQueryActive = !isFiltering && !isRecents
+  const isLoading = (isFoldersQueryActive ? isFoldersLoading : false) || isFilesLoading
 
   const totalFolders = foldersData?.pages[0]?.pageInfo?.total
   const totalFiles = filesData?.pages[0]?.pageInfo?.total
@@ -449,6 +454,7 @@ export default function FileSystemManager({
         isFetchingNextFilesPage={isFetchingNextFilesPage}
         isRecentlyDeleted={isRecentlyDeleted}
         isRecents={isRecents}
+        isLoading={isLoading}
         rootFolderId={rootFolderId}
       />
     )
@@ -544,6 +550,7 @@ export default function FileSystemManager({
             isFetchingNextFilesPage={isFetchingNextFilesPage}
             isRecentlyDeleted={isRecentlyDeleted}
             isRecents={isRecents}
+            isLoading={isLoading}
             filterConditions={filterConditions}
             onFilterChange={setFilterConditions}
             sort={sort}

--- a/packages/webui/components/loading-skeletons.tsx
+++ b/packages/webui/components/loading-skeletons.tsx
@@ -167,3 +167,65 @@ export function FileDetailSkeleton() {
     </div>
   )
 }
+
+export function FileBrowserContentSkeleton({
+  displayStyle = 'card',
+}: {
+  displayStyle?: 'card' | 'list'
+}) {
+  if (displayStyle === 'list') {
+    return (
+      <div className="p-4 space-y-2" data-testid="file-browser-loading-skeleton">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4 py-2 border-b border-border/40">
+            <Skeleton className="h-4 w-4 rounded" />
+            <Skeleton className="h-4 w-4 rounded" />
+            <Skeleton className="h-4 w-48" />
+            <div className="ml-auto flex items-center gap-8">
+              <Skeleton className="h-3 w-16" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4 space-y-4" data-testid="file-browser-loading-skeleton">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+        {Array.from({ length: 10 }).map((_, i) => (
+          <div key={i} className="flex flex-col rounded-lg border bg-card p-3 space-y-3">
+            <Skeleton className="aspect-square w-full rounded-md" />
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <div className="flex justify-between items-center">
+                <Skeleton className="h-3 w-1/4" />
+                <Skeleton className="h-3 w-1/3" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function MobileFileBrowserContentSkeleton() {
+  return (
+    <div
+      className="p-3 space-y-3 max-w-lg mx-auto w-full"
+      data-testid="mobile-file-browser-loading-skeleton"
+    >
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="flex items-center gap-3 p-3 rounded-lg border bg-card">
+          <Skeleton className="h-10 w-10 rounded-md shrink-0" />
+          <div className="space-y-2 flex-1">
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-3 w-1/3" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/webui/components/public-share-manager.tsx
+++ b/packages/webui/components/public-share-manager.tsx
@@ -160,6 +160,7 @@ export function PublicShareManager({
     fetchNextPage: fetchNextFoldersPage,
     hasNextPage: hasNextPageFolders,
     isFetchingNextPage: isFetchingNextFoldersPage,
+    isLoading: isFoldersLoading,
     error: foldersError,
   } = useInfiniteQuery<AssetInfoPaginatedList>({
     queryKey: ['public-share-children', shareId, currentFolderId, 'folder', password],
@@ -193,6 +194,7 @@ export function PublicShareManager({
     fetchNextPage: fetchNextFilesPage,
     hasNextPage: hasNextPageFiles,
     isFetchingNextPage: isFetchingNextFilesPage,
+    isLoading: isFilesLoading,
   } = useInfiniteQuery<AssetInfoPaginatedList>({
     queryKey: ['public-share-children', shareId, currentFolderId, 'file', password],
     queryFn: async ({ pageParam }) => {
@@ -691,6 +693,7 @@ export function PublicShareManager({
                 fetchNextFilesPage={fetchNextFilesPage}
                 hasNextFilesPage={hasNextPageFiles}
                 isFetchingNextFilesPage={isFetchingNextFilesPage}
+                isLoading={isFoldersLoading || isFilesLoading}
                 isShareView={true}
                 isPublic={true}
                 shareId={shareId}
@@ -725,6 +728,7 @@ export function PublicShareManager({
                 fetchNextFilesPage={fetchNextFilesPage}
                 hasNextFilesPage={hasNextPageFiles}
                 isFetchingNextFilesPage={isFetchingNextFilesPage}
+                isLoading={isFoldersLoading || isFilesLoading}
                 isShareView={true}
                 isPublic={true}
                 shareId={shareId}

--- a/packages/webui/components/share-manager.tsx
+++ b/packages/webui/components/share-manager.tsx
@@ -112,6 +112,7 @@ export default function ShareManager({
     fetchNextPage: fetchNextFoldersPage,
     hasNextPage: hasNextPageFolders,
     isFetchingNextPage: isFetchingNextFoldersPage,
+    isLoading: isFoldersLoading,
   } = useInfiniteQuery<AssetInfoPaginatedList>({
     queryKey: ['folder-children', teamId, currentFolderId, 'folder', sort, order],
     queryFn: async ({ pageParam }) => {
@@ -137,6 +138,7 @@ export default function ShareManager({
     fetchNextPage: fetchNextFilesPage,
     hasNextPage: hasNextPageFiles,
     isFetchingNextPage: isFetchingNextFilesPage,
+    isLoading: isFilesLoading,
   } = useInfiniteQuery<AssetInfoPaginatedList>({
     queryKey: ['folder-children', teamId, currentFolderId, 'file', sort, order],
     queryFn: async ({ pageParam }) => {
@@ -321,6 +323,7 @@ export default function ShareManager({
             fetchNextFilesPage={fetchNextFilesPage}
             hasNextFilesPage={hasNextPageFiles}
             isFetchingNextFilesPage={isFetchingNextFilesPage}
+            isLoading={isFoldersLoading || isFilesLoading}
             filterConditions={[]}
             onFilterChange={() => {}}
             dragState={dragState}


### PR DESCRIPTION
## Summary

Fixes the issue where navigating to a folder or project page momentarily displays "This folder is empty" while folder/file contents are still loading over the network.

## Changes

- **Component Props**: Added `isLoading?: boolean` prop to `FileBrowserProps` and `MobileFileBrowserProps`.
- **Loading Skeletons**: Added `FileBrowserContentSkeleton` and `MobileFileBrowserContentSkeleton` components in `loading-skeletons.tsx` to show clean grid/list placeholder skeletons while initial data is being fetched.
- **Empty State Guard**: Guarded the empty folder state evaluation in `FileBrowser` and `MobileFileBrowser` with `!isLoading`.
- **i18n**: Replaced hardcoded `"This folder is empty"` text with Paraglide i18n message `{m.this_folder_is_empty()}`.
- **Parent Managers**: Extracted `isLoading` from `useInfiniteQuery` in `FileSystemManager`, `ShareManager`, and `PublicShareManager`, passing it down to file browsers.
- **Tests**: Added unit tests in `file-browser.test.tsx` and updated `mobile-file-browser.test.tsx` verifying that empty state is not rendered when `isLoading: true`.

## Verification

Ran all workspace verification checks simultaneously:
- `bun run lint`: passed (0 errors)
- `bun run format`: passed
- `bun run typecheck`: passed
- `bun run test`: passed (147 test files, 1386 tests)
- `bun run test:e2e:webui`: passed (9 tests)
- `bun run test:e2e:workflow`: passed (13 test files, 56 tests)
- `bun run test:e2e:app`: passed (38 tests)

## Notes

None.