### PR TITLE
feat(cli): control asset deletion via SHUMAI_ALLOW_DELETE env var

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -20,6 +20,9 @@ export SHUMAI_API_SERVER="http://localhost:3000"
 
 # Your personal API Token (Generate this in the WebUI via Settings -> Developer tab)
 export SHUMAI_API_KEY="your-developer-api-token"
+
+# Optional: Enable asset deletion capability (disabled by default for safety)
+export SHUMAI_ALLOW_DELETE="true"
 ```
 
 ---
@@ -112,16 +115,13 @@ shumai-cli mv <assetId...> -p <parentId>
 
 #### 8. Delete an Asset
 
-Delete a single file or folder by moving it to the Trash bin. For safety, this command only deletes one asset at a time and strictly requires the `--allow-delete` flag.
+Delete a single file or folder by moving it to the Trash bin. For safety, this command only deletes one asset at a time and requires the `SHUMAI_ALLOW_DELETE="true"` environment variable to be set in your environment.
 
 ```bash
-shumai-cli delete <assetId> --allow-delete
+shumai-cli delete <assetId>
 # or using the short alias:
-shumai-cli rm <assetId> --allow-delete
+shumai-cli rm <assetId>
 ```
-
-- **Options:**
-  - `--allow-delete`: Required authorization flag to confirm asset deletion.
 
 ---
 

--- a/apps/cli/src/commands/commands.test.ts
+++ b/apps/cli/src/commands/commands.test.ts
@@ -75,6 +75,8 @@ describe('CLI Commands', () => {
     },
   }
 
+  const originalAllowDelete = process.env.SHUMAI_ALLOW_DELETE
+
   beforeEach(() => {
     vi.resetAllMocks()
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
@@ -94,6 +96,11 @@ describe('CLI Commands', () => {
     writeSpy.mockRestore()
     errorSpy.mockRestore()
     exitSpy.mockRestore()
+    if (originalAllowDelete !== undefined) {
+      process.env.SHUMAI_ALLOW_DELETE = originalAllowDelete
+    } else {
+      delete process.env.SHUMAI_ALLOW_DELETE
+    }
   })
 
   describe('project ls', () => {
@@ -481,34 +488,39 @@ describe('CLI Commands', () => {
   })
 
   describe('deleteAsset', () => {
-    it('exits with error when --allow-delete is false', async () => {
-      await expect(deleteAsset(['a-1'], false)).rejects.toThrow('process.exit(1)')
+    it('exits with error when SHUMAI_ALLOW_DELETE is not set or not true', async () => {
+      delete process.env.SHUMAI_ALLOW_DELETE
+      await expect(deleteAsset(['a-1'])).rejects.toThrow('process.exit(1)')
       expect(errorSpy).toHaveBeenCalledWith(
-        'Error: Deleting an asset requires the --allow-delete flag.',
+        'Error: Asset deletion is disabled in this environment.',
       )
     })
 
     it('exits with error when assetIds is empty', async () => {
-      await expect(deleteAsset([], true)).rejects.toThrow('process.exit(1)')
+      process.env.SHUMAI_ALLOW_DELETE = 'true'
+      await expect(deleteAsset([])).rejects.toThrow('process.exit(1)')
       expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Asset ID is required'))
     })
 
     it('exits with error when more than one asset ID is passed', async () => {
-      await expect(deleteAsset(['a-1', 'a-2'], true)).rejects.toThrow('process.exit(1)')
+      process.env.SHUMAI_ALLOW_DELETE = 'true'
+      await expect(deleteAsset(['a-1', 'a-2'])).rejects.toThrow('process.exit(1)')
       expect(errorSpy).toHaveBeenCalledWith('Error: Can only delete one asset at a time.')
     })
 
     it('exits with error when asset is not found', async () => {
+      process.env.SHUMAI_ALLOW_DELETE = 'true'
       mockClient.api.folders[':folderId'].$get.mockResolvedValue({
         ok: false,
         json: async () => ({ error: 'Asset not found' }),
       } as unknown as Response)
 
-      await expect(deleteAsset(['a-1'], true)).rejects.toThrow('process.exit(1)')
+      await expect(deleteAsset(['a-1'])).rejects.toThrow('process.exit(1)')
       expect(errorSpy).toHaveBeenCalledWith('Error: Asset not found')
     })
 
-    it('successfully deletes a file when --allow-delete is provided', async () => {
+    it('successfully deletes a file when SHUMAI_ALLOW_DELETE is true', async () => {
+      process.env.SHUMAI_ALLOW_DELETE = 'true'
       mockClient.api.folders[':folderId'].$get.mockResolvedValue({
         ok: true,
         json: async () => ({ id: 'a-1', type: 'file' }),
@@ -517,7 +529,7 @@ describe('CLI Commands', () => {
         ok: true,
       } as unknown as Response)
 
-      await deleteAsset(['a-1'], true)
+      await deleteAsset(['a-1'])
 
       expect(mockClient.api.files.$delete).toHaveBeenCalledWith({
         json: { ids: ['a-1'] },
@@ -526,7 +538,8 @@ describe('CLI Commands', () => {
       expect(logSpy).toHaveBeenCalledWith('Deleted asset a-1')
     })
 
-    it('successfully deletes a folder when --allow-delete is provided', async () => {
+    it('successfully deletes a folder when SHUMAI_ALLOW_DELETE is 1', async () => {
+      process.env.SHUMAI_ALLOW_DELETE = '1'
       mockClient.api.folders[':folderId'].$get.mockResolvedValue({
         ok: true,
         json: async () => ({ id: 'folder-1', type: 'folder' }),
@@ -535,7 +548,7 @@ describe('CLI Commands', () => {
         ok: true,
       } as unknown as Response)
 
-      await deleteAsset(['folder-1'], true)
+      await deleteAsset(['folder-1'])
 
       expect(mockClient.api.folders.$delete).toHaveBeenCalledWith({
         json: { ids: ['folder-1'] },
@@ -544,6 +557,7 @@ describe('CLI Commands', () => {
     })
 
     it('exits with error when delete API returns an error', async () => {
+      process.env.SHUMAI_ALLOW_DELETE = 'true'
       mockClient.api.folders[':folderId'].$get.mockResolvedValue({
         ok: true,
         json: async () => ({ id: 'a-1', type: 'file' }),
@@ -553,7 +567,7 @@ describe('CLI Commands', () => {
         json: async () => ({ error: 'Failed to delete' }),
       } as unknown as Response)
 
-      await expect(deleteAsset(['a-1'], true)).rejects.toThrow('process.exit(1)')
+      await expect(deleteAsset(['a-1'])).rejects.toThrow('process.exit(1)')
       expect(errorSpy).toHaveBeenCalledWith('Error: Failed to delete')
     })
   })

--- a/apps/cli/src/commands/delete.ts
+++ b/apps/cli/src/commands/delete.ts
@@ -1,13 +1,15 @@
 import { getClient } from '../client'
 
-export async function deleteAsset(assetIds: string[], allowDelete: boolean) {
-  if (!allowDelete) {
-    console.error('Error: Deleting an asset requires the --allow-delete flag.')
+export async function deleteAsset(assetIds: string[]) {
+  const isAllowed =
+    process.env.SHUMAI_ALLOW_DELETE === 'true' || process.env.SHUMAI_ALLOW_DELETE === '1'
+  if (!isAllowed) {
+    console.error('Error: Asset deletion is disabled in this environment.')
     process.exit(1)
   }
 
   if (!assetIds || assetIds.length === 0) {
-    console.error('Error: Asset ID is required. Usage: shumai-cli delete <assetId> --allow-delete')
+    console.error('Error: Asset ID is required. Usage: shumai-cli delete <assetId>')
     process.exit(1)
   }
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -19,11 +19,10 @@ Commands:
   create-version <path> -p <id>   Create a new version of an existing file or version stack
   rename <assetId> <newName>      Rename an existing file or folder
   move <assetIds...> -p <target>  Move one or more assets to a destination parent folder (alias: mv)
-  delete <assetId> --allow-delete Delete a single file or folder (alias: rm)
+  delete <assetId>                Delete a single file or folder (alias: rm)
 
 Options:
   -p, --parent <id>              The parent folder/asset ID (required for ls, mkdir, upload, create-version, move)
-  --allow-delete                 Required flag to authorize deleting an asset
   -h, --help                     Show help details
 `)
 }
@@ -43,14 +42,10 @@ async function main() {
     parentId = args[parentIdx + 1]
   }
 
-  const allowDelete = args.includes('--allow-delete')
-
   const cleanArgs: string[] = []
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '-p' || args[i] === '--parent') {
       i++
-    } else if (args[i] === '--allow-delete') {
-      // skip flag
     } else {
       cleanArgs.push(args[i])
     }
@@ -129,12 +124,10 @@ async function main() {
   } else if (cmd === 'delete' || cmd === 'rm') {
     const assetIds = cleanArgs.slice(1)
     if (assetIds.length === 0) {
-      console.error(
-        'Error: Asset ID is required. Usage: shumai-cli delete <assetId> --allow-delete',
-      )
+      console.error('Error: Asset ID is required. Usage: shumai-cli delete <assetId>')
       process.exit(1)
     }
-    await deleteAsset(assetIds, allowDelete)
+    await deleteAsset(assetIds)
   } else {
     console.error(`Error: Unknown command "${cmd}". Run "shumai-cli --help" for usage.`)
     process.exit(1)


### PR DESCRIPTION
## Summary

Replaces the `--allow-delete` command-line flag in `shumai-cli` with an environment variable gate (`SHUMAI_ALLOW_DELETE`). When interacting with autonomous AI agents that have CLI access, flags advertised in `--help` or error messages can be trivially discovered and passed by the agent. By checking `SHUMAI_ALLOW_DELETE` and omitting the variable name from CLI help and error messages, deletion permission is securely controlled by the environment operator.

## Changes

- Updated [`apps/cli/src/commands/delete.ts`](file:///Users/yiling/Projects/shumai/apps/cli/src/commands/delete.ts) to verify `process.env.SHUMAI_ALLOW_DELETE === 'true' || process.env.SHUMAI_ALLOW_DELETE === '1'`, outputting a generic error message (`Error: Asset deletion is disabled in this environment.`) if disabled.
- Updated [`apps/cli/src/index.ts`](file:///Users/yiling/Projects/shumai/apps/cli/src/index.ts) to remove the `--allow-delete` option from `printHelp()` and argument parsing.
- Updated [`apps/cli/README.md`](file:///Users/yiling/Projects/shumai/apps/cli/README.md) to document `SHUMAI_ALLOW_DELETE="true"` in the environment configuration and deletion instructions.
- Updated [`apps/cli/src/commands/commands.test.ts`](file:///Users/yiling/Projects/shumai/apps/cli/src/commands/commands.test.ts) to test deletion authorization via the `SHUMAI_ALLOW_DELETE` environment variable and ensure isolation across tests.

## Verification

Ran all mandatory checks simultaneously:
- `bun run lint` (passed)
- `bun run format` (passed)
- `bun run typecheck` (passed)
- `bun run test` (passed: 163 test files, 1553 tests passed)
- `bun run test:e2e:workflow` (passed: 13 files, 56 tests passed)
- `bun run test:e2e:webui` (passed: 9 tests passed)
- `bun run test:e2e:app` (passed: 38 tests passed)

## Notes

No breaking changes for API or WebUI; enhances CLI safety ergonomics.