### PR TITLE
feat(agent): improve timestamp precision and proxy selection for video screenshots

### DIFF
--- a/packages/agent/src/context/serialize-context.test.ts
+++ b/packages/agent/src/context/serialize-context.test.ts
@@ -119,7 +119,7 @@ describe('serializeContextToXml', () => {
       <folder id="ast_01JC03_PARENT" name="Footage" />
     </ancestors>
   </current_asset>
-  <position type="time" seconds="14.25" />
+  <position type="time" seconds="14.2500" />
   <annotation />
   <attached_files>
     <file id="ast_01JC05_ATT1" name="brand_guidelines_2026.pdf" type="file" media_type="pdf" path="Brand/brand_guidelines_2026.pdf" />
@@ -315,7 +315,7 @@ describe('serializeContextToXml', () => {
       expect(refOrder).toEqual(['a_asset', 'm_asset', 'z_asset'])
     })
 
-    it('normalizes float formatting with fixed .toFixed(2)', () => {
+    it('normalizes float formatting with fixed precision (toFixed(4) for position, toFixed(2) for duration)', () => {
       const context1: ShumaiMessageContext = {
         currentAsset: { id: '1', name: 'a', type: 'file', durationSeconds: 14 },
         position: { type: 'time', seconds: 5.5 },
@@ -326,9 +326,9 @@ describe('serializeContextToXml', () => {
       }
 
       expect(serializeContextToXml(context1)).toContain('duration_seconds="14.00"')
-      expect(serializeContextToXml(context1)).toContain('seconds="5.50"')
+      expect(serializeContextToXml(context1)).toContain('seconds="5.5000"')
       expect(serializeContextToXml(context2)).toContain('duration_seconds="14.00"')
-      expect(serializeContextToXml(context2)).toContain('seconds="5.50"')
+      expect(serializeContextToXml(context2)).toContain('seconds="5.5000"')
     })
   })
 })

--- a/packages/core/src/transcode/transcode.ts
+++ b/packages/core/src/transcode/transcode.ts
@@ -1225,12 +1225,12 @@ export class TranscodeService {
 
       // 4. Extract each screenshot
       for (const t of timestamps) {
-        const outName = `shot-${t.toFixed(3)}-${ulid()}.webp`
+        const outName = `shot-${t.toFixed(4)}-${ulid()}.webp`
         const localShotPath = path.join(tmpDir, outName)
 
         const args = [
           '-ss',
-          t.toFixed(3),
+          t.toFixed(4),
           '-i',
           videoPath,
           '-vframes',
@@ -1248,7 +1248,7 @@ export class TranscodeService {
         const isMatch =
           commentTimestamp !== undefined &&
           commentTimestamp !== null &&
-          Math.abs(t - commentTimestamp) < 1e-4
+          Math.abs(t - commentTimestamp) <= 1e-3
 
         // 5. Overlay annotations if timestamp matches commentTimestamp (within float tolerance)
         if (isMatch && params.annotations && params.annotations.length > 0) {

--- a/packages/dtos/src/context.ts
+++ b/packages/dtos/src/context.ts
@@ -26,7 +26,7 @@ function formatAttr(name: string, value: string | undefined): string {
  * 1. Tag sequence: <user>, <thread>, <current_asset>, <position>, <annotation>, <attached_files>, <referenced_assets>
  * 2. Attribute sequence on every tag follows fixed, invariant order.
  * 3. Arrays (attachedFiles, referencedAssets) sorted by id ascending.
- * 4. Floats formatted with .toFixed(2), integers rounded.
+ * 4. Time position floats formatted with .toFixed(4), duration with .toFixed(2), integers rounded.
  * 5. String values escaped via escapeXmlAttr.
  * 6. Exact 2-space indentation and LF newlines.
  */
@@ -101,7 +101,7 @@ export function serializeContextToXml(context?: ShumaiMessageContext | null): st
   // 3. <position ... />
   if (context.position) {
     if (context.position.type === 'time') {
-      lines.push(`  <position type="time" seconds="${context.position.seconds.toFixed(2)}" />`)
+      lines.push(`  <position type="time" seconds="${context.position.seconds.toFixed(4)}" />`)
     } else if (context.position.type === 'page') {
       lines.push(`  <position type="page" page="${Math.round(context.position.page)}" />`)
     }

--- a/packages/transcode/src/workflows/take-video-screenshots.test.ts
+++ b/packages/transcode/src/workflows/take-video-screenshots.test.ts
@@ -107,4 +107,63 @@ describe('takeVideoScreenshotsWorkflow', () => {
       },
     })
   })
+
+  it('should prefer highest-resolution video transcode proxy over master storageKey', async () => {
+    const task: WorkflowTask = {
+      id: 'task-screenshot-proxy',
+      assetId: 'asset-video-proxy',
+      type: WorkflowTaskType.transcode_screenshot,
+      status: WorkflowTaskStatus.pending,
+      sessionId: null,
+      output: null,
+      payload: {
+        projectId: 'proj-1',
+        screenshot: {
+          start: 1.2345,
+          end: 1.2345,
+          count: 1,
+          commentTimestamp: 1.2345,
+          annotations: [],
+        },
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      heartbeat: null,
+      teamId: 'team-1',
+      projectId: 'proj-1',
+      uid: 'task-uid',
+      model: null,
+      inputTokens: 0,
+      outputTokens: 0,
+    }
+
+    mockActivities.getAssetActivity.mockResolvedValue({
+      id: 'asset-video-proxy',
+      storageKey: { key: 'raw-master.mp4' },
+      mediaType: 'video/mp4',
+      media: {
+        videoTranscodes: [
+          { key: 'proxy-720p.mp4', height: 720, width: 1280 },
+          { key: 'proxy-1080p.mp4', height: 1080, width: 1920 },
+          { key: 'proxy-360p.mp4', height: 360, width: 640 },
+        ],
+      },
+    })
+
+    mockActivities.takeScreenshotsActivity.mockResolvedValue([
+      { key: 'files/asset-video-proxy/screenshots/shot1.webp', timestamp: 1.2345 },
+    ])
+
+    await takeVideoScreenshotsWorkflow(task)
+
+    expect(mockActivities.takeScreenshotsActivity).toHaveBeenCalledWith({
+      assetKey: 'proxy-1080p.mp4',
+      assetId: 'asset-video-proxy',
+      start: 1.2345,
+      end: 1.2345,
+      count: 1,
+      commentTimestamp: 1.2345,
+      annotations: [],
+    })
+  })
 })

--- a/packages/transcode/src/workflows/take-video-screenshots.ts
+++ b/packages/transcode/src/workflows/take-video-screenshots.ts
@@ -17,10 +17,23 @@ export async function takeVideoScreenshotsWorkflow(task: WorkflowTask): Promise<
     }
 
     const { asset, key } = await fetchAssetWithKey(workerQueue, task.assetId)
+    let targetKey = key
+    if (asset?.media) {
+      const mediaInfo = asset.media as unknown as PrismaJson.MediaInfo
+      if (mediaInfo.videoTranscodes && mediaInfo.videoTranscodes.length > 0) {
+        const sorted = [...mediaInfo.videoTranscodes]
+          .filter((t) => t.key)
+          .sort((a, b) => (b.height || 0) - (a.height || 0))
+        if (sorted.length > 0 && sorted[0].key) {
+          targetKey = sorted[0].key
+        }
+      }
+    }
+
     const { takeScreenshotsActivity } = getActivities()
 
     const screenshots = await executeActivity(workerQueue, takeScreenshotsActivity, {
-      assetKey: key,
+      assetKey: targetKey,
       assetId: asset.id,
       start: payload.screenshot.start,
       end: payload.screenshot.end,


### PR DESCRIPTION
## Summary

Improves timestamp precision and video proxy selection for video screenshots and agent context, guaranteeing frame-accurate screenshot extraction.

## Changes

- **Context XML Serialization**: Updated `<position type="time" seconds="..." />` serialization in `packages/dtos/src/context.ts` from 2 decimal places (`.toFixed(2)`) to 4 decimal places (`.toFixed(4)`, 0.1ms precision). Kept coarse high-level duration at `.toFixed(2)`.
- **FFmpeg Frame Seeking**: Updated `takeScreenshots` in `packages/core/src/transcode/transcode.ts` to seek with `.toFixed(4)` precision and updated screenshot output filenames to `shot-${t.toFixed(4)}-${ulid()}.webp`.
- **Annotation Overlay Snapping Tolerance**: Refined floating-point tolerance check in `transcode.ts` to `Math.abs(t - commentTimestamp) <= 1e-3`.
- **Transcoded Proxy Video Selection**: In `takeVideoScreenshotsWorkflow`, resolved the highest-resolution transcoded CFR video proxy from `asset.media.videoTranscodes` when available, falling back to the raw master key. This guarantees 1:1 CFR frame alignment with the web player.
- **Tests**: Updated unit tests in `serialize-context.test.ts` and added proxy selection verification in `take-video-screenshots.test.ts`.

## Verification

Ran all verification suites:
- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test` (148 test files, 1408 passed)
- `bun run test:e2e:webui` (9 passed)
- `bun run test:e2e:workflow` (13 test files, 56 passed)
- `bun run test:e2e:app` (38 passed)

## Notes

Follow-up task noted for chat mode: wire drawing annotations from `AgentSessionEntry` to media tools when `userCommentId` is null.