### PR TITLE
refactor(webui): use semantic system colors in notification settings

### DIFF
--- a/packages/webui/components/settings/NotificationSettings.test.tsx
+++ b/packages/webui/components/settings/NotificationSettings.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { NotificationSettings } from './NotificationSettings'
+import type { NotificationSettings as Settings } from '@shumai/dtos'
+
+const mockGetSettings = vi.fn()
+const mockPostSettings = vi.fn()
+
+vi.mock('@/ui/api/client', () => ({
+  client: {
+    api: {
+      teams: {
+        ':teamId': {
+          notifications: {
+            settings: {
+              $get: () => mockGetSettings(),
+              $post: (args: unknown) => mockPostSettings(args),
+            },
+          },
+        },
+      },
+    },
+  },
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+describe('NotificationSettings', () => {
+  const initialSettings: Settings = {
+    comments: true,
+    replies: true,
+    mentions: true,
+    yourUploads: false,
+    otherUploads: true,
+    statusUpdates: true,
+    kanbanTasks: true,
+    kanbanComments: true,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSettings.mockResolvedValue({
+      ok: true,
+      json: async () => initialSettings,
+    })
+    mockPostSettings.mockResolvedValue({
+      ok: true,
+      json: async () => ({ ...initialSettings, yourUploads: true }),
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  function renderComponent() {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    })
+
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <NotificationSettings teamId="team-1" />
+      </QueryClientProvider>,
+    )
+  }
+
+  it('renders all notification sections and switches', async () => {
+    const { container } = renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText(/comments & replies/i)).toBeDefined()
+    })
+
+    expect(screen.getByText(/assets & statuses/i)).toBeDefined()
+    expect(screen.getByText(/kanban notifications/i)).toBeDefined()
+
+    // Verify switches are rendered
+    const switches = screen.getAllByRole('switch')
+    expect(switches.length).toBe(8)
+
+    // Verify no hardcoded blue/purple color classes exist in the markup
+    const html = container.innerHTML
+    expect(html).not.toMatch(/text-blue-500/)
+    expect(html).not.toMatch(/bg-blue-50/)
+    expect(html).not.toMatch(/text-purple-600/)
+    expect(html).not.toMatch(/bg-purple-50/)
+    expect(html).not.toMatch(/text-indigo-500/)
+    expect(html).not.toMatch(/border-slate-/)
+  })
+
+  it('handles toggling a notification setting', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText(/comments & replies/i)).toBeDefined()
+    })
+
+    const switches = screen.getAllByRole('switch')
+    // Click the first switch (comments)
+    fireEvent.click(switches[0])
+
+    await waitFor(() => {
+      expect(mockPostSettings).toHaveBeenCalledTimes(1)
+      expect(mockPostSettings).toHaveBeenCalledWith({
+        param: { teamId: 'team-1' },
+        json: {
+          ...initialSettings,
+          comments: false,
+        },
+      })
+    })
+  })
+})

--- a/packages/webui/components/settings/NotificationSettings.tsx
+++ b/packages/webui/components/settings/NotificationSettings.tsx
@@ -71,28 +71,24 @@ export function NotificationSettings({ teamId }: { teamId: string }) {
     <ScrollArea className="h-full">
       <div className="space-y-6 pr-4 pb-8">
         {/* Comments Settings */}
-        <Card className="border border-slate-200 dark:border-slate-800">
-          <CardHeader className="border-b border-slate-100 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/50">
+        <Card className="overflow-hidden gap-0 py-0">
+          <CardHeader className="border-b border-border bg-muted/30 py-5">
             <div className="flex items-center gap-2">
-              <MessageSquare className="w-5 h-5 text-blue-500" />
+              <MessageSquare className="w-5 h-5 text-primary" />
               <CardTitle className="text-lg">{m.comments_and_replies()}</CardTitle>
             </div>
             <CardDescription>{m.comments_notification_description()}</CardDescription>
           </CardHeader>
-          <CardContent className="divide-y divide-slate-100 dark:divide-slate-800 p-0">
+          <CardContent className="divide-y divide-border p-0">
             {/* General Comments */}
             <div className="flex items-center justify-between p-6">
               <div className="flex gap-4">
-                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400">
+                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-muted text-foreground">
                   <MessageSquare className="w-4 h-4" />
                 </div>
                 <div className="space-y-0.5">
-                  <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
-                    {m.general_comments()}
-                  </h4>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">
-                    {m.when_someone_comments()}
-                  </p>
+                  <h4 className="text-sm font-semibold text-foreground">{m.general_comments()}</h4>
+                  <p className="text-sm text-muted-foreground">{m.when_someone_comments()}</p>
                 </div>
               </div>
               <Switch
@@ -105,16 +101,12 @@ export function NotificationSettings({ teamId }: { teamId: string }) {
             {/* Comment Replies */}
             <div className="flex items-center justify-between p-6">
               <div className="flex gap-4">
-                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-purple-50 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400">
+                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-muted text-foreground">
                   <MessageCircle className="w-4 h-4" />
                 </div>
                 <div className="space-y-0.5">
-                  <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
-                    {m.comment_replies()}
-                  </h4>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">
-                    {m.when_someone_replies()}
-                  </p>
+                  <h4 className="text-sm font-semibold text-foreground">{m.comment_replies()}</h4>
+                  <p className="text-sm text-muted-foreground">{m.when_someone_replies()}</p>
                 </div>
               </div>
               <Switch
@@ -127,16 +119,12 @@ export function NotificationSettings({ teamId }: { teamId: string }) {
             {/* Mentions */}
             <div className="flex items-center justify-between p-6">
               <div className="flex gap-4">
-                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-pink-50 dark:bg-pink-900/20 text-pink-600 dark:text-pink-400">
+                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-muted text-foreground">
                   <AtSign className="w-4 h-4" />
                 </div>
                 <div className="space-y-0.5">
-                  <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
-                    {m.at_mentions()}
-                  </h4>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">
-                    {m.when_someone_mentions()}
-                  </p>
+                  <h4 className="text-sm font-semibold text-foreground">{m.at_mentions()}</h4>
+                  <p className="text-sm text-muted-foreground">{m.when_someone_mentions()}</p>
                 </div>
               </div>
               <Switch
@@ -149,28 +137,24 @@ export function NotificationSettings({ teamId }: { teamId: string }) {
         </Card>
 
         {/* Assets Settings */}
-        <Card className="border border-slate-200 dark:border-slate-800">
-          <CardHeader className="border-b border-slate-100 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/50">
+        <Card className="overflow-hidden gap-0 py-0">
+          <CardHeader className="border-b border-border bg-muted/30 py-5">
             <div className="flex items-center gap-2">
-              <UploadCloud className="w-5 h-5 text-emerald-500" />
+              <UploadCloud className="w-5 h-5 text-primary" />
               <CardTitle className="text-lg">{m.assets_and_statuses()}</CardTitle>
             </div>
             <CardDescription>{m.assets_notification_description()}</CardDescription>
           </CardHeader>
-          <CardContent className="divide-y divide-slate-100 dark:divide-slate-800 p-0">
+          <CardContent className="divide-y divide-border p-0">
             {/* Your Uploads */}
             <div className="flex items-center justify-between p-6">
               <div className="flex gap-4">
-                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400">
+                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-muted text-foreground">
                   <Bell className="w-4 h-4" />
                 </div>
                 <div className="space-y-0.5">
-                  <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
-                    {m.your_uploads()}
-                  </h4>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">
-                    {m.when_you_upload_assets()}
-                  </p>
+                  <h4 className="text-sm font-semibold text-foreground">{m.your_uploads()}</h4>
+                  <p className="text-sm text-muted-foreground">{m.when_you_upload_assets()}</p>
                 </div>
               </div>
               <Switch
@@ -183,14 +167,12 @@ export function NotificationSettings({ teamId }: { teamId: string }) {
             {/* Other Uploads */}
             <div className="flex items-center justify-between p-6">
               <div className="flex gap-4">
-                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 dark:text-emerald-400">
+                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-muted text-foreground">
                   <UploadCloud className="w-4 h-4" />
                 </div>
                 <div className="space-y-0.5">
-                  <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
-                    {m.other_uploads()}
-                  </h4>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                  <h4 className="text-sm font-semibold text-foreground">{m.other_uploads()}</h4>
+                  <p className="text-sm text-muted-foreground">
                     {m.when_other_users_upload_assets()}
                   </p>
                 </div>
@@ -205,16 +187,12 @@ export function NotificationSettings({ teamId }: { teamId: string }) {
             {/* Status Updates */}
             <div className="flex items-center justify-between p-6">
               <div className="flex gap-4">
-                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-amber-50 dark:bg-amber-900/20 text-amber-600 dark:text-amber-400">
+                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-muted text-foreground">
                   <Activity className="w-4 h-4" />
                 </div>
                 <div className="space-y-0.5">
-                  <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
-                    {m.status_updates()}
-                  </h4>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">
-                    {m.when_someone_changes_status()}
-                  </p>
+                  <h4 className="text-sm font-semibold text-foreground">{m.status_updates()}</h4>
+                  <p className="text-sm text-muted-foreground">{m.when_someone_changes_status()}</p>
                 </div>
               </div>
               <Switch
@@ -227,28 +205,24 @@ export function NotificationSettings({ teamId }: { teamId: string }) {
         </Card>
 
         {/* Kanban Settings */}
-        <Card className="border border-slate-200 dark:border-slate-800">
-          <CardHeader className="border-b border-slate-100 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/50">
+        <Card className="overflow-hidden gap-0 py-0">
+          <CardHeader className="border-b border-border bg-muted/30 py-5">
             <div className="flex items-center gap-2">
-              <LayoutDashboard className="w-5 h-5 text-indigo-500" />
+              <LayoutDashboard className="w-5 h-5 text-primary" />
               <CardTitle className="text-lg">{m.kanban_notifications()}</CardTitle>
             </div>
             <CardDescription>{m.kanban_notification_description()}</CardDescription>
           </CardHeader>
-          <CardContent className="divide-y divide-slate-100 dark:divide-slate-800 p-0">
+          <CardContent className="divide-y divide-border p-0">
             {/* Kanban Tasks */}
             <div className="flex items-center justify-between p-6">
               <div className="flex gap-4">
-                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-50 dark:bg-indigo-900/20 text-indigo-600 dark:text-indigo-400">
+                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-muted text-foreground">
                   <LayoutDashboard className="w-4 h-4" />
                 </div>
                 <div className="space-y-0.5">
-                  <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
-                    {m.kanban_tasks()}
-                  </h4>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">
-                    {m.when_kanban_task_events()}
-                  </p>
+                  <h4 className="text-sm font-semibold text-foreground">{m.kanban_tasks()}</h4>
+                  <p className="text-sm text-muted-foreground">{m.when_kanban_task_events()}</p>
                 </div>
               </div>
               <Switch
@@ -261,16 +235,12 @@ export function NotificationSettings({ teamId }: { teamId: string }) {
             {/* Kanban Comments */}
             <div className="flex items-center justify-between p-6">
               <div className="flex gap-4">
-                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-cyan-50 dark:bg-cyan-900/20 text-cyan-600 dark:text-cyan-400">
+                <div className="mt-1 flex items-center justify-center w-8 h-8 rounded-lg bg-muted text-foreground">
                   <MessageSquare className="w-4 h-4" />
                 </div>
                 <div className="space-y-0.5">
-                  <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
-                    {m.kanban_comments()}
-                  </h4>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">
-                    {m.when_kanban_task_commented()}
-                  </p>
+                  <h4 className="text-sm font-semibold text-foreground">{m.kanban_comments()}</h4>
+                  <p className="text-sm text-muted-foreground">{m.when_kanban_task_commented()}</p>
                 </div>
               </div>
               <Switch


### PR DESCRIPTION
## Summary

Replaces hardcoded color utilities (blue, purple, indigo, pink, cyan, emerald, amber, and slate) in NotificationSettings with semantic system color design tokens (`text-primary`, `border-border`, `bg-muted/30`, `bg-muted`, `text-foreground`, `text-muted-foreground`, `divide-border`) to ensure full theme compatibility and alignment with project design guidelines.

## Changes

- Updated [`NotificationSettings.tsx`](packages/webui/components/settings/NotificationSettings.tsx) cards and headers to use semantic system tokens (`text-primary`, `border-border`, `bg-muted/30`, `divide-border`, `bg-muted`, `text-foreground`, `text-muted-foreground`).
- Removed arbitrary hardcoded palette classes (`blue-500`, `blue-50`, `purple-50`, `purple-600`, `indigo-500`, `indigo-50`, `pink-50`, `cyan-50`, `slate-100`, `border-slate-*`, etc.).
- Added unit tests in [`NotificationSettings.test.tsx`](packages/webui/components/settings/NotificationSettings.test.tsx) verifying component rendering, switch toggling, and absence of hardcoded blue/purple color classes.

## Verification

All required checks pass simultaneously:
- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test` (150 files, 1455 tests passed)
- `bun run test:e2e:app` (38 passed)
- `bun run test:e2e:webui` (9 passed)
- `bun run test:e2e:workflow` (13 files, 56 passed)

## Notes

None.