### PR TITLE
fix(agent): set empty details in asset tool results to avoid data duplication

### DIFF
--- a/packages/agent/src/reproduce-tool-null-coercion.test.ts
+++ b/packages/agent/src/reproduce-tool-null-coercion.test.ts
@@ -76,7 +76,13 @@ describe('reproduce null coercion in harness tool validation', () => {
 
     // execute must accept the valid call (data-only) without throwing
     const result = await tool.execute('call-1', validated as never)
-    expect(result.details).toEqual({ id: 'file-1', name: 'test', type: 'file', size: 100 })
+    expect(result.details).toEqual({})
+    expect(JSON.parse((result.content[0] as { text: string }).text)).toEqual({
+      id: 'file-1',
+      name: 'test',
+      type: 'file',
+      size: 100,
+    })
     expect(s3Service.putObject).toHaveBeenCalledTimes(1)
     expect(authzService.hasPermission).toHaveBeenCalledTimes(1)
     expect(assetService.createFile).toHaveBeenCalledTimes(1)

--- a/packages/agent/src/tools/create-file.test.ts
+++ b/packages/agent/src/tools/create-file.test.ts
@@ -86,7 +86,13 @@ describe('createCreateFileTool', () => {
       metadata: undefined,
     })
 
-    expect(result.details).toEqual({ id: 'file-1', name: 'test', type: 'file', size: 100 })
+    expect(result.details).toEqual({})
+    expect(JSON.parse((result.content[0] as { text: string }).text)).toEqual({
+      id: 'file-1',
+      name: 'test',
+      type: 'file',
+      size: 100,
+    })
   })
 
   it('should forward the metadata to assetService.createFile when provided', async () => {
@@ -209,7 +215,13 @@ describe('createCreateFileTool', () => {
       metadata: undefined,
     })
 
-    expect(result.details).toEqual({ id: 'file-1', name: 'test', type: 'file', size: 100 })
+    expect(result.details).toEqual({})
+    expect(JSON.parse((result.content[0] as { text: string }).text)).toEqual({
+      id: 'file-1',
+      name: 'test',
+      type: 'file',
+      size: 100,
+    })
   })
 
   it('should default unknown extensions to text/plain when creating from content', async () => {

--- a/packages/agent/src/tools/create-file.ts
+++ b/packages/agent/src/tools/create-file.ts
@@ -133,7 +133,7 @@ export function createCreateFileTool(userId: string, metadataSchema?: TSchema): 
 
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        details: result,
+        details: {},
       }
     },
   }

--- a/packages/agent/src/tools/create-folder.test.ts
+++ b/packages/agent/src/tools/create-folder.test.ts
@@ -45,7 +45,8 @@ describe('createCreateFolderTool', () => {
       creatorId: 'user-1',
     })
 
-    expect(result.details).toEqual({
+    expect(result.details).toEqual({})
+    expect(JSON.parse((result.content[0] as { text: string }).text)).toEqual({
       id: 'folder-1',
       name: 'New Folder',
       type: 'folder',

--- a/packages/agent/src/tools/create-folder.ts
+++ b/packages/agent/src/tools/create-folder.ts
@@ -44,7 +44,7 @@ export function createCreateFolderTool(userId: string): AgentTool<typeof createF
 
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        details: result,
+        details: {},
       }
     },
   }

--- a/packages/agent/src/tools/create-version.test.ts
+++ b/packages/agent/src/tools/create-version.test.ts
@@ -83,7 +83,13 @@ describe('createCreateVersionTool', () => {
       metadata: undefined,
     })
 
-    expect(result.details).toEqual({ id: 'file-1', name: 'v2', type: 'file', size: 100 })
+    expect(result.details).toEqual({})
+    expect(JSON.parse((result.content[0] as { text: string }).text)).toEqual({
+      id: 'file-1',
+      name: 'v2',
+      type: 'file',
+      size: 100,
+    })
   })
 
   it('should forward the metadata to assetService.createVersion when provided', async () => {

--- a/packages/agent/src/tools/create-version.ts
+++ b/packages/agent/src/tools/create-version.ts
@@ -82,7 +82,7 @@ export function createCreateVersionTool(userId: string, metadataSchema?: TSchema
 
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        details: result,
+        details: {},
       }
     },
   }

--- a/packages/agent/src/tools/list-assets.test.ts
+++ b/packages/agent/src/tools/list-assets.test.ts
@@ -48,7 +48,8 @@ describe('createListAssetsTool', () => {
       after: undefined,
     })
 
-    expect(result.details).toEqual({
+    expect(result.details).toEqual({})
+    expect(JSON.parse((result.content[0] as { text: string }).text)).toEqual({
       assets: [
         { id: '01M2FILE2', name: 'file2.txt', type: 'file', size: 200 },
         { id: '01M1FILE1', name: 'file1.txt', type: 'file', size: 100 },

--- a/packages/agent/src/tools/list-assets.ts
+++ b/packages/agent/src/tools/list-assets.ts
@@ -70,7 +70,7 @@ export function createListAssetsTool(userId: string): AgentTool<typeof listAsset
 
       return {
         content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
-        details: output,
+        details: {},
       }
     },
   }


### PR DESCRIPTION
## Summary

Eliminates redundant data serialization in `AgentSessionEntry` by returning empty `details: {}` in agent asset tools (`list_assets`, `create_folder`, `create_file`, `create_version`).

## Changes

- Updated [`list_assets`](packages/agent/src/tools/list-assets.ts), [`create_folder`](packages/agent/src/tools/create-folder.ts), [`create_file`](packages/agent/src/tools/create-file.ts), and [`create_version`](packages/agent/src/tools/create-version.ts) to return `details: {}`.
- Updated unit test suites ([`list-assets.test.ts`](packages/agent/src/tools/list-assets.test.ts), [`create-folder.test.ts`](packages/agent/src/tools/create-folder.test.ts), [`create-file.test.ts`](packages/agent/src/tools/create-file.test.ts), [`create-version.test.ts`](packages/agent/src/tools/create-version.test.ts), and [`reproduce-tool-null-coercion.test.ts`](packages/agent/src/reproduce-tool-null-coercion.test.ts)) to assert `details: {}` and verify stringified JSON outputs in `content`.

## Verification

Ran all verification commands simultaneously:
- `bun run lint` (passed)
- `bun run format` (passed)
- `bun run typecheck` (passed)
- `bun run test` (148 files, 1399 passed)
- `bun run test:e2e:workflow` (13 files, 56 passed)
- `bun run test:e2e:webui` (9 passed)
- `bun run test:e2e:app` (38 passed)

## Notes

None.