### PR TITLE
fix(webui): clamp file card creation info to 2 lines and show tooltip on hover

### DIFF
--- a/packages/webui/components/file-browser/file-card.test.tsx
+++ b/packages/webui/components/file-browser/file-card.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { FileCard } from './file-card'
@@ -150,5 +150,68 @@ describe('FileCard', () => {
     expect(agentBadge).toBeTruthy()
     expect(agentBadge.textContent).toBe('AI')
     expect(screen.getByText('v2')).toBeTruthy()
+  })
+
+  it('applies line-clamp-2 and h-[2lh] to creation info paragraph', () => {
+    const itemWithCreator: AssetInfo = {
+      ...fileItem,
+      creator: { id: 'u1', name: 'Alice' },
+    } as AssetInfo
+
+    renderComponent({ item: itemWithCreator })
+
+    const creatorParagraph = screen.getByText(/Alice/i)
+    expect(creatorParagraph.className).toContain('line-clamp-2')
+    expect(creatorParagraph.className).toContain('h-[2lh]')
+  })
+
+  it('does not show tooltip on hover when creator text is not truncated', () => {
+    vi.useFakeTimers()
+    const itemWithCreator: AssetInfo = {
+      ...fileItem,
+      creator: { id: 'u1', name: 'Alice' },
+    } as AssetInfo
+
+    renderComponent({ item: itemWithCreator })
+
+    const creatorParagraph = screen.getByText(/Alice/i)
+    Object.defineProperty(creatorParagraph, 'scrollHeight', { value: 30, configurable: true })
+    Object.defineProperty(creatorParagraph, 'clientHeight', { value: 40, configurable: true })
+    Object.defineProperty(creatorParagraph, 'scrollWidth', { value: 100, configurable: true })
+    Object.defineProperty(creatorParagraph, 'clientWidth', { value: 150, configurable: true })
+
+    fireEvent.pointerMove(creatorParagraph, { pointerType: 'mouse' })
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    expect(screen.queryByRole('tooltip')).toBeNull()
+    vi.useRealTimers()
+  })
+
+  it('shows tooltip on hover when creator text is truncated', () => {
+    vi.useFakeTimers()
+    const itemWithCreator: AssetInfo = {
+      ...fileItem,
+      creator: { id: 'u1', name: 'Very Long Creator Name That Wraps' },
+    } as AssetInfo
+
+    renderComponent({ item: itemWithCreator })
+
+    const creatorParagraph = screen.getByText(/Very Long Creator Name/i)
+    Object.defineProperty(creatorParagraph, 'scrollHeight', { value: 80, configurable: true })
+    Object.defineProperty(creatorParagraph, 'clientHeight', { value: 40, configurable: true })
+
+    fireEvent.pointerMove(creatorParagraph, { pointerType: 'mouse' })
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    const tooltip = screen.getByRole('tooltip')
+    expect(tooltip).toBeTruthy()
+    expect(tooltip.textContent).toContain('Very Long Creator Name')
+    vi.useRealTimers()
   })
 })

--- a/packages/webui/components/file-browser/file-card.tsx
+++ b/packages/webui/components/file-browser/file-card.tsx
@@ -14,6 +14,12 @@ import {
   DropdownMenuTrigger,
 } from '@/ui/components/ui/dropdown-menu'
 import { EditableText } from '@/ui/components/ui/editable-text'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/ui/components/ui/tooltip'
 import { ProgressCircle } from '@/ui/components/ui/progress-circle'
 import { Skeleton } from '@/ui/components/ui/skeleton'
 import { formatTimeAgo } from '@/ui/lib/time'
@@ -90,6 +96,8 @@ export function FileCard({
 }: FileCardProps) {
   const [name, setName] = useState(item.name)
   const inputRef = useRef<HTMLInputElement>(null)
+  const [isCreatorTooltipOpen, setIsCreatorTooltipOpen] = useState(false)
+  const creatorRef = useRef<HTMLParagraphElement>(null)
 
   const fileUploadState = useUploadStore((state) => state.fileProgress[item.id || ''])
   const uploadPercent = fileUploadState
@@ -223,6 +231,19 @@ export function FileCard({
     }
   }
 
+  const creatorText = useMemo(() => {
+    if (!displayItem.createdAt) return ''
+    return m.created_by_at({
+      time: formatTimeAgo(displayItem.createdAt),
+      author: displayItem.agent
+        ? m.user_via_agent({
+            user: displayItem.creator?.name || m.unknown_user(),
+            agent: displayItem.agent.name,
+          })
+        : displayItem.creator?.name || m.unknown_user(),
+    })
+  }, [displayItem.createdAt, displayItem.agent, displayItem.creator?.name])
+
   return (
     <div
       ref={setNodeRef}
@@ -307,7 +328,7 @@ export function FileCard({
       </div>
 
       <div className="flex items-center justify-between gap-2 p-3">
-        <div className="min-w-0 flex-1 line-clamp-3 h-[3lh]">
+        <div className="min-w-0 flex-1">
           <EditableText
             ref={inputRef}
             value={name}
@@ -317,18 +338,40 @@ export function FileCard({
             disabled={!isEditing}
             className="h-auto p-0 text-sm font-medium text-foreground truncate !bg-transparent"
           />
-          <p className="text-sm text-muted-foreground">
-            {displayItem.createdAt &&
-              m.created_by_at({
-                time: formatTimeAgo(displayItem.createdAt),
-                author: displayItem.agent
-                  ? m.user_via_agent({
-                      user: displayItem.creator?.name || m.unknown_user(),
-                      agent: displayItem.agent.name,
-                    })
-                  : displayItem.creator?.name || m.unknown_user(),
-              })}
-          </p>
+          <TooltipProvider delayDuration={100}>
+            <Tooltip
+              open={isCreatorTooltipOpen}
+              onOpenChange={(nextOpen) => {
+                if (nextOpen) {
+                  if (
+                    creatorRef.current &&
+                    (creatorRef.current.scrollHeight > creatorRef.current.clientHeight ||
+                      creatorRef.current.scrollWidth > creatorRef.current.clientWidth)
+                  ) {
+                    setIsCreatorTooltipOpen(true)
+                  } else {
+                    setIsCreatorTooltipOpen(false)
+                  }
+                } else {
+                  setIsCreatorTooltipOpen(false)
+                }
+              }}
+            >
+              <TooltipTrigger asChild>
+                <p ref={creatorRef} className="text-sm text-muted-foreground line-clamp-2 h-[2lh]">
+                  {creatorText}
+                </p>
+              </TooltipTrigger>
+              {isCreatorTooltipOpen && (
+                <TooltipContent
+                  side="bottom"
+                  className="max-w-md break-all text-wrap [text-wrap:normal] text-left"
+                >
+                  {creatorText}
+                </TooltipContent>
+              )}
+            </Tooltip>
+          </TooltipProvider>
         </div>
         {!isRecents && (
           <DropdownMenu modal={false}>


### PR DESCRIPTION
## Summary

Fixes an issue where long creator names in the file list card had their text cut mid-glyph vertically due to `line-clamp-3 h-[3lh]` on the parent container. The creation info area now consistently reserves 2 lines (`h-[2lh]`) with proper text clamping (`line-clamp-2`), and displays a tooltip with the full creation info on hover when the text is truncated.

## Changes

- Moved line clamp and height constraints off the outer text container in `FileCard` directly onto the creator paragraph as `line-clamp-2 h-[2lh]`.
- Wrapped the creator paragraph in Radix UI `Tooltip` to display the full text on hover when truncated (`scrollHeight > clientHeight || scrollWidth > clientWidth`).
- Added unit tests in `file-card.test.tsx` verifying the CSS classes and hover tooltip behavior.

## Verification

All checks passed simultaneously:
- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test` (163 test files, 1556 tests passed)
- `bun run test:e2e:app` (38 tests passed)
- `bun run test:e2e:webui` (9 tests passed)
- `bun run test:e2e:workflow` (13 test files, 56 tests passed)

## Notes

None.