### PR TITLE
fix(webui): strip styles and preserve multiline text on paste in chat input

### DIFF
--- a/packages/db/src/test-global-setup.ts
+++ b/packages/db/src/test-global-setup.ts
@@ -1,7 +1,6 @@
 import { PostgreSqlContainer } from '@testcontainers/postgresql'
 import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
-import { Wait } from 'testcontainers'
 
 const execAsync = promisify(exec)
 
@@ -9,13 +8,7 @@ let dbContainer: import('@testcontainers/postgresql').StartedPostgreSqlContainer
 
 export async function globalTestSetup() {
   console.log('Starting Testcontainers for global setup...')
-  dbContainer = await new PostgreSqlContainer('pgvector/pgvector:pg18')
-    .withWaitStrategy(
-      // casting to any due to testcontainers wait strategy type mismatch
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      Wait.forLogMessage('database system is ready to accept connections', 1) as any,
-    )
-    .start()
+  dbContainer = await new PostgreSqlContainer('pgvector/pgvector:pg18').start()
 
   const databaseUrl = dbContainer.getConnectionUri()
   console.log('Database started at:', databaseUrl)

--- a/packages/webui/components/chat/message-input.test.tsx
+++ b/packages/webui/components/chat/message-input.test.tsx
@@ -141,3 +141,111 @@ describe('ChatInput mention navigation', () => {
     expect(mentionNode.textContent).toContain('David Human')
   })
 })
+
+describe('ChatInput paste handling', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('pastes plain text only and strips HTML formatting when styled HTML is in clipboard', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    const mockSendMessage = vi.fn()
+    const mockChangeText = vi.fn()
+
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <ChatInput
+          projectId="proj-1"
+          onSendMessage={mockSendMessage}
+          onChangeText={mockChangeText}
+        />
+      </QueryClientProvider>,
+    )
+
+    const editor = container.querySelector('[contenteditable="true"]') as HTMLDivElement
+    expect(editor).toBeTruthy()
+
+    // Focus editor and set selection
+    editor.focus()
+    const range = document.createRange()
+    range.selectNodeContents(editor)
+    range.collapse(false)
+    const sel = window.getSelection()!
+    sel.removeAllRanges()
+    sel.addRange(range)
+
+    // Simulate pasting HTML with plain text fallback
+    fireEvent.paste(editor, {
+      clipboardData: {
+        getData: (format: string) => {
+          if (format === 'text/plain') return 'Clean plain text'
+          if (format === 'text/html')
+            return '<span style="color: red; font-size: 24px;"><b>Clean plain text</b></span>'
+          return ''
+        },
+      },
+    })
+
+    expect(editor.innerHTML).not.toContain('<span')
+    expect(editor.innerHTML).not.toContain('style=')
+    expect(editor.textContent).toBe('Clean plain text')
+    expect(mockChangeText).toHaveBeenCalledWith('Clean plain text')
+
+    // Press Enter to send
+    fireEvent.keyDown(editor, { key: 'Enter' })
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      'Clean plain text',
+      [],
+      [],
+      undefined,
+      undefined,
+      [],
+    )
+  })
+
+  it('preserves multiple lines when multiline text is pasted', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    const mockSendMessage = vi.fn()
+
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <ChatInput projectId="proj-1" onSendMessage={mockSendMessage} />
+      </QueryClientProvider>,
+    )
+
+    const editor = container.querySelector('[contenteditable="true"]') as HTMLDivElement
+    expect(editor).toBeTruthy()
+
+    editor.focus()
+    const range = document.createRange()
+    range.selectNodeContents(editor)
+    range.collapse(false)
+    const sel = window.getSelection()!
+    sel.removeAllRanges()
+    sel.addRange(range)
+
+    const multilineText = 'First line\nSecond line\nThird line'
+
+    fireEvent.paste(editor, {
+      clipboardData: {
+        getData: (format: string) => {
+          if (format === 'text/plain') return multilineText
+          return `<p>First line</p><p>Second line</p><p>Third line</p>`
+        },
+      },
+    })
+
+    expect(editor.textContent).toBe(multilineText)
+
+    // Send message and verify multiline content is preserved in onSendMessage
+    fireEvent.keyDown(editor, { key: 'Enter' })
+    expect(mockSendMessage).toHaveBeenCalledWith(multilineText, [], [], undefined, undefined, [])
+  })
+})

--- a/packages/webui/components/chat/message-input.tsx
+++ b/packages/webui/components/chat/message-input.tsx
@@ -432,6 +432,52 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
       editorRef.current.focus()
     }
 
+    const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      const text = e.clipboardData.getData('text/plain')
+      if (!text) return
+
+      let selection = window.getSelection()
+      if (
+        !selection ||
+        selection.rangeCount === 0 ||
+        !editorRef.current?.contains(selection.anchorNode)
+      ) {
+        if (editorRef.current) {
+          editorRef.current.focus()
+          const range = document.createRange()
+          range.selectNodeContents(editorRef.current)
+          range.collapse(false)
+          selection = window.getSelection()
+          selection?.removeAllRanges()
+          selection?.addRange(range)
+        }
+      }
+
+      const success =
+        typeof document.execCommand === 'function' &&
+        document.queryCommandSupported?.('insertText') &&
+        document.execCommand('insertText', false, text)
+
+      if (!success) {
+        const sel = window.getSelection()
+        if (sel && sel.rangeCount > 0) {
+          const range = sel.getRangeAt(0)
+          range.deleteContents()
+          const textNode = document.createTextNode(text)
+          range.insertNode(textNode)
+          range.setStartAfter(textNode)
+          range.collapse(true)
+          sel.removeAllRanges()
+          sel.addRange(range)
+        } else if (editorRef.current) {
+          editorRef.current.innerText += text
+        }
+      }
+
+      handleInput()
+    }
+
     const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
       if (e.nativeEvent.isComposing) return
 
@@ -889,10 +935,11 @@ export const ChatInput = React.forwardRef<HTMLDivElement, ChatInputProps>(
             suppressContentEditableWarning
             onInput={handleInput}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             data-placeholder={
               placeholder || (replyingTo ? m.reply_placeholder() : m.message_placeholder())
             }
-            className={`bg-transparent border-none focus:ring-0 resize-none min-h-[40px] leading-relaxed py-2 focus:outline-none block ${paddingLeftClass}`}
+            className={`bg-transparent border-none focus:ring-0 resize-none min-h-[40px] leading-relaxed py-2 focus:outline-none block whitespace-pre-wrap break-words ${paddingLeftClass}`}
           />
         </div>
 


### PR DESCRIPTION
## Summary

1. Prevents rich-text and HTML formatting (fonts, colors, background styling) from being pasted and rendered into the one-to-one chat and comment input box, while ensuring multiline text and line breaks are fully preserved.
2. Fixes an intermittent CI test setup failure by removing the premature single-occurrence log message wait strategy on the PostgreSQL container, allowing `PostgreSqlContainer` to use its built-in `pg_isready` health check.

## Changes

- **WebUI Chat Input**:
  - Added `onPaste` handler in [`ChatInput`](packages/webui/components/chat/message-input.tsx) to intercept paste events, extract plain text from clipboard, and insert it at the cursor position with undo/redo support.
  - Added `whitespace-pre-wrap break-words` to the input `contentEditable` `div` to properly render pasted multiline text with line breaks.
  - Added unit tests in [`packages/webui/components/chat/message-input.test.tsx`](packages/webui/components/chat/message-input.test.tsx) verifying rich HTML style stripping and multiline text preservation.
- **Database Test Global Setup**:
  - Removed custom `Wait.forLogMessage('database system is ready to accept connections', 1)` in [`packages/db/src/test-global-setup.ts`](packages/db/src/test-global-setup.ts), using `PostgreSqlContainer`'s built-in `pg_isready` health check to prevent the temporary-startup race condition on CI.

## Verification

- `bun run lint` (passed)
- `bun run format` (passed)
- `bun run typecheck` (passed)
- `bun run test` (passed 148 test files, 1401 tests)
- `bun run test:e2e:webui` (passed 9 tests)
- `bun run test:e2e:workflow` (passed 13 test files, 56 tests)
- `bun run test:e2e:app` (passed 38 tests)

## Notes

None.